### PR TITLE
Badge aggregation

### DIFF
--- a/src/snovault/__init__.py
+++ b/src/snovault/__init__.py
@@ -59,6 +59,7 @@ def includeme(config):
     config.include('.predicates')
     config.include('.invalidation')
     config.include('.upgrader')
+    config.include('.aggregated_items')
     config.include('.auditor')
     config.include('.storage')
     config.include('.typeinfo')

--- a/src/snovault/aggregated_items.py
+++ b/src/snovault/aggregated_items.py
@@ -37,7 +37,7 @@ def item_view_aggregated_items(context, request):
         raise HTTPForbidden()
     return {
         '@id': source['object']['@id'],
-        'aggregated_items': source['aggregated_items'],
+        'aggregated_items': source.get('aggregated_items', {})
     }
 
 

--- a/src/snovault/aggregated_items.py
+++ b/src/snovault/aggregated_items.py
@@ -1,6 +1,7 @@
 from .calculated import calculated_property
 from .resources import Item
 from pyramid.view import view_config
+from pyramid.httpexceptions import HTTPForbidden
 
 
 def includeme(config):
@@ -31,8 +32,7 @@ def item_view_aggregated_items(context, request):
             'aggregated_items': {},
         }
     source = context.model.source
-    # use audit permissions for now
-    allowed = set(source['principals_allowed']['audit'])
+    allowed = set(source['principals_allowed']['view'])  # use view permissions
     if allowed.isdisjoint(request.effective_principals):
         raise HTTPForbidden()
     return {

--- a/src/snovault/aggregated_items.py
+++ b/src/snovault/aggregated_items.py
@@ -1,0 +1,57 @@
+from .calculated import calculated_property
+from .resources import Item
+from pyramid.view import view_config
+
+
+def includeme(config):
+    config.include('.calculated')
+    config.scan(__name__)
+
+
+@view_config(context=Item, permission='audit', request_method='GET',
+             name='aggregated-items')
+def item_view_aggregated_items(context, request):
+    """
+    View config for aggregated_items. If the current model does not have
+    `source`, it means we are using write (RDS) storage and not ES. In that
+    case, do not calculate the aggregated_items, as that would required
+    the whole @@index-data view to be run
+
+    Args:
+        context: current Item
+        request: current request
+
+    Returns:
+        A dictionary including item path and aggregated_items
+    """
+    # if we do not have the cached ES model, do not run aggs
+    if not hasattr(context.model, 'source'):
+        return {
+            '@id': request.resource_path(context),
+            'aggregated_items': {},
+        }
+    source = context.model.source
+    # use audit permissions for now
+    allowed = set(source['principals_allowed']['audit'])
+    if allowed.isdisjoint(request.effective_principals):
+        raise HTTPForbidden()
+    return {
+        '@id': source['object']['@id'],
+        'aggregated_items': source['aggregated_items'],
+    }
+
+
+@calculated_property(context=Item, category='page', name='aggregated-items',
+                     condition=lambda request: request.has_permission('audit'))
+def aggregated_items_property(context, request):
+    """
+    Frame=page calculated property to add aggregated_items to response.
+    The request.embed calls item_view_aggregated_items
+    Args:
+        context: current Item
+        request: current Request
+    Returns:
+        Dictionary result of aggregated_items
+    """
+    path = request.resource_path(context)
+    return request.embed(path, '@@aggregated-items')['aggregated_items']

--- a/src/snovault/elasticsearch/cached_views.py
+++ b/src/snovault/elasticsearch/cached_views.py
@@ -76,17 +76,3 @@ def cached_view_audit_self(context, request):
         '@id': path,
         'audit': [a for a in chain(*source['audit'].values()) if a['path'] == path],
     }
-
-
-@view_config(context=ICachedItem, request_method='GET', name='aggregrated-items')
-def cached_view_aggregated_items(context, request):
-    import pdb; pdb.set_trace()
-    source = context.model.source
-    # use audit permissions for now
-    allowed = set(source['principals_allowed']['audit'])
-    if allowed.isdisjoint(request.effective_principals):
-        raise HTTPForbidden()
-    return {
-        '@id': source['object']['@id'],
-        'audit': source['aggregated_items'],
-    }

--- a/src/snovault/elasticsearch/cached_views.py
+++ b/src/snovault/elasticsearch/cached_views.py
@@ -76,3 +76,17 @@ def cached_view_audit_self(context, request):
         '@id': path,
         'audit': [a for a in chain(*source['audit'].values()) if a['path'] == path],
     }
