### PR TITLE
Hotfix to compare es and db document count for existing indices

### DIFF
--- a/src/snovault/connection.py
+++ b/src/snovault/connection.py
@@ -52,6 +52,8 @@ class Connection(object):
 
     def get_by_uuid(self, uuid, default=None):
         if isinstance(uuid, basestring):
+            # some times we get @id type things here
+            uuid = uuid.split("/")[-1]
             try:
                 uuid = UUID(uuid)
             except ValueError:

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -628,11 +628,11 @@ def build_index(app, es, in_type, mapping, dry_run, check_first):
         # if 'indexing' doc exists within meta, then re-index for this type
         indexing_xmin = None
         try:
-            status = es.get(index='meta', doc_type='meta', id='indexing')
+            status = es.get(index='meta', doc_type='meta', id='indexing', ignore=404)
         except:
             print('MAPPING: indexing record not found in meta for collection %s' % (in_type))
         else:
-            indexing_xmin = status['_source']['xmin']
+            indexing_xmin = status.get('_source', {}).get('xmin')
         if indexing_xmin is not None:
             print('MAPPING: re-indexing all items in the new index %s' % (in_type))
             run_indexing(app, [in_type])
@@ -656,7 +656,7 @@ def snovault_cleanup(es, registry):
             snovault_index.delete(ignore=404)
 
 
-def run(app, collections=None, dry_run=False, check_first=True):
+def run(app, collections=None, dry_run=False, check_first=False):
     registry = app.registry
     es = app.registry[ELASTIC_SEARCH]
     if not dry_run:

--- a/src/snowflakes/search.py
+++ b/src/snowflakes/search.py
@@ -468,7 +468,7 @@ def set_sort_order(request, search, search_term, types, doc_types, result):
             order = 'asc'
         sort['embedded.' + name + '.lower_case_sort.keyword'] = result_sort[name] = {
             'order': order,
-            'unmapped_type': 'long',
+            'unmapped_type': 'keyword',
         }
     # Otherwise we use a default sort only when there's no text search to be ranked
     if not sort and search_term == '*':
@@ -484,12 +484,12 @@ def set_sort_order(request, search, search_term, types, doc_types, result):
         if not sort:
             sort['embedded.date_created.raw'] = result_sort['date_created'] = {
                 'order': 'desc',
-                'ignore_unmapped': True,
+                'unmapped_type': 'keyword',
             }
             sort['embedded.label.raw'] = result_sort['label'] = {
                 'order': 'asc',
                 'missing': '_last',
-                'ignore_unmapped': True,
+                'unmapped_type': 'keyword',
             }
     if sort and result_sort:
         result['sort'] = result_sort


### PR DESCRIPTION
Compare the document count between the collection (db) and es index when using an existing index in create_mapping. If they are not equal, reindex the whole doc_type.