### PR TITLE
Indexing timing

### DIFF
--- a/src/snovault/_version.py
+++ b/src/snovault/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "1.2.6"
+__version__ = "1.2.7"

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -474,6 +474,10 @@ def es_mapping(mapping, agg_items_mapping):
             'paths': {
                 'type': 'keyword',
                 'include_in_all': False
+            },
+            'indexing_stats': {
+                'type': 'object',
+                'include_in_all': False
             }
         }
     }

--- a/src/snovault/elasticsearch/indexer.py
+++ b/src/snovault/elasticsearch/indexer.py
@@ -369,8 +369,10 @@ class Indexer(object):
                 check_sid(sid, max_sid)  # max_sid should be set already
             result = request.embed(index_data_query, as_user='INDEXER')
             duration = timer() - start
+            # add total duration to indexing_stats in document
+            result['indexing_stats']['total_indexing_view'] = duration
             log.bind(collection=result.get('item_type'))
-            # log.info("Time to embed", duration=duration, cat="embed object")
+            # log.info("Time for index-data", duration=duration, cat="indexing view")
         except SidException as e:
             duration = timer() - start
             log.warning('Invalid max sid. Resending...', duration=duration, cat=cat)

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -1110,8 +1110,8 @@ def test_indexing_info(app, testapp, indexer_testapp):
     assert idx_info_err.json['status'] == 'error'
     src_idx_info = testapp.get('/indexing-info?uuid=%s' % source['uuid'])
     assert src_idx_info.json['status'] == 'success'
-    assert 'indexing_stats' in src_idx_info
-    assert 'embedded_view' in src_idx_info['indexing_stats']
+    assert 'indexing_stats' in src_idx_info.json
+    assert 'embedded_view' in src_idx_info.json['indexing_stats']
     # up to date
     assert src_idx_info.json['sid_es'] == src_idx_info.json['sid_db']
     assert set(src_idx_info.json['uuids_invalidated']) == set([target1['uuid'], source['uuid']])
@@ -1119,8 +1119,8 @@ def test_indexing_info(app, testapp, indexer_testapp):
     testapp.patch_json('/testing-link-sources-sno/' + source['uuid'], {'target': target2['uuid']})
     src_idx_info2 = testapp.get('/indexing-info?uuid=%s' % source['uuid'])
     assert src_idx_info2.json['status'] == 'success'
-    assert 'indexing_stats' in src_idx_info2
-    assert 'embedded_view' in src_idx_info2['indexing_stats']
+    assert 'indexing_stats' in src_idx_info2.json
+    assert 'embedded_view' in src_idx_info2.json['indexing_stats']
     # es is now out of date, since not indexed yet
     assert src_idx_info2.json['sid_es'] < src_idx_info2.json['sid_db']
     # target1 will still be in invalidated uuids, since es has not updated
@@ -1131,8 +1131,8 @@ def test_indexing_info(app, testapp, indexer_testapp):
     src_idx_info3 = testapp.get('/indexing-info?uuid=%s' % source['uuid'])
     assert src_idx_info3.json['status'] == 'success'
     assert src_idx_info3.json['sid_es'] == src_idx_info3.json['sid_db']
-    assert 'indexing_stats' in src_idx_info3
-    assert 'embedded_view' in src_idx_info3['indexing_stats']
+    assert 'indexing_stats' in src_idx_info3.json
+    assert 'embedded_view' in src_idx_info3.json['indexing_stats']
     # target1 has now been updated and removed from invalidated uuids
     assert set(src_idx_info3.json['uuids_invalidated']) == set([target2['uuid'], source['uuid']])
     # try the view without calculated embedded view


### PR DESCRIPTION
- Add `indexing_stats` to the document returned by `/index-data` view
- Change `/indexing-info` view to report `indexing_stats`
- Test update

All values in `indexing_stats` are in seconds.