### PR TITLE
1.2.2 -- Indexer fixes related to KeyError and MissingIndexItemException

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -75,7 +75,6 @@ output = ${buildout:directory}/production.ini
 accession_factory = snowflakes.server_defaults.test_accession
 file_upload_bucket = snowflakes-files-dev
 blob_bucket = snovault-blobs-dev
-indexer_processes =
 
 [production]
 recipe = collective.recipe.modwsgi

--- a/candidate.cfg
+++ b/candidate.cfg
@@ -1,8 +1,0 @@
-[buildout]
-extends = buildout.cfg
-
-[production-ini]
-accession_factory = snowflakes.server_defaults.enc_accession
-file_upload_bucket = snowflake-files
-blob_bucket = snovault-blobs
-indexer_processes = 16

--- a/development.ini
+++ b/development.ini
@@ -10,7 +10,6 @@ load_test_only = true
 create_tables = true
 testing = true
 postgresql.statement_timeout = 20
-indexer.processes =
 should_index = true
 elasticsearch.aws_auth = false
 

--- a/production.ini.in
+++ b/production.ini.in
@@ -6,7 +6,6 @@ file_upload_bucket = ${file_upload_bucket}
 blob_bucket = ${blob_bucket}
 blob_store_profile_name = encoded-files-upload
 accession_factory = ${accession_factory}
-indexer.processes = ${indexer_processes}
 elasticsearch.aws_auth = true
 
 [composite:indexer]

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.rst')).read()
 CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
 
