### PR TITLE
SQS Change + flaky

### DIFF
--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -1029,7 +1029,7 @@ def run(app, collections=None, dry_run=False, check_first=False, skip_indexing=F
     # clear the indexer queue on a total reindex
     if total_reindex or purge_queue:
         log.info('___PURGING THE QUEUE AND CLEARING INDEXING RECORDS BEFORE MAPPING___\n', cat=cat)
-        indexer_queue.clear_queue()
+        indexer_queue.purge_queue()
         # we also want to remove the 'indexing' index, which stores old records
         # it's not guaranteed to be there, though
         es_safe_execute(es.indices.delete, index='indexing', ignore=[400,404])

--- a/src/snovault/elasticsearch/indexer_queue.py
+++ b/src/snovault/elasticsearch/indexer_queue.py
@@ -345,14 +345,12 @@ class QueueManager(object):
     def clear_queue(self):
         """
         Manually clears the queue by repeatedly calling receieve_messages then
-        deleting those messages. A sleep is necessary in case there is a delay
-        in message propagation.
+        deleting those messages.
         """
         msgs = self.receive_messages()
         while msgs:
-            self.delete_messages(msgs)  # what to do with failures?
-            time.sleep(2)
-            msgs = self.receive_messages()  
+            self.delete_messages(msgs)
+            msgs = self.receive_messages()
 
     def delete_queue(self, queue_url):
         """

--- a/src/snovault/elasticsearch/indexer_queue.py
+++ b/src/snovault/elasticsearch/indexer_queue.py
@@ -328,8 +328,7 @@ class QueueManager(object):
             queue_urls[queue_name] = queue_url
         return queue_urls
 
-
-    def clear_queue(self):
+    def purge_queue(self):
         """
         Clear out the queue and dlq completely. You can no longer retrieve
         these messages. Takes up to 60 seconds.
@@ -342,6 +341,18 @@ class QueueManager(object):
             except self.client.exceptions.PurgeQueueInProgress:
                 log.warning('\n___QUEUE IS ALREADY BEING PURGED: %s___\n' % queue_url,
                             queue_url=queue_url)
+
+    def clear_queue(self):
+        """
+        Manually clears the queue by repeatedly calling receieve_messages then
+        deleting those messages. A sleep is necessary in case there is a delay
+        in message propagation.
+        """
+        msgs = self.receive_messages()
+        while msgs:
+            self.delete_messages(msgs)  # what to do with failures?
+            time.sleep(2)
+            msgs = self.receive_messages()  
 
     def delete_queue(self, queue_url):
         """


### PR DESCRIPTION
- Change 'clear_queue' to now recv + delete messages to manually clear rather than actually purging.
- Move old 'clear_queue' into new 'purge_queue' method
- Modify create_mapping to use new purge_queue method
- Modify tests that automatically purged to no longer do so, done manually now with clear_queue
- Mark indexing tests as flaky