### PR TITLE
Abstract profiles

### DIFF
--- a/src/snovault/config.py
+++ b/src/snovault/config.py
@@ -48,13 +48,14 @@ def root(factory):
 
 
 def collection(name, **kw):
-    """ Attach a collection at the location ``name``.
-
+    """
+    Attach a collection at the location ``name``.
     Use as a decorator on Collection subclasses.
     """
 
     def set_collection(config, Collection, name, Item, **kw):
         registry = config.registry
+        # registers the type in registry[TYPES].all and .by_item_type
         ti = registry[TYPES].register(Item)
         collection = Collection(registry, name, ti, **kw)
         registry[COLLECTIONS].register(name, collection)
@@ -73,16 +74,18 @@ def collection(name, **kw):
 
 
 def abstract_collection(name, **kw):
-    """ Attach a collection at the location ``name``.
-
+    """
+    Attach a collection at the location ``name``.
     Use as a decorator on Collection subclasses.
     """
 
     def set_collection(config, Collection, name, Item, **kw):
         registry = config.registry
-        ti = registry[TYPES].register_abstract(Item.__name__)
-        registry[TYPES].all[Item] = ti  # XXX Ugly this is here.
-        collection = Collection(registry, name, ti, **kw)
+        # registers the type in registry[TYPES].by_abstract_type
+        # and the abstract type in registry[TYPES].all
+        abstract_ti = registry[TYPES].register_abstract(Item)
+        # register an abstract collection
+        collection = Collection(registry, name, abstract_ti, **kw)
         registry[COLLECTIONS].register(name, collection)
 
     def decorate(Item):

--- a/src/snovault/config.py
+++ b/src/snovault/config.py
@@ -102,6 +102,13 @@ def abstract_collection(name, **kw):
 
 
 class CollectionsTool(dict):
+    """
+    Helper class used to register and store different item collections.
+    Collection/AbstractCollection class are defined in snovault.resources.py
+    Includes:
+    - Collections registered using the @collection decorator
+    - AbstractCollections registed using @abstract_collection
+    """
     def __init__(self):
         self.by_item_type = {}
 

