### PR TITLE
Allow deletion of enum fields without a default

### DIFF
--- a/src/snovault/tests/test_post_put_patch.py
+++ b/src/snovault/tests/test_post_put_patch.py
@@ -133,6 +133,25 @@ def test_patch_delete_fields(content, testapp):
     assert res.json['@graph'][0]['simple1'] == 'simple1 default'
 
 
+def test_patch_delete_fields_enum(content, testapp):
+    """
+    enum with no default set, should delete completely
+    """
+    url = content['@id']
+    res = testapp.get(url)
+    assert res.json['simple1'] == 'simple1 default'
+    assert res.json['simple2'] == 'simple2 default'
+
+    res = testapp.patch_json(url, {'enum_no_default': '2', 'simple1': 'this is a test'}, status=200)
+    assert res.json['@graph'][0]['enum_no_default'] == '2'
+    assert res.json['@graph'][0]['simple1'] == 'this is a test'
+
+    # delete enums without a default removes it completely
+    res = testapp.patch_json(url + "?delete_fields=simple1,enum_no_default", {}, status=200)
+    assert 'enum_no_default' not in res.json['@graph'][0].keys()
+    assert res.json['@graph'][0]['simple1'] == 'simple1 default'
+
+
 def test_patch_delete_fields_non_string(content, testapp):
     url = content['@id']
     res = testapp.get(url)

--- a/src/snovault/tests/testing_views.py
+++ b/src/snovault/tests/testing_views.py
@@ -181,6 +181,13 @@ class TestingPostPutPatchSno(Item):
             'field_no_default': {
                 'type': 'string',
             },
+            'enum_no_default': {
+                'type': 'string',
+                'enum': [
+                    '1',
+                    '2'
+                ]
+            },
             'protected': {
                 # This should be allowed on PUT so long as value is the same
                 'type': 'string',

--- a/src/snovault/validators.py
+++ b/src/snovault/validators.py
@@ -66,6 +66,9 @@ def add_delete_fields(request, data, schema):
                 continue
             if 'default' in field_schema:
                 val = field_schema['default']
+            elif isinstance(field_schema.get('enum'), list):
+                # an enum used with no default; use previous value
+                continue
             elif field_schema.get('type') == 'array':
                 val = []
             elif field_schema.get('type') == 'object':
@@ -104,4 +107,5 @@ def validate_item_content_patch(context, request):
         raise ValidationFailure('body', ['uuid'], msg)
     current = context.upgrade_properties().copy()
     current['uuid'] = str(context.uuid)
+    # this will add defaults values back to deleted fields with schema defaults
     validate_request(schema, request, data, current)


### PR DESCRIPTION
### Allow deletion of enums using ?delete_fields query
Enums without default values were not handled in `add_delete_fields` function used within `validate_item_content_patch`.

Made a simple fix to handle enums: validators.py line 69. Also added a simple test.

Run live on mastertest and tested by Koray, who confirmed it works.