### PR TITLE
DLQ to Primary Route

### DIFF
--- a/src/snovault/elasticsearch/indexer_queue.py
+++ b/src/snovault/elasticsearch/indexer_queue.py
@@ -19,6 +19,7 @@ log = structlog.getLogger(__name__)
 def includeme(config):
     config.add_route('queue_indexing', '/queue_indexing')
     config.add_route('indexing_status', '/indexing_status')
+    config.add_route('dlq_to_primary', '/dlq_to_primary')
     env_name = config.registry.settings.get('env.name')
     config.registry[INDEXER_QUEUE] = QueueManager(config.registry)
     # INDEXER_QUEUE_MIRROR is used because webprod and webprod2 share a DB

--- a/src/snovault/elasticsearch/indexer_queue.py
+++ b/src/snovault/elasticsearch/indexer_queue.py
@@ -127,9 +127,8 @@ def dlq_to_primary(request):
         return response
     # send messages if we got any
     failed = queue_indexer.send_messages(dlq_messages)
-    response['failed'] = 0
+    response['number_failed'] = 0
     if len(failed) != 0:
-        response['failed'] = failed
         response['number_failed'] = len(failed)
     response['number_migrated'] = len(dlq_messages) - len(failed)
     return response

--- a/src/snovault/elasticsearch/indexer_queue.py
+++ b/src/snovault/elasticsearch/indexer_queue.py
@@ -122,12 +122,12 @@ def dlq_to_primary(request):
     queue_indexer = request.registry[INDEXER_QUEUE]
     dlq_messages = queue_indexer.receive_messages(target_queue='dlq')
     response = {}
+    response['number_failed'] = 0
     if len(dlq_messages) == 0:
         response['number_migrated'] = 0
         return response
     # send messages if we got any
     failed = queue_indexer.send_messages(dlq_messages)
-    response['number_failed'] = 0
     if len(failed) != 0:
         response['number_failed'] = len(failed)
     response['number_migrated'] = len(dlq_messages) - len(failed)

--- a/src/snovault/elasticsearch/indexer_queue.py
+++ b/src/snovault/elasticsearch/indexer_queue.py
@@ -127,11 +127,11 @@ def dlq_to_primary(request):
         return response
     # send messages if we got any
     failed = queue_indexer.send_messages(dlq_messages)
+    response['failed'] = 0
     if len(failed) != 0:
         response['failed'] = failed
         response['number_failed'] = len(failed)
     response['number_migrated'] = len(dlq_messages) - len(failed)
-    response['migrated'] = set(dlq_messages) - set(failed)
     return response
 
 

