### PR TITLE
Sid indexing tracking

### DIFF
--- a/src/snovault/elasticsearch/indexer.py
+++ b/src/snovault/elasticsearch/indexer.py
@@ -213,8 +213,6 @@ class Indexer(object):
                     self.queue.send_messages([msg_body], target_queue=target_queue)
                     to_delete.append(msg)
                     continue
-                if msg_body['strict'] is False:
-                    non_strict_uuids.add(msg_uuid)
                 # build the object and index into ES
                 # if strict==True, do not add uuids rev_linking to item to queue
                 if msg_body['strict'] is True:
@@ -241,6 +239,9 @@ class Indexer(object):
                         self.queue.replace_messages([msg], target_queue=target_queue, vis_timeout=180)
                         errors.append(error)
                 else:
+                    # if non-strict, adding will queue associated items to secondary
+                    if msg_body['strict'] is False:
+                        non_strict_uuids.add(msg_uuid)
                     if counter: counter[0] += 1  # do not increment on error
                     to_delete.append(msg)
                 # delete messages when we have the right number

--- a/src/snovault/indexing_views.py
+++ b/src/snovault/indexing_views.py
@@ -209,10 +209,10 @@ def indexing_info(request):
         embedded_view = request.invoke_view(path, index_uuid=uuid, as_user='INDEXER')
         end = timer()
         response['embedded_seconds'] = end - start
-        find_uuids = get_rev_linked_items(request, uuid)
-        find_uuids.add(uuid)
-        assc_uuids = find_uuids_for_indexing(request.registry, find_uuids)
-        response['uuids_invalidated'] = list(assc_uuids)
+        es_assc_uuids = find_uuids_for_indexing(request.registry, set([uuid]))
+        new_rev_link_uuids = get_rev_linked_items(request, uuid)
+        # invalidated: items linking to this in es + newly rev linked items
+        response['uuids_invalidated'] = list(es_assc_uuids | new_rev_link_uuids)
         response['description'] = 'Using live results for embedded view of %s. Query with run=False to skip this.' % uuid
     else:
         response['description'] = 'Query with run=True to calculate live information on invalidation and embedding time.'

--- a/src/snovault/indexing_views.py
+++ b/src/snovault/indexing_views.py
@@ -6,10 +6,12 @@ from pyramid.security import (
 )
 from pyramid.traversal import resource_path
 from pyramid.view import view_config
+from pyramid.settings import asbool
 from timeit import default_timer as timer
 from .resources import Item
 from .authentication import calc_principals
 from .interfaces import STORAGE
+from .elasticsearch.indexer_utils import find_uuids_for_indexing
 
 def includeme(config):
     config.add_route('indexing-info', '/indexing-info')
@@ -208,10 +210,9 @@ def indexing_info(request):
         end = timer()
         response['embedded_seconds'] = end - start
         find_uuids = get_rev_linked_items(request, uuid)
-        response['uuids_rev_linked_to_this'] = list(find_uuids)
         find_uuids.add(uuid)
         assc_uuids = find_uuids_for_indexing(request.registry, find_uuids)
-        response['uuids_invalidated_by_this'] = list(assc_uuids)
+        response['uuids_invalidated'] = list(assc_uuids)
         response['description'] = 'Using live results for embedded view of %s. Query with run=False to skip this.' % uuid
     else:
         response['description'] = 'Query with run=True to calculate live information on invalidation and embedding time.'

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -12,7 +12,6 @@ from pyramid.view import (
     render_view_to_response,
     view_config,
 )
