### PR TITLE
Release 1.2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ tests_require = [
 
 setup(
     name='snovault',
-    version='1.2.0',
+    version='1.2.1',
     description='Snovault Hybrid Object Relational Database Framework',
     long_description=README + '\n\n' + CHANGES,
     packages=find_packages('src'),


### PR DESCRIPTION
Small change to ItemWithAttachment to add `mimetype_map` class attribute. This is used when comparing equivalency between mimetypes in attachments.