+
+
+@view_config(context=ICachedItem, request_method='GET', name='aggregrated-items')
+def cached_view_aggregated_items(context, request):
+    import pdb; pdb.set_trace()
+    source = context.model.source
+    # use audit permissions for now
+    allowed = set(source['principals_allowed']['audit'])
+    if allowed.isdisjoint(request.effective_principals):
+        raise HTTPForbidden()
+    return {
+        '@id': source['object']['@id'],
+        'audit': source['aggregated_items'],
+    }

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -482,10 +482,14 @@ def aggregated_items_mapping(types, item_type):
     """
     Create the mapping for the aggregated items of the given type.
     This is a simple mapping, since all values can be set as keywords
-    (only used for exact match search and not sorted)
-
+    (only used for exact match search and not sorted).
     Since the fields for each aggregated item are split by dots, we organize
     these as the hierarchical objects for Elasticsearch
+    Args:
+        types: result of request.registry[TYPES]
+        item_type: string item type that we are creating the mapping for
+    Returns:
+        Dictionary mapping for the aggrated_items of the given item type
     """
     type_info = types[item_type]
     aggregated_items = type_info.aggregated_items

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -438,6 +438,10 @@ def es_mapping(mapping):
                     }
                 }
             },
+            'aggregated_items': {
+                'type': 'object',
+                'include_in_all': False,
+            },
             'linked_uuids': {
                 'type': 'text',
                 'include_in_all': False

--- a/src/snovault/embed.py
+++ b/src/snovault/embed.py
@@ -23,6 +23,7 @@ def includeme(config):
     config.add_request_method(lambda request: set(), '_audit_uuids', reify=True)
     config.add_request_method(lambda request: {}, '_rev_linked_uuids_by_item', reify=True)
     config.add_request_method(lambda request: {}, '_aggregated_items', reify=True)
+    config.add_request_method(lambda request: {}, '_aggregate_for', reify=True)
     config.add_request_method(lambda request: False, '_indexing_view', reify=True)
     config.add_request_method(lambda request: None, '__parent__', reify=True)
 
@@ -95,6 +96,7 @@ def _embed(request, path, as_user='EMBED'):
     subreq = make_subrequest(request, path)
     subreq.override_renderer = 'null_renderer'
     subreq._indexing_view = request._indexing_view
+    subreq._aggregate_for = request._aggregate_for
     subreq._aggregated_items = request._aggregated_items
     # pass the uuids we want to run audits on
     if '@@audit' in path:

--- a/src/snovault/embed.py
+++ b/src/snovault/embed.py
@@ -22,6 +22,7 @@ def includeme(config):
     config.add_request_method(lambda request: set(), '_linked_uuids', reify=True)
     config.add_request_method(lambda request: set(), '_audit_uuids', reify=True)
     config.add_request_method(lambda request: {}, '_rev_linked_uuids_by_item', reify=True)
+    config.add_request_method(lambda request: {}, '_badges', reify=True)
     config.add_request_method(lambda request: False, '_indexing_view', reify=True)
     config.add_request_method(lambda request: None, '__parent__', reify=True)
 

--- a/src/snovault/embed.py
+++ b/src/snovault/embed.py
@@ -62,12 +62,13 @@ def embed(request, *elements, **kw):
     # Cache cut response time from ~800ms to ~420ms.
     embed_cache = request.registry[CONNECTION].embed_cache
     as_user = kw.get('as_user')
+    index_uuid = kw.get('index_uuid')
     path = join(*elements)
     path = unquote_bytes_to_wsgi(native_(path))
     # as_user controls whether or not the embed_cache is used
     # if request._indexing_view is True, always use the cache
     if as_user is not None and not request._indexing_view:
-        result, linked_uuids, rev_linked_uuids_by_item = _embed(request, path, as_user)
+        result, linked_uuids, rev_linked_uuids_by_item, agg_items = _embed(request, path, as_user)
     else:
         cached = embed_cache.get(path, None)
         if cached is None:
@@ -76,8 +77,14 @@ def embed(request, *elements, **kw):
             cached = _embed(request, path, as_user=subreq_user)
             # caching audits is safe because they don't add to linked_uuids
             embed_cache[path] = cached
-        result, linked_uuids, rev_linked_uuids_by_item = cached
+        result, linked_uuids, rev_linked_uuids_by_item, agg_items = cached
         result = deepcopy(result)
+    # aggregated_items may be cached; if so, add them to the request
+    # these conditions only fulfilled when using @@embedded and aggregated
+    # items have NOT yet been processed (_aggregate_for is removed if so)
+    if index_uuid and getattr(request, '_aggregate_for').get('uuid') == index_uuid:
+        request._aggregated_items = agg_items
+        request._aggregate_for['uuid'] = None
     # hardcode this because audits can cause serious problems with frame=page
     if '@@audit' not in path:
         request._linked_uuids.update(linked_uuids)
@@ -110,7 +117,8 @@ def _embed(request, path, as_user='EMBED'):
         result = request.invoke_subrequest(subreq)
     except HTTPNotFound:
         raise KeyError(path)
-    return result, subreq._linked_uuids, subreq._rev_linked_uuids_by_item
+    return (result, subreq._linked_uuids,
+            subreq._rev_linked_uuids_by_item, subreq._aggregated_items)
 
 
 class NullRenderer:

--- a/src/snovault/embed.py
+++ b/src/snovault/embed.py
@@ -95,6 +95,7 @@ def _embed(request, path, as_user='EMBED'):
     subreq = make_subrequest(request, path)
     subreq.override_renderer = 'null_renderer'
     subreq._indexing_view = request._indexing_view
+    subreq._aggregated_items = request._aggregated_items
     # pass the uuids we want to run audits on
     if '@@audit' in path:
         subreq._audit_uuids = request._audit_uuids

--- a/src/snovault/embed.py
+++ b/src/snovault/embed.py
@@ -22,7 +22,7 @@ def includeme(config):
     config.add_request_method(lambda request: set(), '_linked_uuids', reify=True)
     config.add_request_method(lambda request: set(), '_audit_uuids', reify=True)
     config.add_request_method(lambda request: {}, '_rev_linked_uuids_by_item', reify=True)
-    config.add_request_method(lambda request: {}, '_badges', reify=True)
+    config.add_request_method(lambda request: {}, '_aggregated_items', reify=True)
     config.add_request_method(lambda request: False, '_indexing_view', reify=True)
     config.add_request_method(lambda request: None, '__parent__', reify=True)
 

--- a/src/snovault/indexing_views.py
+++ b/src/snovault/indexing_views.py
@@ -21,6 +21,22 @@ class SidException(Exception):
 
 @view_config(context=Item, name='index-data', permission='index', request_method='GET')
 def item_index_data(context, request):
+    """
+    Very important view which is used to calculate all the data indexed in ES
+    for the given item. If an int sid is provided as a request parameter,
+    will raise an sid exception if the current item context is behind the
+    given sid.
+    Computationally intensive. Performs the full embedding and calculates
+    audits and aggregated_items, among other things.
+
+    Args:
+        context: current Item
+        request: current request
+
+    Returns:
+        A dictionary document representing the full data to index for the
+        given item
+    """
     uuid = str(context.uuid)
     properties = context.upgrade_properties()
 

--- a/src/snovault/indexing_views.py
+++ b/src/snovault/indexing_views.py
@@ -87,7 +87,7 @@ def item_index_data(context, request):
     audit = request.invoke_view(path, '@@audit')['audit']
     obj = request.invoke_view(path, '@@object')
     document = {
-        'aggregated': aggregated,
+        'aggregated_items': aggregated_items,
         'audit': audit,
         'embedded': embedded,
         'item_type': context.type_info.item_type,

--- a/src/snovault/indexing_views.py
+++ b/src/snovault/indexing_views.py
@@ -90,7 +90,7 @@ def item_index_data(context, request):
     }
     # since request._indexing_view is set to True in indexer.py,
     # all embeds (including subrequests) below will use the embed cache
-    embedded = request.invoke_view(path, '@@embedded')
+    embedded = request.invoke_view(path, '@@embedded', index_uuid=uuid)
     # get _linked and _rev_linked uuids from the request before @@audit views add to them
     linked_uuids = request._linked_uuids.copy()
     rev_linked_by_item = request._rev_linked_uuids_by_item.copy()

--- a/src/snovault/indexing_views.py
+++ b/src/snovault/indexing_views.py
@@ -68,7 +68,7 @@ def item_index_data(context, request):
     request._linked_uuids = set()
     request._audit_uuids = set()
     request._rev_linked_uuids_by_item = {}
-    request._badges = {}
+    request._aggregated_items = {}
     # since request._indexing_view is set to True in indexer.py,
     # all embeds (including subrequests) below will use the embed cache
     embedded = request.invoke_view(path, '@@embedded')
@@ -77,15 +77,14 @@ def item_index_data(context, request):
     rev_linked_by_item = request._rev_linked_uuids_by_item.copy()
     # find uuids traversed that rev link to this item
     rev_linked_to_me = set([id for id in rev_linked_by_item if uuid in rev_linked_by_item[id]])
-    # get badges aggregated during the embedding process
-    badges = request._badges.copy()
+    # get items aggregated during the embedding process
+    aggregated_items = request._aggregated_items.copy()
     # set the uuids we want to audit on
     request._audit_uuids = linked_uuids
     audit = request.invoke_view(path, '@@audit')['audit']
     obj = request.invoke_view(path, '@@object')
     document = {
         'audit': audit,
-        'badges': badges,
         'embedded': embedded,
         'linked_uuids': sorted(linked_uuids),
         'item_type': context.type_info.item_type,

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -131,8 +131,9 @@ def item_view_object(context, request):
     Render json structure. This is the most basic view and contains the scope
     of only one item. The steps to generate it are:
     1. Fetch stored properties, possibly upgrading.
-    2. Link canonicalization (overwriting uuids.) with item_with_links
+    2. Link canonicalization (overwriting uuids with links)
        - adds uuid to request._linked_uuids if request._indexing_view
+       - adds badges to request._badges
     3. Calculated properties
     """
     properties = context.item_with_links(request)

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -164,6 +164,7 @@ def item_view_embedded(context, request):
         # is used in a frame=embedded calc property.
         # use a list here so that the reference is maintained through subreq
         request._aggregate_for['uuid'] = None
+
     return embedded
 
 

--- a/src/snovault/resources.py
+++ b/src/snovault/resources.py
@@ -313,7 +313,7 @@ class Item(Resource):
     def item_with_links(self, request):
         # This works from the schema rather than the links table
         # so that upgrade on GET can work.
-        ### context.__json__ CALLS THE UPGRADER ###
+        ### context.__json__ CALLS THE UPGRADER (upgrade_properties) ###
         properties = self.__json__(request)
         for path in self.type_info.schema_links:
             uuid_to_path(request, properties, path)

--- a/src/snovault/resources.py
+++ b/src/snovault/resources.py
@@ -204,6 +204,7 @@ class Item(Resource):
     base_types = ['Item']
     name_key = None
     rev = {}
+    aggregated_list = []
     embedded_list = []
     audit_inherit = None
     schema = None

--- a/src/snovault/resources.py
+++ b/src/snovault/resources.py
@@ -204,7 +204,7 @@ class Item(Resource):
     base_types = ['Item']
     name_key = None
     rev = {}
-    aggregated_list = []
+    aggregated_items = {}
     embedded_list = []
     audit_inherit = None
     schema = None

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -850,6 +850,7 @@ def test_aggregated_items(app, testapp, indexer_testapp):
     - Check that the aggregations worked correctly
     - Patch the TestingLinkAggregateSno to only 1 TestingLinkSourceSno, index
     - Ensure that the aggregated_items changed, checking ES
+    - Ensure that duplicate aggregated_items are deduplicated
     - Check aggregated-items view; should now match ES results
     """
     import webtest
@@ -915,10 +916,13 @@ def test_aggregated_items(app, testapp, indexer_testapp):
             assert target_agg['item']['test_description'] == 'target two'
             assert target_agg['item']['target']['uuid'] == target2['uuid']
     # now make sure they get updated on a patch
+    # use duplicate items, which should be deduplicated
     testapp.patch_json('/testing-link-aggregates-sno/' + aggregated['uuid'],
                        {'targets': [
                            {'test_description': 'target one revised',
-                            'target': '775795d3-4410-4114-836b-8eeecf1d0c2f'}
+                            'target': '775795d3-4410-4114-836b-8eeecf1d0c2f'},
+                           {'test_description': 'target one revised',
+                            'target': '775795d3-4410-4114-836b-8eeecf1d0c2f'},
                         ]})
     indexer_testapp.post_json('/index', {'record': True})
     time.sleep(10)  # be lazy and just wait a bit

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -932,5 +932,7 @@ def test_aggregated_items(app, testapp, indexer_testapp):
     post_agg_view = testapp.get(agg_res_atid + '@@aggregated-items', status=200).json
     assert post_agg_view['@id'] == agg_res_atid
     assert post_agg_view['aggregated_items'] == es_agg_res['_source']['aggregated_items']
-    # clean up the testing_link_aggregate_sno index
-    es.delete(index='testing_link_aggregate_sno', doc_type='testing_link_aggregate_sno', id=agg_res_uuid)
+    # clean up the test items
+    testapp.patch_json('/testing-link-aggregates-sno/' + aggregated['uuid'],
+                       {'targets': []})
+    indexer_testapp.post_json('/index', {'record': True})

--- a/src/snovault/tests/testing_views.py
+++ b/src/snovault/tests/testing_views.py
@@ -103,9 +103,9 @@ class TestingLinkSourceSno(Item):
     }
 
 