-from pyramid.threadlocal import manager, get_current_request
 from urllib.parse import urlencode
 from .calculated import calculate_properties
 from .resources import (

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -14,7 +14,6 @@ from pyramid.view import (
 )
 from pyramid.threadlocal import manager, get_current_request
 from urllib.parse import urlencode
-from timeit import default_timer as timer
 from .calculated import calculate_properties
 from .resources import (
     AbstractCollection,
@@ -29,13 +28,8 @@ from .util import (
     check_es_and_cache_linked_sids,
     validate_es_content
 )
-from .interfaces import STORAGE
-from .indexing_views import get_rev_linked_items
-from .elasticsearch.indexer_utils import find_uuids_for_indexing
-
 
 def includeme(config):
-    config.add_route('indexing-info', '/indexing-info')
     config.scan(__name__)
 
 
@@ -307,47 +301,3 @@ def item_view_raw(context, request):
     # add uuid to raw view
     props['uuid'] = str(context.uuid)
     return props
-
-
-@view_config(route_name='indexing-info', permission='index', request_method='GET')
-def indexing_info(request):
-    """
-    Endpoint to check some indexing-related properties of a given uuid, which
-    is provided using the `uuid=` query parameter. This route cannot be defined
-    with the context of a specific Item because that will cause the underlying
-    request to use a cached view from Elasticsearch and not properly run
-    the @@embedded view from the database.
-
-    If you do not want to calculate the embedded object, use `run=False`
-
-    Args:
-        request: current Request object
-
-    Returns:
-        dict response
-    """
-    uuid = request.params.get('uuid')
-    if not uuid:
-        return {'status': 'error', 'title': 'Error', 'message': 'ERROR! Provide a uuid to the query.'}
-
-    db_sid = request.registry[STORAGE].write.get_by_uuid(uuid).sid
-    es_sid = request.registry[STORAGE].read.get_by_uuid(uuid).sid
-    response = {'sid_db': db_sid, 'sid_es': es_sid, 'title': 'Indexing Info for %s' % uuid}
-    if asbool(request.params.get('run', True)):
-        request._indexing_view = True
-        request.datastore = 'database'
-        path = '/' + uuid + '/@@embedded'
-        start = timer()
-        embedded_view = request.invoke_view(path, index_uuid=uuid, as_user='INDEXER')
-        end = timer()
-        response['embedded_seconds'] = end - start
-        find_uuids = get_rev_linked_items(request, uuid)
-        response['uuids_rev_linked_to_this'] = list(find_uuids)
-        find_uuids.add(uuid)
-        assc_uuids = find_uuids_for_indexing(request.registry, find_uuids)
-        response['uuids_invalidated_by_this'] = list(assc_uuids)
-        response['description'] = 'Using live results for embedded view of %s. Query with run=False to skip this.' % uuid
-    else:
-        response['description'] = 'Query with run=True to calculate live information on invalidation and embedding time.'
-    response['status'] = 'success'
-    return response

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -12,7 +12,9 @@ from pyramid.view import (
     render_view_to_response,
     view_config,
 )
+from pyramid.threadlocal import manager, get_current_request
 from urllib.parse import urlencode
+from timeit import default_timer as timer
 from .calculated import calculate_properties
 from .resources import (
     AbstractCollection,
@@ -27,9 +29,13 @@ from .util import (
     check_es_and_cache_linked_sids,
     validate_es_content
 )
+from .interfaces import STORAGE
+from .indexing_views import get_rev_linked_items
+from .elasticsearch.indexer_utils import find_uuids_for_indexing
 
 
 def includeme(config):
+    config.add_route('indexing-info', '/indexing-info')
     config.scan(__name__)
 
 
@@ -163,8 +169,8 @@ def item_view_object(context, request):
     return properties
 
 
-@view_config(context=Item, permission='view', request_method='GET',
-             name='embedded')
+@view_config(context=Item, permission='index', request_method='GET', name='force-embedded')
+@view_config(context=Item, permission='view', request_method='GET', name='embedded')
 def item_view_embedded(context, request):
     """
     Calculate and return the embedded view for an item. This is an intensive
@@ -295,8 +301,53 @@ def item_view_columns(context, request):
              name='raw')
 def item_view_raw(context, request):
     props = context.properties
+    # only upgrade properties if explicitly requested
     if asbool(request.params.get('upgrade', True)):
         props =  context.upgrade_properties()
     # add uuid to raw view
     props['uuid'] = str(context.uuid)
     return props
+
+
+@view_config(route_name='indexing-info', permission='index', request_method='GET')
+def indexing_info(request):
+    """
+    Endpoint to check some indexing-related properties of a given uuid, which
+    is provided using the `uuid=` query parameter. This route cannot be defined
+    with the context of a specific Item because that will cause the underlying
+    request to use a cached view from Elasticsearch and not properly run
+    the @@embedded view from the database.
+
+    If you do not want to calculate the embedded object, use `run=False`
+
+    Args:
+        request: current Request object
+
+    Returns:
+        dict response
+    """
+    uuid = request.params.get('uuid')
+    if not uuid:
+        return {'status': 'error', 'title': 'Error', 'message': 'ERROR! Provide a uuid to the query.'}
+
+    db_sid = request.registry[STORAGE].write.get_by_uuid(uuid).sid
+    es_sid = request.registry[STORAGE].read.get_by_uuid(uuid).sid
+    response = {'sid_db': db_sid, 'sid_es': es_sid, 'title': 'Indexing Info for %s' % uuid}
+    if asbool(request.params.get('run', True)):
+        request._indexing_view = True
+        request.datastore = 'database'
+        path = '/' + uuid + '/@@embedded'
+        start = timer()
+        embedded_view = request.invoke_view(path, index_uuid=uuid, as_user='INDEXER')
+        end = timer()
+        response['embedded_seconds'] = end - start
+        find_uuids = get_rev_linked_items(request, uuid)
+        response['uuids_rev_linked_to_this'] = list(find_uuids)
+        find_uuids.add(uuid)
+        assc_uuids = find_uuids_for_indexing(request.registry, find_uuids)
+        response['uuids_invalidated_by_this'] = list(assc_uuids)
+        response['description'] = 'Using live results for embedded view of %s. Query with run=False to skip this.' % uuid
+    else:
+        response['description'] = 'Query with run=True to calculate live information on invalidation and embedding time.'
+    response['status'] = 'success'
+    return response

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -163,7 +163,6 @@ def item_view_object(context, request):
     return properties
 
 
-@view_config(context=Item, permission='index', request_method='GET', name='force-embedded')
 @view_config(context=Item, permission='view', request_method='GET', name='embedded')
 def item_view_embedded(context, request):
     """

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -1018,3 +1018,29 @@ def test_aggregated_items(app, testapp, indexer_testapp):
     testapp.patch_json('/testing-link-aggregates-sno/' + aggregated['uuid'],
                        {'targets': []})
     indexer_testapp.post_json('/index', {'record': True})
+
+
+def test_indexing_info(app, testapp, indexer_testapp):
+    """
+    Test the information on indexing-info for a given uuid and make sure that
+    it updates properly following indexing
+    """
+    target1 = {'name': 't_one', 'uuid': str(uuid.uuid4())}
+    target2 = {'name': 't_two', 'uuid': str(uuid.uuid4())}
+    source = {
+        'name': 'idx_source',
+        'target': target1['uuid'],
+        'uuid': str(uuid.uuid4()),
+        'status': 'current',
+    }
+    target1_res = testapp.post_json('/testing-link-targets-sno/', target1, status=201)
+    target2_res = testapp.post_json('/testing-link-targets-sno/', target2, status=201)
+    source_res = testapp.post_json('/testing-link-sources-sno/', source, status=201)
+    res = indexer_testapp.post_json('/index', {'record': True})
+    time.sleep(2)
+    # indexing-info fails without uuid query param
+    import pdb; pdb.set_trace()
+    idx_info_err = testapp.get('indexing-info')
+    assert idx_info_err.json['status'] == 'error'
+    source_idx_info = testapp.get('indexing-info?uuid=%s' % source['uuid'])
+    assert source_idx_info.json['status'] == 'success'


### PR DESCRIPTION
This branch adds the `indexing-info` endpoint, which can be used to obtain the DB and ES sids of a given item, as well calculate the `@@embedded` view with datastore=database to identify associated items (w.r.t. indexing) and get timing information.

Usage: `GET /indexing-info?uuid=<uuid>&run=True`
Setting `run=False` will cause cause the endpoint to skip calculation of `@@embedded` and just return sid information.

Also fixed a bug in indexer that would add secondary items to the queue when a non-strict message gets move to the deferred queue.

Added tests for both of these things.