--- a/src/snovault/jsonld_context.py
+++ b/src/snovault/jsonld_context.py
@@ -285,6 +285,9 @@ def ontology_from_schema(schema, prefix, term_path, item_type, class_name, base_
 @view_config(route_name='jsonld_context_no_slash', request_method='GET')
 @view_config(route_name='jsonld_context', request_method='GET')
 def jsonld_context(context, request):
+    """
+    Basically a view that list all the terms used on the site in JSON-ld format
+    """
     return request.registry['snovault.jsonld.context']
 
 

--- a/src/snovault/resources.py
+++ b/src/snovault/resources.py
@@ -117,6 +117,17 @@ class Root(Resource):
 
 
 class AbstractCollection(Resource, Mapping):
+    """
+    Collection for a certain type of resource that stores the following info:
+    - registry (pyramid registry)
+    - type_info (TypeInfo for a certain item type, see snovault.typeinfo.py)
+    - __acl__
+    - uniqueKey for the collection (e.g. item_name:key)
+    And some other info as well.
+
+    Collections allow retrieval of specific items with them by using the `get`
+    method with uuid or the unique_key
+    """
     properties = {}
     unique_key = None
 

--- a/src/snovault/resources.py
+++ b/src/snovault/resources.py
@@ -214,7 +214,7 @@ class Collection(AbstractCollection):
 # schema definition, so we define it here to import & re-use.
 display_title_schema = {
     "title": "Display Title",
-    "description": "A calculated title for every object in 4DN",
+    "description": "A calculated title for every object",
     "type": "string",
 }
 

--- a/src/snowflakes/tests/test_views.py
+++ b/src/snowflakes/tests/test_views.py
@@ -1,4 +1,5 @@
 import pytest
+from snovault import TYPES
 
 
 def _type_length():
@@ -307,7 +308,37 @@ def test_profiles(testapp, item_type):
     res = testapp.get('/profiles/%s.json' % item_type).maybe_follow(status=200)
     errors = Draft4Validator.check_schema(res.json)
     assert not errors
+    # added from snovault.schema_views._annotated_schema
+    assert 'rdfs:seeAlso' in res.json
+    assert 'rdfs:subClassOf' in res.json
+    assert 'children' in res.json
 
+
+@pytest.mark.parametrize('item_type', ['Item', 'item', 'Snowset', 'snowset'])
+def test_profiles_abstract(testapp, item_type):
+    from jsonschema_serialize_fork import Draft4Validator
+    res = testapp.get('/profiles/%s.json' % item_type).maybe_follow(status=200)
+    errors = Draft4Validator.check_schema(res.json)
+    assert not errors
+    # added from snovault.schema_views._annotated_schema
+    assert 'rdfs:seeAlso' in res.json
+    # Item/item does not have subClass
+    if item_type.lower() == 'item':
+        assert 'rdfs:subClassOf' not in res.json
+    else:
+        assert 'rdfs:subClassOf' in res.json
+    # abstract types wil have children
+    assert len(res.json['children']) >= 1
+
+
+def test_profiles_all(testapp, registry):
+    from jsonschema_serialize_fork import Draft4Validator
+    res = testapp.get('/profiles/').maybe_follow(status=200)
+    # make sure all types are present, including abstract types
+    for ti in registry[TYPES].by_item_type.values():
+        assert ti.name in res.json
+    for ti in registry[TYPES].by_abstract_type.values():
+        assert ti.name in res.json
 
 def test_bad_frame(testapp, award):
     res = testapp.get(award['@id'] + '?frame=bad', status=404)

--- a/src/snowflakes/types/base.py
+++ b/src/snowflakes/types/base.py
@@ -110,7 +110,14 @@ class Collection(snovault.Collection, AbstractCollection):
             self.__acl__ = ALLOW_SUBMITTER_ADD
 
 
+@snovault.abstract_collection(
+    name='items',
+    properties={
+        'title': "Item Listing",
+        'description': 'Abstract collection of all Items.',
+    })
 class Item(snovault.Item):
+    item_type = 'item'
     AbstractCollection = AbstractCollection
     Collection = Collection
     STATUS_ACL = {

--- a/src/snowflakes/types/snow.py
+++ b/src/snowflakes/types/snow.py
@@ -20,6 +20,7 @@ def item_is_revoked(request, path):
         'description': 'Abstract class describing different collections of snowflakes.',
     })
 class Snowset(Item):
+    item_type = 'snowset'
     base_types = ['Snowset'] + Item.base_types
     embedded_list = [
         'submitted_by.*',


### PR DESCRIPTION
The main goal of this branch is to add item types contained in abstract collections to the profiles endpoint. This includes the general `/profiles/` route, which has all profiles keyed by item name, and the `/profiles/{item}.json` endpoint, which is the profile for a specific endpoint for an item. In the latter, `{item}` can be item name (e.g. MyItem) or item type (e.g. my_item).

In addition, also added the following keys to the profile for each item:
- `rdfs:seeAlso`: link to the terms page for the item
- `children`: links to the profiles pages for any and all child item types
- `rdfs:subClassOf`: link to the profiles page for the parent class. This will be present for all items except the base `Item`, which has no parent

Essentially, this branch accomplishes this by adding the `registry[TYPES].by_abstract_type` store, which contains the TypeInfo objects for items in abstract collections. Previously, this was not present. I removed `registry[TYPES].abstract`, which was unused. The AbstractTypeInfo object for the aforementioned abstract types is still kept in `registry[TYPES].all` the same way as before.

These changes required a minor change to the `abstract_collection` decorator in snovault.config.py, since registering the abstract types now requires the item factory, not just the item name.

Also added a few tests and some documentation. Upon release, will be associated with release `v1.1.0`.