### PR TITLE
fourfront_utils.crawl_schema

### DIFF
--- a/src/snowflakes/tests/test_fourfront_utils.py
+++ b/src/snowflakes/tests/test_fourfront_utils.py
@@ -2,7 +2,8 @@ import pytest
 from snovault.fourfront_utils import (
     build_default_embeds,
     find_default_embeds_for_schema,
-    expand_embedded_list
+    expand_embedded_list,
+    crawl_schema
 )
 
 def test_get_jsonld_types_from_collection_type(app):
@@ -57,3 +58,13 @@ def test_find_default_embeds_and_expand_emb_list(registry):
                       'snowset.uuid', 'snowset.award.link_id', 'snowset.award.display_title', 'snowset.award.@id',
                       'snowset.award.principals_allowed.*', 'snowset.award.uuid']
     assert set(expected_built) == set(build_default_embeds(embs_to_add2, set()))
+
+
+def test_crawl_schema(registry):
+    from snovault import TYPES
+    field_path = 'lab.awards.title'
+    type_info = registry[TYPES].by_item_type['snowflake']
+    snowflake_schema = type_info.schema
+    res = fourfront_utils.crawl_schema(registry[TYPES], field_path, snowflake_schema)
+    assert isinstance(res, dict)
+    assert res['type'] == 'string'

--- a/src/snowflakes/tests/test_fourfront_utils.py
+++ b/src/snowflakes/tests/test_fourfront_utils.py
@@ -70,7 +70,6 @@ def test_crawl_schema(registry):
     assert res['type'] == 'string'
 
     # test some bad cases.
-    # test some bad cases. In this one, we drill down too far
     with pytest.raises(Exception) as exec_info:
         crawl_schema(registry[TYPES], field_path, 'not_a_schema')
     # different error, since it attempts to find the file locally

--- a/src/snowflakes/tests/test_fourfront_utils.py
+++ b/src/snowflakes/tests/test_fourfront_utils.py
@@ -62,9 +62,37 @@ def test_find_default_embeds_and_expand_emb_list(registry):
 
 def test_crawl_schema(registry):
     from snovault import TYPES
+    from copy import deepcopy
     field_path = 'lab.awards.title'
-    type_info = registry[TYPES].by_item_type['snowflake']
-    snowflake_schema = type_info.schema
-    res = fourfront_utils.crawl_schema(registry[TYPES], field_path, snowflake_schema)
+    snowflake_schema = registry[TYPES].by_item_type['snowflake'].schema
+    res = crawl_schema(registry[TYPES], field_path, snowflake_schema)
     assert isinstance(res, dict)
     assert res['type'] == 'string'
+
+    # test some bad cases.
+    # test some bad cases. In this one, we drill down too far
+    with pytest.raises(Exception) as exec_info:
+        crawl_schema(registry[TYPES], field_path, 'not_a_schema')
+    # different error, since it attempts to find the file locally
+    assert 'Invalid starting schema' in str(exec_info)
+
+    field_path2 = 'lab.awards.title.title'
+    with pytest.raises(Exception) as exec_info2:
+        crawl_schema(registry[TYPES], field_path2, snowflake_schema)
+    # different error, since it attempts to find the file locally
+    assert 'Non-dictionary schema' in str(exec_info2)
+
+    field_path3 = 'lab.awards.not_a_field'
+    with pytest.raises(Exception) as exec_info3:
+        crawl_schema(registry[TYPES], field_path3, snowflake_schema)
+    # different error, since it attempts to find the file locally
+    assert 'Field not found' in str(exec_info3)
+
+    # screw with the schema to create an invalid linkTo
+    snowflake_schema = registry[TYPES].by_item_type['snowflake'].schema
+    schema_copy = deepcopy(snowflake_schema)
+    schema_copy['properties']['lab']['linkTo'] = 'NotAnItem'
+    with pytest.raises(Exception) as exec_info4:
+        crawl_schema(registry[TYPES], field_path, schema_copy)
+    # different error, since it attempts to find the file locally
+    assert 'Invalid linkTo' in str(exec_info4)


### PR DESCRIPTION
Added a generic `crawl_schema` function to src/fourfront_utils. It facilitates easy finding of schema properties, including traversal of linkTo's.

Usage: (given the starting schema for an object)

from snovault import TYPES, fourfront_utils
field_schema = fourfront_utils.crawl_schema(registry[TYPES], 'field1.field2.field3', starting_schema)
(Will return the field_schema for `field3`)