-@collection('testing-link-aggregateds-sno')
-class TestingLinkAggregatedSno(Item):
-    item_type = 'testing_link_aggregated_sno'
+@collection('testing-link-aggregates-sno')
+class TestingLinkAggregateSno(Item):
+    item_type = 'testing_link_aggregate_sno'
     schema = {
         'type': 'object',
         'properties': {
@@ -125,16 +125,16 @@ class TestingLinkAggregatedSno(Item):
                         },
                         'target':{
                             'type': 'string',
-                            'linkTo': 'TestingLinkTargetSno',
+                            'linkTo': 'TestingLinkTargetSno'
                         }
                     }
                 }
             },
             'status': {
                 'type': 'string',
-            },
+            }
         },
-        'required': ['target'],
+        'required': ['targets'],
         'additionalProperties': False,
     }
     aggregated_items = {

--- a/src/snovault/tests/testing_views.py
+++ b/src/snovault/tests/testing_views.py
@@ -103,6 +103,45 @@ class TestingLinkSourceSno(Item):
     }
 
 
+@collection('testing-link-aggregateds-sno')
+class TestingLinkAggregatedSno(Item):
+    item_type = 'testing_link_aggregated_sno'
+    schema = {
+        'type': 'object',
+        'properties': {
+            'name': {
+                'type': 'string',
+            },
+            'uuid': {
+                'type': 'string',
+            },
+            'targets': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'test_description': {
+                            'type': 'string'
+                        },
+                        'target':{
+                            'type': 'string',
+                            'linkTo': 'TestingLinkTargetSno',
+                        }
+                    }
+                }
+            },
+            'status': {
+                'type': 'string',
+            },
+        },
+        'required': ['target'],
+        'additionalProperties': False,
+    }
+    aggregated_items = {
+        "targets": ['target.uuid', 'test_description']
+    }
+
+
 @collection('testing-link-targets-sno', unique_key='testing_link_target_sno:name')
 class TestingLinkTargetSno(Item):
     item_type = 'testing_link_target_sno'

