### PR TITLE
Docs Build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,7 @@
+version: 2
+
+python:
+  version: 3.6
+
+sphinx:
+  configuration: docs/source/conf.py

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -73,3 +73,22 @@ Specific tests to run locally for schema changes::
 Run the Pyramid tests with::
 
     $ bin/test
+
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+   
+   index
+   overview
+   attachment
+   auth
+   custom-travis
+   database
+   embedding-and-indexing
+   es-mapping
+   invalidation
+   object-lifecycle
+   search_info
+   snowflakes
+   testing


### PR DESCRIPTION
- Fixes docs build by explicitly setting configuration location in `.readthedocs.yml`