### PR TITLE
Muffle git stderr (C4-26) and better error reporting of intermittent KeyError problems

### DIFF
--- a/src/snovault/elasticsearch/indexer.py
+++ b/src/snovault/elasticsearch/indexer.py
@@ -14,7 +14,7 @@ from elasticsearch.exceptions import (
 from pyramid.view import view_config
 from urllib3.exceptions import ReadTimeoutError
 
-from snovault import (
+from .. import (
     DBSESSION,
     STORAGE
 )
@@ -25,7 +25,7 @@ from .interfaces import (
     INDEXER_QUEUE
 )
 from ..embed import MissingIndexItemException
-from ..util import debug_log
+from ..util import debug_log, dictionary_lookup
 
 log = structlog.getLogger(__name__)
 
@@ -253,7 +253,10 @@ class Indexer(object):
                         to_delete = []
                     continue
 
-                msg_uuid= msg_body['uuid']
+                # This rather than msg_body['uuid'] to get better error reporting
+                # in case uuid is missing from dictionary, which probably happens
+                # because the msg_body is some other kind of object entirely. -kmp 9-Feb-2020
+                msg_uuid = dictionary_lookup(msg_body, 'uuid')
                 msg_sid = msg_body['sid']
                 msg_curr_time = msg_body['timestamp']
                 msg_detail = msg_body.get('detail')

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -1319,6 +1319,7 @@ def test_validators_on_indexing(app, testapp, indexer_testapp):
     assert val_err_view['validation_errors'] == es_res['_source']['validation_errors']
 
 
+@pytest.mark.flaky(max_runs=2, rerun_filter=delay_rerun)
 def test_elasticsearch_item_basic(app, testapp, indexer_testapp, es_based_target):
     es = app.registry[ELASTIC_SEARCH]
     namespaced_target = indexer_utils.get_namespaced_index(app, 'testing_link_target_elastic_search')

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -1458,6 +1458,7 @@ def test_elasticsearch_item_with_source(app, testapp, indexer_testapp, es_based_
     testapp.get(es_based_target['@id'] + '?datastore=database', status=404)
 
 
+@pytest.mark.flaky(max_runs=2, rerun_filter=delay_rerun)
 def test_elasticsearch_item_embedded_agg(app, testapp, indexer_testapp, es_based_target):
     """
     Test embedding items in TestingLinkTargetElasticSearch and using

--- a/src/snovault/tests/test_indexing.py
+++ b/src/snovault/tests/test_indexing.py
@@ -1359,6 +1359,7 @@ def test_elasticsearch_item_basic(app, testapp, indexer_testapp, es_based_target
     assert initial_count == after_count
 
 
+@pytest.mark.flaky(max_runs=2, rerun_filter=delay_rerun)
 def test_elasticsearch_item_with_source(app, testapp, indexer_testapp, es_based_target):
     """
     Test rev_linking with a TestingLinkTargetElasticSearch item, including

--- a/src/snovault/tests/test_util.py
+++ b/src/snovault/tests/test_util.py
@@ -1,0 +1,27 @@
+import pytest
+from ..util import dictionary_lookup
+
+def test_dictionary_lookup():
+
+    d1 = {'a': 3, 'b': 4}
+    assert dictionary_lookup(d1, 'a') == 3
+    assert dictionary_lookup(d1, 'b') == 4
+
+    d2 = {'x': 10}
+    try:
+        dictionary_lookup(d2, 'y')
+    except ValueError as e:
+        assert isinstance(e, ValueError)
+        assert str(e) == '''{'x': 10} has no 'y' key.'''
+
+    try:
+        dictionary_lookup(17, 'z')
+    except ValueError as e:
+        assert isinstance(e, ValueError)
+        assert str(e) == '''17 is not a dictionary.'''
+
+    try:
+        dictionary_lookup(repr(d2), 'x')
+    except ValueError as e:
+        assert isinstance(e, ValueError)
+        assert str(e) == '''"{'x': 10}" is not a dictionary.'''

--- a/src/snovault/tests/test_util.py
+++ b/src/snovault/tests/test_util.py
@@ -1,5 +1,5 @@
 import pytest
-from ..util import dictionary_lookup
+from ..util import dictionary_lookup, DictionaryKeyError
 
 def test_dictionary_lookup():
 
@@ -14,7 +14,7 @@ def test_dictionary_lookup():
     try:
         dictionary_lookup(d2, 'y')
     except Exception as e:
-        assert isinstance(e, KeyError)
+        assert isinstance(e, DictionaryKeyError)
         assert str(e) == '''{'x': 10} has no 'y' key.'''
     else:
         raise AssertionError("No exception was raised where one was expected.")
@@ -22,7 +22,7 @@ def test_dictionary_lookup():
     try:
         dictionary_lookup(17, 'z')
     except Exception as e:
-        assert isinstance(e, ValueError)
+        assert isinstance(e, DictionaryKeyError)
         assert str(e) == '''17 is not a dictionary.'''
     else:
         raise AssertionError("No exception was raised where one was expected.")
@@ -31,7 +31,7 @@ def test_dictionary_lookup():
         # String form of JSON isn't what's needed. It has to be parsed (i.e., a dict).
         dictionary_lookup(repr(d2), 'x')
     except Exception as e:
-        assert isinstance(e, ValueError)
+        assert isinstance(e, DictionaryKeyError)
         assert str(e) == '''"{'x': 10}" is not a dictionary.'''
     else:
         raise AssertionError("No exception was raised where one was expected.")

--- a/src/snovault/tests/test_util.py
+++ b/src/snovault/tests/test_util.py
@@ -7,21 +7,31 @@ def test_dictionary_lookup():
     assert dictionary_lookup(d1, 'a') == 3
     assert dictionary_lookup(d1, 'b') == 4
 
+    # TODO: These next few would be easier to do in unittest.TestCase where we could use self.assertRaisesRegexpe.
+    #       Maybe a later version of pytest has the equivalent feature. -kmp 9-Feb-2020
+
     d2 = {'x': 10}
     try:
         dictionary_lookup(d2, 'y')
-    except ValueError as e:
-        assert isinstance(e, ValueError)
+    except Exception as e:
+        assert isinstance(e, KeyError)
         assert str(e) == '''{'x': 10} has no 'y' key.'''
+    else:
+        raise AssertionError("No exception was raised where one was expected.")
 
     try:
         dictionary_lookup(17, 'z')
-    except ValueError as e:
+    except Exception as e:
         assert isinstance(e, ValueError)
         assert str(e) == '''17 is not a dictionary.'''
+    else:
+        raise AssertionError("No exception was raised where one was expected.")
 
     try:
+        # String form of JSON isn't what's needed. It has to be parsed (i.e., a dict).
         dictionary_lookup(repr(d2), 'x')
-    except ValueError as e:
+    except Exception as e:
         assert isinstance(e, ValueError)
         assert str(e) == '''"{'x': 10}" is not a dictionary.'''
+    else:
+        raise AssertionError("No exception was raised where one was expected.")

--- a/src/snovault/util.py
+++ b/src/snovault/util.py
@@ -18,6 +18,21 @@ log = structlog.getLogger(__name__)
 ###################
 
 
+def dictionary_lookup(dictionary, key):
+    """
+    dictionary_lookup(d, k) is the same as d[k] but with more informative error reporting.
+    Note, however, that on any error (and in particular on missing key), this raises ValueError (not KeyError).
+    """
+    if not isinstance(dictionary, dict):
+        raise ValueError("%r is not a dictionary." % dictionary)
+    elif key not in dictionary:
+        # We might wish we could use KeyError, but its argument coventions and descriptive string are
+        # so broken as to really be beyond repair. Better to just identify this as bad data. -kmp 9-Feb-2020
+        raise ValueError("%r has no %r key." % (dictionary, key))
+    else:
+        return dictionary[key]
+
+
 def debug_log(func):
     """ Decorator that adds some debug output of the view to log that we got there """
     @functools.wraps(func)

--- a/src/snovault/util.py
+++ b/src/snovault/util.py
@@ -26,16 +26,17 @@ class DictionaryKeyError(KeyError):
         self._dictionary_key = key
 
     def __str__(self):
-        return "%r has no %r key." % (self._dictionary, self._dictionary_key)
+        if isinstance(self._dictionary, dict):
+            return "%r has no %r key." % (self._dictionary, self._dictionary_key)
+        else:
+            return "%r is not a dictionary." % self._dictionary
 
 
 def dictionary_lookup(dictionary, key):
     """
     dictionary_lookup(d, k) is the same as d[k] but with more informative error reporting.
     """
-    if not isinstance(dictionary, dict):
-        raise ValueError("%r is not a dictionary." % dictionary)
-    elif key not in dictionary:
+    if not isinstance(dictionary, dict) or (key not in dictionary):
         raise DictionaryKeyError(dictionary=dictionary, key=key)
     else:
         return dictionary[key]

--- a/src/snovault/util.py
+++ b/src/snovault/util.py
@@ -18,17 +18,25 @@ log = structlog.getLogger(__name__)
 ###################
 
 
+class DictionaryKeyError(KeyError):
+
+    def __init__(self, dictionary, key):
+        super(DictionaryKeyError, self).__init__(key)
+        self._dictionary = dictionary
+        self._dictionary_key = key
+
+    def __str__(self):
+        return "%r has no %r key." % (self._dictionary, self._dictionary_key)
+
+
 def dictionary_lookup(dictionary, key):
     """
     dictionary_lookup(d, k) is the same as d[k] but with more informative error reporting.
-    Note, however, that on any error (and in particular on missing key), this raises ValueError (not KeyError).
     """
     if not isinstance(dictionary, dict):
         raise ValueError("%r is not a dictionary." % dictionary)
     elif key not in dictionary:
-        # We might wish we could use KeyError, but its argument coventions and descriptive string are
-        # so broken as to really be beyond repair. Better to just identify this as bad data. -kmp 9-Feb-2020
-        raise ValueError("%r has no %r key." % (dictionary, key))
+        raise DictionaryKeyError(dictionary=dictionary, key=key)
     else:
         return dictionary[key]
 


### PR DESCRIPTION
This contains two small changes:

- A fix to [C4-26](https://hms-dbmi.atlassian.net/browse/C4-26) (Stray stderr typeout from subprocess git call).
- Sets up to acquire debugging information about a `uuid` missing in some message queue processing in the function `update_objects_queue`. Regarding this second issue, even while just debugging this change, we got enough data to file [C4-27](https://hms-dbmi.atlassian.net/browse/C4-27) (Extra message queue envelope seen in some testing), but we don't yet have a fix for that.