--- a/src/snovault/typeinfo.py
+++ b/src/snovault/typeinfo.py
@@ -53,7 +53,7 @@ class TypeInfo(AbstractTypeInfo):
         self.item_type = item_type
         self.factory = factory
         self.base_types = factory.base_types
-        self.aggregated_list = factory.aggregated_list
+        self.aggregated_items = factory.aggregated_items
         self.embedded_list = factory.embedded_list
 
     @reify

--- a/src/snovault/typeinfo.py
+++ b/src/snovault/typeinfo.py
@@ -53,6 +53,7 @@ class TypeInfo(AbstractTypeInfo):
         self.item_type = item_type
         self.factory = factory
         self.base_types = factory.base_types
+        self.aggregated_list = factory.aggregated_list
         self.embedded_list = factory.embedded_list
 
     @reify

--- a/src/snovault/util.py
+++ b/src/snovault/util.py
@@ -307,7 +307,7 @@ def recursively_process_field(item, split_fields):
         # happens if a string/int is encountered at the top level
         return item
     if next_level is None:
-        return "No value"
+        return None
     if len(split_fields[1:]) == 0:
         # we are at the end of the path
         return next_level


### PR DESCRIPTION
Add support for `aggregated_items` on individual item types and the accompanying `frame=aggregated-items`. This is controlled by setting the `aggregated_items` attribute on the type. Aggregated items are ONLY shown when Elasticsearch is used as a datasource, since `indexing_views.py` is required when populating them.

The actual aggregation process is quite lightweight, since it is made to work synchronously with the embedding process. See the Fourfront branch (https://github.com/4dn-dcic/fourfront/pull/887) for realistic usage of this feature.