### PR TITLE
FF-911 addendum

### DIFF
--- a/src/snovault/config.py
+++ b/src/snovault/config.py
@@ -80,7 +80,7 @@ def abstract_collection(name, **kw):
 
     def set_collection(config, Collection, name, Item, **kw):
         registry = config.registry
-        ti = registry[TYPES].register_abstract(Item.__name__)
+        ti = registry[TYPES].register_abstract(Item.__name__, Item)
         registry[TYPES].all[Item] = ti  # XXX Ugly this is here.
         collection = Collection(registry, name, ti, **kw)
         registry[COLLECTIONS].register(name, collection)


### PR DESCRIPTION
Changed AbstractTypeInfo to use a factory (which can be set to None) to allow the schema to be obtained from the Item defined in the corresponding types file. This schema is then combined with subtype schemas to come up with the type schema, which causes it to maintin ordering for cols and facets