-version_path = path.join(this_directory, "src/snovault/_version.py")
-this_version = io.open(version_path).readlines()[-1].split()[-1].strip("\"'")
+version_path = os.path.join(here, "src/snovault/_version.py")
+this_version = open(version_path).readlines()[-1].split()[-1].strip("\"'")
 
 
 requires = [

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,9 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.rst')).read()
 CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
 
+version_path = path.join(this_directory, "src/snovault/_version.py")
+this_version = io.open(version_path).readlines()[-1].split()[-1].strip("\"'")
+
 
 requires = [
     'Pillow',
@@ -64,7 +67,7 @@ tests_require = [
 
 setup(
     name='snovault',
-    version='1.2.1',
+    version=this_version,
     description='Snovault Hybrid Object Relational Database Framework',
     long_description=README + '\n\n' + CHANGES,
     packages=find_packages('src'),

--- a/src/snovault/_version.py
+++ b/src/snovault/_version.py
@@ -1,0 +1,4 @@
+"""Version information."""
+
+# The following line *must* be the last in the module, exactly as formatted:
+__version__ = "1.2.2"

--- a/src/snovault/elasticsearch/indexer_queue.py
+++ b/src/snovault/elasticsearch/indexer_queue.py
@@ -70,12 +70,15 @@ def queue_indexing(request):
     target = request.json.get('target_queue', 'primary')
     if req_uuids:
         # queue these as secondary
-        queued, failed = queue_indexer.add_uuids(request.registry, req_uuids, strict=strict,
-                                                 target_queue=target, telemetry_id=telemetry_id)
+        queued, failed = queue_indexer.add_uuids(request.registry, req_uuids,
+                                                 strict=strict, target_queue=target,
+                                                 telemetry_id=telemetry_id)
         response['requested_uuids'] = req_uuids
     else:
         # queue these as secondary
-        queued, failed = queue_indexer.add_collections(request.registry, req_collections, strict=strict,
+        queued, failed = queue_indexer.add_collections(request.registry,
+                                                       req_collections,
+                                                       strict=strict,
                                                        target_queue=target,
                                                        telemetry_id=telemetry_id)
         response['requested_collections'] = req_collections

--- a/src/snovault/elasticsearch/indexer_queue.py
+++ b/src/snovault/elasticsearch/indexer_queue.py
@@ -12,6 +12,7 @@ from pyramid.view import view_config
 from pyramid.decorator import reify
 from .interfaces import INDEXER_QUEUE, INDEXER_QUEUE_MIRROR
 from .indexer_utils import get_uuids_for_types
+from collections import OrderedDict
 
 log = structlog.getLogger(__name__)
 
@@ -178,10 +179,10 @@ class QueueManager(object):
             self.second_queue_url = self.get_queue_url(self.second_queue_name)
             self.dlq_url = self.get_queue_url(self.dlq_name)
         # short names for queues
-        self.queue_targets = {
+        self.queue_targets = OrderedDict({
             'primary': self.queue_url,
             'secondary': self.second_queue_url
-        }
+        })
 
     def add_uuids(self, registry, uuids, strict=False, target_queue='primary',
                   sid=None, telemetry_id=None):

--- a/src/snovault/indexing_views.py
+++ b/src/snovault/indexing_views.py
@@ -21,11 +21,6 @@ def includeme(config):
     config.scan(__name__)
 
 
-# really simple exception to know when the sid check fails
-class SidException(Exception):
-    pass
-
-
 def join_linked_uuids_sids(request, uuids):
     """
     Simply iterate through the uuids and return an array of dicts containing
@@ -86,18 +81,6 @@ def item_index_data(context, request):
     uuid = str(context.uuid)
     # upgrade_properties calls necessary upgraders based on schema_version
     properties = context.upgrade_properties()
-
-    # compare sid check to the max sid among all items
-    max_sid = context.max_sid
-    sid_check = request.params.get('sid', None)
-    if sid_check:
-        try:
-            sid_check = int(sid_check)
-        except ValueError:
-            raise ValueError('sid parameter must be an integer. Provided sid: %s' % sid)
-        if max_sid < sid_check:
-            raise SidException('sid from the query (%s) is greater than maximum sid (%s). Bailing.'
-                               % (sid_check, max_sid))
 
     # ES versions 2 and up don't allow dots in links. Update these to use ~s
     new_links = {}
@@ -168,7 +151,7 @@ def item_index_data(context, request):
         'linked_uuids_embedded': join_linked_uuids_sids(request, linked_uuids_embedded),
         'linked_uuids_object': join_linked_uuids_sids(request, linked_uuids_object),
         'links': links,
-        'max_sid': max_sid,
+        'max_sid': context.max_sid,
         'object': object_view,
         'paths': sorted(paths),
         'principals_allowed': principals_allowed,

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -58,7 +58,6 @@ def app_settings(wsgi_server_host_port, elasticsearch_server, postgresql_server,
     settings['collection_datastore'] = 'elasticsearch'
     settings['item_datastore'] = 'elasticsearch'
     settings['indexer'] = True
-    settings['indexer.processes'] = 2
 
     # use aws auth to access elasticsearch
     if aws_auth:

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -34,7 +34,7 @@ from snovault.elasticsearch.create_mapping import (
     confirm_mapping,
     compare_against_existing_mapping
 )
-from snovault.elasticsearch.indexing import (
+from snovault.elasticsearch.indexer import (
     check_sid,
     SidException
 )

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -34,6 +34,10 @@ from snovault.elasticsearch.create_mapping import (
     confirm_mapping,
     compare_against_existing_mapping
 )
+from snovault.elasticsearch.indexing import (
+    check_sid,
+    SidException
+)
 from pyramid.paster import get_appsettings
 
 pytestmark = [pytest.mark.indexing]
@@ -598,7 +602,6 @@ def test_queue_indexing_with_linked(app, testapp, indexer_testapp, dummy_request
 
 
 def test_indexing_invalid_sid(app, testapp, indexer_testapp):
-    from snovault.indexing_views import SidException
     indexer_queue = app.registry[INDEXER_QUEUE]
     es = app.registry[ELASTIC_SEARCH]
     # post an item, index, then find version (sid)
@@ -620,11 +623,10 @@ def test_indexing_invalid_sid(app, testapp, indexer_testapp):
     assert es_item['_version'] == initial_version + 1
     assert es_item['_source']['max_sid'] == initial_version + 1
 
-    # now try to manually bump an invalid version for the queued item
-    # check for SidException from indexing-views
-    index_query = '/%s/@@index-data?sid=%s' % (test_uuid, initial_version + 2)
+    # manually cause SidException
+    max_sid = app.registry[STORAGE].write.get_max_sid()
     with pytest.raises(SidException):
-        testapp.get(index_query)
+        check_sid(initial_version + 2, max_sid)
 
 
 def test_indexing_invalid_sid_linked_items(app, testapp, indexer_testapp):

--- a/src/snowflakes/tests/features/conftest.py
+++ b/src/snowflakes/tests/features/conftest.py
@@ -22,7 +22,6 @@ def app_settings(wsgi_server_host_port, elasticsearch_server, postgresql_server,
     settings['item_datastore'] = 'elasticsearch'
     settings['indexer'] = True
     settings['should_index'] = True
-    settings['indexer.processes'] = 2
 
     # use aws auth to access elasticsearch
     if aws_auth:

--- a/test.cfg
+++ b/test.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends = buildout.cfg
-
-[production-ini]
-indexer_processes = 16


### PR DESCRIPTION
This branch includes a couple bug fixes, refactoring, and (hopefully) performance improvements:
- sid checking moved to `Indexer.update_object`. This allows `SidException` to be caught before `MissingIndexItemException`
- `KeyError` will no longer trigger a retry for indexing. This is okay because sid checking should handle cases where items are missing
- index listener will check to see if there are any items in `primary_waiting` or `secondary_waiting` queues before calling `/index`
- sid now included in `find_and_queue_secondary_items` call when purging items. Uses current max sid
- Added `src/snovault/_version.py`, which is read by setup.py. Not necessary, but better form
- Trivial code refactoring and test revision