### PR TITLE
C4-23 Fix Mirror Health

### DIFF
--- a/src/snovault/elasticsearch/esstorage.py
+++ b/src/snovault/elasticsearch/esstorage.py
@@ -93,6 +93,8 @@ class ElasticSearchStorage(object):
         if self.registry.settings.get('mirror.env.name'):  # mirror info does not change. Cache it
             mirror_env = self.registry.settings['mirror.env.name']
             self.mirror_health = ff_utils.get_health_page(ff_env=mirror_env)
+        else:
+            self.mirror_health = None
 
     def _one(self, search):
         # execute search and return a model if there is one hit

--- a/src/snovault/elasticsearch/esstorage.py
+++ b/src/snovault/elasticsearch/esstorage.py
@@ -90,12 +90,11 @@ class ElasticSearchStorage(object):
         self.registry = registry
         self.es = registry[ELASTIC_SEARCH]
         self.index = get_namespaced_index(registry, '*')
-        if self.registry.settings.get('mirror.env.name'):  # mirror info does not change. Cache it
-            self.mirror_env = self.registry.settings['mirror.env.name']
+        self.mirror_env = self.registry.settings.get('mirror.env.name', None)
+        self.mirror_health = None
+        if self.mirror_env:  # mirror info does not change. Cache it
             self.mirror_health = ff_utils.get_health_page(ff_env=self.mirror_env)
-        else:
-            self.mirror_env = None
-            self.mirror_health = None
+
 
     def _one(self, search):
         # execute search and return a model if there is one hit

--- a/src/snovault/util.py
+++ b/src/snovault/util.py
@@ -41,15 +41,20 @@ class TimedCache(object):
     def __init__(self, ttl):
         """ Initializes the cache setting the TTL and underlying structure
 
-            :args ttl: time-to-live of all values in the cache
+            :args ttl: time-to-live of all values in the cache (in minutes)
         """
-        self.ttl = ttl
+        self.ttl = datetime.timedelta(minutes=ttl)
         self.cache = {}
 
     def insert(self, key, func):
         self.cache[key] = TimedCacheTuple(func)
     
     def get(self, key):
+        vals = self.cache.get(key)
+        if vals:  # if we have a value, check ttl, recompute if need be
+            if (vals.time + self.ttl) > datetime.datetime.now():
+                self.insert(key, vals.func)
+        
         return self.cache.get(key)
     
     def __getitem__(self, key):

--- a/src/snovault/util.py
+++ b/src/snovault/util.py
@@ -55,6 +55,10 @@ class TimedCache(object):
     def __getitem__(self, key):
         return self.cache.get(key).val  # return only the value
 
+    def update(self):
+        for k, v in self.cache.items():
+            self.insert(k, v.func)  
+
 
 def debug_log(func):
     """ Decorator that adds some debug output of the view to log that we got there """

--- a/src/snovault/util.py
+++ b/src/snovault/util.py
@@ -19,52 +19,6 @@ log = structlog.getLogger(__name__)
 ###################
 
 
-class TimedCacheTuple(object):
-    """ A 3 tuple containing an arbitrary value, a time and a function 
-        pointer used to compute that value
-    """
-
-    def __init__(self, func):
-        self.time = datetime.datetime.now()  # relative should be ok here
-        self.func = func
-        self.val = func()
-
-
-class TimedCache(object):
-    """ 
-    A cache that stores key, value pairs where the key is an
-    arbitrary ID and the value is a the above class consisting of the value, 
-    insertion time and function pointer to recompute the value. 
-    TimedCache has a global TTL applied to all items in the cache.
-    """
-
-    def __init__(self, ttl):
-        """ Initializes the cache setting the TTL and underlying structure
-
-            :args ttl: time-to-live of all values in the cache (in minutes)
-        """
-        self.ttl = datetime.timedelta(minutes=ttl)
-        self.cache = {}
-
-    def insert(self, key, func):
-        self.cache[key] = TimedCacheTuple(func)
-    
-    def get(self, key):
-        vals = self.cache.get(key)
-        if vals:  # if we have a value, check ttl, recompute if need be
-            if (vals.time + self.ttl) > datetime.datetime.now():
-                self.insert(key, vals.func)
-        
-        return self.cache.get(key)
-    
-    def __getitem__(self, key):
-        return self.cache.get(key).val  # return only the value
-
-    def update(self):
-        for k, v in self.cache.items():
-            self.insert(k, v.func)  
-
-
 def debug_log(func):
     """ Decorator that adds some debug output of the view to log that we got there """
     @functools.wraps(func)

--- a/src/snovault/util.py
+++ b/src/snovault/util.py
@@ -1,7 +1,6 @@
 import functools
 import json
 import sys
-import datetime
 from copy import deepcopy
 
 import structlog


### PR DESCRIPTION
- Previously when purging items from ElasticSearch we would grab our 'ES Mirror' on the fly which ended up doing a very expensive AWS API request
- Instead, do this once upon ESStorage initialization since the value we care about will never change regardless of blue/green deployment schedule