--- a/src/snovault/elasticsearch/indexer_queue.py
+++ b/src/snovault/elasticsearch/indexer_queue.py
@@ -203,7 +203,8 @@ class QueueManager(object):
         # short names for queues. Use OrderedDict to preserve order in Py < 3.6
         self.queue_targets = OrderedDict([
             ('primary', self.queue_url),
-            ('secondary', self.second_queue_url)
+            ('secondary', self.second_queue_url),
+            ('dlq', self.dlq_url)
         ])
 
     def add_uuids(self, registry, uuids, strict=False, target_queue='primary',

--- a/src/snovault/elasticsearch/indexer_queue.py
+++ b/src/snovault/elasticsearch/indexer_queue.py
@@ -123,7 +123,7 @@ def dlq_to_primary(request):
     dlq_messages = queue_indexer.receive_messages(target_queue='dlq')
     response = {}
     if len(dlq_messages) == 0:
-        response['number_Migrated'] = 0
+        response['number_migrated'] = 0
         return response
     # send messages if we got any
     failed = queue_indexer.send_messages(dlq_messages)

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -158,6 +158,7 @@ def test_indexer_queue_adds_telemetry_id(app):
 
 
 @pytest.mark.es
+@pytest.mark.flaky
 def test_indexer_queue(app):
     indexer_queue_mirror = app.registry[INDEXER_QUEUE_MIRROR]
     # this is only set up for webprod/webprod2
@@ -285,6 +286,7 @@ def test_queue_indexing_after_post_patch(app, testapp):
     indexer_queue.delete_messages(received)
 
 
+@pytest.mark.flaky
 def test_dlq_to_primary(app, anontestapp, indexer_testapp):
     """
     Tests the dlq_to_primary route

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -306,7 +306,7 @@ def test_dlq_to_primary(app, anontestapp, indexer_testapp):
     msgs = indexer_queue.receive_messages()  # receive from primary
     assert len(msgs) == 2
     for msg in msgs:
-        body = json.loads(msg)["Body"]["uuid"]
+        body = msg['Body']['Body']['uuid']
         assert body in test_bodies
 
     # hit route with no messages, should see 0 migrated

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -306,7 +306,7 @@ def test_dlq_to_primary(app, anontestapp, indexer_testapp):
     msgs = indexer_queue.receive_messages()  # receive from primary
     assert len(msgs) == 2
     for msg in msgs:
-        body = msg["Body"]
+        body = json.loads(msg)["Body"]["uuid"]
         assert body in test_bodies
 
     # hit route with no messages, should see 0 migrated

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -206,7 +206,7 @@ def test_indexer_queue(app):
 def test_queue_indexing_telemetry_id(app, testapp):
     indexer_queue = app.registry[INDEXER_QUEUE]
     ordered_queue_targets = [targ for targ in indexer_queue.queue_targets]
-    assert ordered_queue_targets == ['primary', 'secondary']
+    assert ordered_queue_targets == ['primary', 'secondary', 'dlq']
     indexer_queue.clear_queue()
     testapp.post_json(TEST_COLL + '?telemetry_id=test_telem', {'required': ''})
     time.sleep(2)

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -285,7 +285,7 @@ def test_queue_indexing_after_post_patch(app, testapp):
     indexer_queue.delete_messages(received)
 
 
-def test_dlq_to_primary(app, testapp, indexer_testapp):
+def test_dlq_to_primary(app, anontestapp, indexer_testapp):
     """
     Tests the dlq_to_primary route
     Post some messages to the DLQ, hit the route, receive
@@ -312,6 +312,9 @@ def test_dlq_to_primary(app, testapp, indexer_testapp):
     res = indexer_testapp.get('/dlq_to_primary').json
     assert res['number_migrated'] == 0
     assert res['number_failed'] == 0
+
+    # hit route from unauthenticated testapp, should fail
+    anontestapp.get('/dlq_to_primary', status=403)
 
 
 @pytest.mark.flaky

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -308,6 +308,10 @@ def test_dlq_to_primary(app, indexer_testapp):
         body = msg["Body"]
         assert 'destined' in body
 
+    # hit route with no messages, should see 0 migrated
+    res = indexer_testapp.get('/dlq_to_primary').json
+    assert res['number_migrated'] == 0
+
 
 @pytest.mark.flaky
 def test_indexing_simple(app, testapp, indexer_testapp):

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -306,7 +306,8 @@ def test_dlq_to_primary(app, anontestapp, indexer_testapp):
     msgs = indexer_queue.receive_messages()  # receive from primary
     assert len(msgs) == 2
     for msg in msgs:
-        body = msg['Body']['Body']['uuid']
+        # sqs msg reading is super busted so the below is necessary
+        body = json.loads(json.loads(msg['Body'])['Body'])['uuid']
         assert body in test_bodies
 
     # hit route with no messages, should see 0 migrated

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -295,9 +295,8 @@ def test_dlq_to_primary(app, anontestapp, indexer_testapp):
     """
     indexer_queue = app.registry[INDEXER_QUEUE]
     indexer_queue.clear_queue()
-    test_message1 = "destined for primary!"
-    test_message2 = "i am also destined!"
-    success, failed = indexer_queue.add_uuids(app.registry, [test_message1, test_message2],
+    test_bodies = ["destined for primary!", "i am also destined!"]
+    success, failed = indexer_queue.add_uuids(app.registry, test_bodies,
                                         target_queue='dlq')
     assert not failed
     assert len(success) == 2
@@ -308,7 +307,7 @@ def test_dlq_to_primary(app, anontestapp, indexer_testapp):
     assert len(msgs) == 2
     for msg in msgs:
         body = msg["Body"]
-        assert 'destined' in body
+        assert body in test_bodies
 
     # hit route with no messages, should see 0 migrated
     res = indexer_testapp.get('/dlq_to_primary').json

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -285,7 +285,7 @@ def test_queue_indexing_after_post_patch(app, testapp):
     indexer_queue.delete_messages(received)
 
 
-def test_dlq_to_primary(app, indexer_testapp):
+def test_dlq_to_primary(app, testapp, indexer_testapp):
     """
     Tests the dlq_to_primary route
     Post some messages to the DLQ, hit the route, receive
@@ -301,7 +301,7 @@ def test_dlq_to_primary(app, indexer_testapp):
     assert len(success) == 2
     res = indexer_testapp.get('/dlq_to_primary').json
     assert res['number_migrated'] == 2
-    assert res['failed'] == 0
+    assert res['number_failed'] == 0
     msgs = indexer_queue.receive_messages()  # receive from primary
     assert len(msgs) == 2
     for msg in msgs:
@@ -311,6 +311,7 @@ def test_dlq_to_primary(app, indexer_testapp):
     # hit route with no messages, should see 0 migrated
     res = indexer_testapp.get('/dlq_to_primary').json
     assert res['number_migrated'] == 0
+    assert res['number_failed'] == 0
 
 
 @pytest.mark.flaky

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -229,6 +229,8 @@ def test_queue_indexing_telemetry_id(app, testapp):
     assert tries_left > 0
     # delete the messages
     for target in indexer_queue.queue_targets:
+        if 'dlq' in target:  # skip if dlq
+            continue
         received = indexer_queue.receive_messages(target_queue=target)
         assert len(received) > 0
         for msg in received:


### PR DESCRIPTION
- Adds a route to allow the indexer to trigger moving all messages on the DLQ to the Primary Queue
- Adds a test for this route with some other small compatibility fixes