### PR TITLE
FF-1081

### DIFF
--- a/src/snovault/elasticsearch/indexer.py
+++ b/src/snovault/elasticsearch/indexer.py
@@ -138,7 +138,7 @@ class Indexer(object):
             # SPECIAL CASE: if we are looking at secondary but have items in
             # deferred, exit so that we can get a new transaction
             if skip_deferred and try_queue == 'secondary':
-                deferred_waiting = indexer_queue.number_of_messages().get('deferred_waiting')
+                deferred_waiting = self.queue.number_of_messages().get('deferred_waiting')
                 if deferred_waiting and deferred_waiting > 0:
                     break
             messages = self.queue.receive_messages(target_queue=try_queue)

--- a/src/snovault/elasticsearch/indexer.py
+++ b/src/snovault/elasticsearch/indexer.py
@@ -135,6 +135,12 @@ class Indexer(object):
         messages = None
         target_queue = None
         for try_queue in try_order:
+            # SPECIAL CASE: if we are looking at secondary but have items in
+            # deferred, exit so that we can get a new transaction
+            if skip_deferred and try_queue == 'secondary':
+                deferred_waiting = indexer_queue.number_of_messages().get('deferred_waiting')
+                if deferred_waiting and deferred_waiting > 0:
+                    break
             messages = self.queue.receive_messages(target_queue=try_queue)
             if messages:
                 target_queue = try_queue

--- a/src/snovault/elasticsearch/indexer.py
+++ b/src/snovault/elasticsearch/indexer.py
@@ -100,17 +100,6 @@ def index(request):
                     if 'error_message' in item:
                         log.error('Indexing error for {}, error message: {}'.format(item['uuid'], item['error_message']))
                         item['error_message'] = "Error occured during indexing, check the logs"
-            es.indices.refresh(index='meta')
-            # use this opportunity to sync flush the index (no harm if it fails)
-            try:
-                es.indices.flush_synced(index='meta')
-            except ConflictError:
-                pass
-    # refresh all indices
-    try:
-        es.indices.refresh(index='_all')
-    except Exception as e:
-        log.warning('Error refreshing indices after indexing: %s' % str(e))
     return indexing_record
 
 

--- a/src/snovault/elasticsearch/indexer_queue.py
+++ b/src/snovault/elasticsearch/indexer_queue.py
@@ -64,11 +64,11 @@ def queue_indexing(request):
     strict = request.json.get('strict', False)
     if req_uuids:
         # queue these as secondary
-        queued, failed = queue_indexer.add_uuids(request.registry, req_uuids, strict=strict, target_queue='secondary')
+        queued, failed = queue_indexer.add_uuids(request.registry, req_uuids, strict=strict, target_queue='primary')
         response['requested_uuids'] = req_uuids
     else:
         # queue these as secondary
-        queued, failed = queue_indexer.add_collections(request.registry, req_collections, strict=strict, target_queue='secondary')
+        queued, failed = queue_indexer.add_collections(request.registry, req_collections, strict=strict, target_queue='primary')
         response['requested_collections'] = req_collections
     response['notification'] = 'Success'
     response['number_queued'] = len(queued)

--- a/src/snovault/elasticsearch/mpindexer.py
+++ b/src/snovault/elasticsearch/mpindexer.py
@@ -126,7 +126,7 @@ class MPIndexer(Indexer):
             initializer=initializer,
             initargs=self.initargs,
             maxtasksperchild=self.maxtasks,
-            context=get_context('forkserver'),
+            context=get_context('spawn'),
         )
 
     def update_objects(self, request, counter=None):

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -329,9 +329,11 @@ def test_indexing_invalid_sid(app, testapp, indexer_testapp):
     }
     indexer_queue.send_messages([to_queue], target_queue='primary')
     res = indexer_testapp.post_json('/index', {'record': True})
-    time.sleep(5)
-    msg_count = indexer_queue.number_of_messages()
-    assert msg_count['deferred_waiting'] == 1
+    assert res.json['indexing_count'] == 0
+    time.sleep(2)
+    received_deferred = indexer_queue.receive_messages(target_queue='deferred')
+    assert len(received_deferred) == 1
+    indexer_queue.delete_messages(received_deferred, target_queue='deferred')
 
 
 def test_queue_indexing_endpoint(app, testapp, indexer_testapp):


### PR DESCRIPTION
+ Fix the issue with linked items not getting updated on a POST/PATCH by adding the embedded_uuids of each item in the primary/deferred queues to the secondary queue
+ Added an option in the /queue_indexing POST body to determined the target queue for your uuids/collections.
+ Made it so the queue will start new transactions if there are items in the deferred queue while pulling from the secondary queue.
+ MPIndexer now using 'spawn' to initialize multiprocessing pool.
+ Removed some ES refreshes/flushes from /index. Now there is just the initial one.
+ Tests!