### PR TITLE
Ngram Change

### DIFF
--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -278,13 +278,12 @@ def index_settings():
                         'reverse': True
                     },
                     'ngram_tokenizer': {
-                        'type': 'ngram',
+                        'type': 'edge_ngram',
                         'min_gram': 3,
-                        'max_gram': 8,
+                        'max_gram': MAX_NGRAM,
                         'token_chars': [
                             'letter',
-                            'digit',
-                            'whitespace'
+                            'digit'
                         ]
                     }
                 },

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -114,7 +114,7 @@ def schema_mapping(field, schema, top_level=False):
                 },
                 'lower_case_sort': {
                     'type': 'keyword',
-                    'normalizer': 'case_insensistive_sort',
+                    'normalizer': 'case_insensitive',
                     'ignore_above': KW_IGNORE_ABOVE
                 }
             }
@@ -134,7 +134,7 @@ def schema_mapping(field, schema, top_level=False):
                 },
                 'lower_case_sort': {
                     'type': 'keyword',
-                    'normalizer': 'case_insensistive_sort',
+                    'normalizer': 'case_insensitive',
                     'ignore_above': KW_IGNORE_ABOVE
                 }
             }
@@ -150,7 +150,7 @@ def schema_mapping(field, schema, top_level=False):
                 },
                 'lower_case_sort': {
                     'type': 'keyword',
-                    'normalizer': 'case_insensistive_sort',
+                    'normalizer': 'case_insensitive',
                     'ignore_above': KW_IGNORE_ABOVE
                 }
             }
@@ -170,7 +170,7 @@ def schema_mapping(field, schema, top_level=False):
                 },
                 'lower_case_sort': {
                     'type': 'keyword',
-                    'normalizer': 'case_insensistive_sort',
+                    'normalizer': 'case_insensitive',
                     'ignore_above': KW_IGNORE_ABOVE
                 }
             }
@@ -191,7 +191,7 @@ def schema_mapping(field, schema, top_level=False):
                 },
                 'lower_case_sort': {
                     'type': 'keyword',
-                    'normalizer': 'case_insensistive_sort',
+                    'normalizer': 'case_insensitive',
                     'ignore_above': KW_IGNORE_ABOVE
                 }
             }
@@ -207,7 +207,7 @@ def schema_mapping(field, schema, top_level=False):
                 },
                 'lower_case_sort': {
                     'type': 'keyword',
-                    'normalizer': 'case_insensistive_sort',
+                    'normalizer': 'case_insensitive',
                     'ignore_above': KW_IGNORE_ABOVE
                 }
             }
@@ -233,7 +233,7 @@ def index_settings():
                     'substring': {
                         'type': 'nGram',
                         'min_gram': 1,
-                        'max_gram': 33
+                        'max_gram': 12
                     }
                 },
                 'analyzer': {
@@ -279,7 +279,7 @@ def index_settings():
                     }
                 },
                 'normalizer': {
-                    'case_insensistive_sort': {
+                    'case_insensitive': {
                         'type': 'custom',
                         'filter': ['lowercase']
                     }

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -249,13 +249,12 @@ def index_settings():
                     },
                     'snovault_index_analyzer': {
                         'type': 'custom',
-                        'tokenizer': 'whitespace',
+                        'tokenizer': 'ngram_tokenizer',
                         'char_filter': 'html_strip',
                         'filter': [
                             'standard',
                             'lowercase',
                             'asciifolding',
-                            'substring'
                         ]
                     },
                     'snovault_search_analyzer': {
@@ -280,11 +279,12 @@ def index_settings():
                     },
                     'ngram_tokenizer': {
                         'type': 'ngram',
-                        'min_gram': 2,
-                        'max_gram': 12,
+                        'min_gram': 3,
+                        'max_gram': 8,
                         'token_chars': [
                             'letter',
-                            'digit'
+                            'digit',
+                            'whitespace'
                         ]
                     }
                 },

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -54,6 +54,7 @@ NUM_REPLICAS = 1
 SEARCH_MAX = 100000
 # ignore above this number of kb when using mapping keyword fields
 KW_IGNORE_ABOVE = 512
+MAX_NGRAM = 12
 
 
 def determine_if_is_date_field(field, schema):
@@ -233,7 +234,7 @@ def index_settings():
                     'substring': {
                         'type': 'nGram',
                         'min_gram': 1,
-                        'max_gram': 12
+                        'max_gram': MAX_NGRAM
                     }
                 },
                 'analyzer': {

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -277,6 +277,15 @@ def index_settings():
                     'snovault_path_tokenizer': {
                         'type': 'path_hierarchy',
                         'reverse': True
+                    },
+                    'ngram_tokenizer': {
+                        'type': 'ngram',
+                        'min_gram': 2,
+                        'max_gram': 12,
+                        'token_chars': [
+                            'letter',
+                            'digit'
+                        ]
                     }
                 },
                 'normalizer': {

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -54,7 +54,7 @@ NUM_REPLICAS = 1
 SEARCH_MAX = 100000
 # ignore above this number of kb when using mapping keyword fields
 KW_IGNORE_ABOVE = 512
-MAX_NGRAM = 12
+MAX_NGRAM = 8
 
 
 def determine_if_is_date_field(field, schema):
@@ -230,13 +230,6 @@ def index_settings():
                 }
             },
             'analysis': {
-                'filter': {
-                    'substring': {
-                        'type': 'nGram',
-                        'min_gram': 1,
-                        'max_gram': MAX_NGRAM
-                    }
-                },
                 'analyzer': {
                     'default': {
                         'type': 'custom',
@@ -247,7 +240,7 @@ def index_settings():
                             'lowercase',
                         ]
                     },
-                    'snovault_index_analyzer': {
+                    'snovault_index_analyzer': {  # use this for search as well
                         'type': 'custom',
                         'tokenizer': 'ngram_tokenizer',
                         'char_filter': 'html_strip',
@@ -255,15 +248,6 @@ def index_settings():
                             'standard',
                             'lowercase',
                             'asciifolding',
-                        ]
-                    },
-                    'snovault_search_analyzer': {
-                        'type': 'custom',
-                        'tokenizer': 'whitespace',
-                        'filter': [
-                            'standard',
-                            'lowercase',
-                            'asciifolding'
                         ]
                     },
                     'snovault_path_analyzer': {
@@ -342,8 +326,7 @@ def es_mapping(mapping, agg_items_mapping):
     return {
         '_all': {
             'enabled': True,
-            'analyzer': 'snovault_index_analyzer',
-            'search_analyzer': 'snovault_search_analyzer'
+            'analyzer': 'snovault_index_analyzer'
         },
         'dynamic_templates': [
             {


### PR DESCRIPTION
- Rename `case_insensitive_sort` normalizer to fix typo and make more clear
- Drop `max_ngram` from 33 to 10, seems to greatly increase indexing performance while not really sacrificing much in terms of q= discernibility 
- Make `MIN_NGRAM` and `MAX_NGRAM` constants
- Change index_settings to apply ngram tokenizer to search queries and indexing by default
- **TODO** Add documentation about create mapping