### PR TITLE
Remove add_delete_fields

### DIFF
--- a/src/snovault/tests/test_post_put_patch.py
+++ b/src/snovault/tests/test_post_put_patch.py
@@ -162,28 +162,32 @@ def test_patch_delete_fields_non_string(content, testapp):
     assert res.json['@graph'][0]['schema_version'] == '1'
 
 
-def test_patch_delete_fields_still_works_with_no_validation(content, testapp):
+def test_patch_delete_fields_fails_with_no_validation(content, testapp):
     url = content['@id']
     res = testapp.get(url)
     assert res.json['simple1'] == 'simple1 default'
     assert res.json['simple2'] == 'simple2 default'
     assert res.json['field_no_default'] == 'test'
 
-    # with validate=false, then defaults are not populated so default fields are also deleted
-    res = testapp.patch_json(url + "?delete_fields=simple1,field_no_default&validate=false", {}, status=200)
-    assert 'field_no_default' not in res.json['@graph'][0].keys()
-    assert 'simple1' not in res.json['@graph'][0].keys()
+    # using delete_fields with validate=False will now raise a validation err
+    res = testapp.patch_json(url + "?delete_fields=simple1,field_no_default&validate=false", {}, status=422)
+    assert res.json['description'] == "Failed validation"
+    assert 'Cannot delete fields' in res.json['errors'][0]['description']
 
 
 def test_patch_delete_fields_bad_param(content, testapp):
+    """
+    delete_fields should not fail with a bad fieldname, but simply ignore
+    """
     url = content['@id']
     res = testapp.get(url)
     assert res.json['simple1'] == 'simple1 default'
     assert res.json['simple2'] == 'simple2 default'
     assert res.json['field_no_default'] == 'test'
-    res = testapp.patch_json(url + "?delete_fields=simple1,bad_fieldname", {}, status=422)
-    assert res.json['description'] == "Failed validation"
-    assert res.json['errors'][0]['description'] == "Additional properties are not allowed ('bad_fieldname' was unexpected)"
+    res = testapp.patch_json(url + "?delete_fields=simple1,bad_fieldname", {}, status=200)
+    # default value
+    assert res.json['@graph'][0]['simple1'] == 'simple1 default'
+    assert 'bad_fieldname' not in res.json['@graph'][0]
 
 
 def test_patch_delete_fields_import_items_admin(link_targets, testapp):

--- a/src/snovault/validators.py
+++ b/src/snovault/validators.py
@@ -26,7 +26,8 @@ def no_validate_item_content_patch(context, request):
     data = context.properties.copy()
     data.update(request.json)
     schema = context.type_info.schema
-    delete_fields(request, data, schema)
+    # this will raise a validation error if delete_fields param provided
+    delete_fields(request, data)
     if 'uuid' in data:
         if UUID(data['uuid']) != context.uuid:
             msg = 'uuid may not be changed'
@@ -34,53 +35,35 @@ def no_validate_item_content_patch(context, request):
     request.validated.update(data)
 
 
-# Delete fields from data in the delete_fields param of the request
-# Throw a validation error if the field does not exist within the schema
-def delete_fields(request, data, schema):
+def delete_fields(request, data):
+    """
+    Delete fields from data in the delete_fields param of the request.
+    Do not do any special validation here, since that is handled in the
+    validate function that runs this. Modified the input data in place
+
+    Args:
+        request: current Request object
+        data: dict item metadata
+
+    Returns:
+        None
+
+    Raises:
+        ValidationFailure if validate=false in request params
+    """
     if not request.params.get('delete_fields'):
         return
 
-    add_delete_fields(request, data, schema)
-    validated, errors = validate(schema, data)
-    if errors:
-        for error in errors:
-            if isinstance(error, IgnoreUnchanged):
-                if error.validator != 'permission':
-                    continue
-            request.errors.add('body', list(error.path), error.message)
-    if request.errors:
-        raise ValidationFailure('body', ['?delete_fields'], 'error deleting fields')
+    # do not allow validate=false with delete_fields, since it skips schema
+    # validation, which does things like adding defaults
+    if request.params.get('validate') == 'false':
+        err_msg = 'Cannot delete fields on request with with validate=false'
+        raise ValidationFailure('body', ['?delete_fields'], err_msg)
 
     for dfield in request.params['delete_fields'].split(','):
         dfield = dfield.strip()
         if dfield in data:
             del data[dfield]
-
-
-def add_delete_fields(request, data, schema):
-    if request.params.get('delete_fields'):
-        for dfield in request.params['delete_fields'].split(','):
-            dfield = dfield.strip()
-            val = ''
-            field_schema = schema['properties'].get(dfield, {})
-            if field_schema.get('linkTo'):
-                continue
-            if 'default' in field_schema:
-                val = field_schema['default']
-            elif isinstance(field_schema.get('enum'), list):
-                # an enum used with no default; use previous value
-                continue
-            elif field_schema.get('type') == 'boolean':
-                val = False
-            elif field_schema.get('type') == 'array':
-                val = []
-            elif field_schema.get('type') == 'object':
-                val = {}
-            elif field_schema.get('type') in ['number', 'integer']:
-                val = 0
-            elif determine_if_is_date_field(dfield, field_schema):
-                val = '2000-01-01'
-            data[dfield] = val
 
 
 # Schema checking validators
@@ -106,7 +89,7 @@ def validate_item_content_patch(context, request):
         del data['schema_version']
     data.update(request.json)
     schema = context.type_info.schema
-    delete_fields(request, data, schema)
+    delete_fields(request, data)
     if 'uuid' in data and UUID(data['uuid']) != context.uuid:
         msg = 'uuid may not be changed'
         raise ValidationFailure('body', ['uuid'], msg)


### PR DESCRIPTION
Remove `add_delete_fields` from `delete_fields` functionality in snovault.validators. As far as I can tell, the only use of this is deleting fields with `validate=false` query param (which we don't even want to do). Instead, raise ValidationFailure if you attempt to do that

**UPDATE**
This didn't quite work. When deleting a protected field (e.g. permission = import_items) when need to validate based off of the _previous_ contents before deleting. I think Jeremy's code handled this in an opaque way. Now, I use the `current` param in the call to `validate()` in `delete_fields` to take changed values into account. I also added another argument to `validate`, called `validate_current`, which will cause validation errors from the current contents to be considered when comparing new/current contents.

I realize that this may be a bit confusing in a vacuum, so let me know if anything needs more in-depth explanation. The best way to test is to build the [companion FF branch](https://github.com/4dn-dcic/fourfront/pull/1052) (or just fetch it and manually change your snovault branch)