### PR TITLE
C4-49 Performance fixes

### DIFF
--- a/snovault/elasticsearch/esstorage.py
+++ b/snovault/elasticsearch/esstorage.py
@@ -90,11 +90,8 @@ class ElasticSearchStorage(object):
         self.registry = registry
         self.es = registry[ELASTIC_SEARCH]
         self.index = get_namespaced_index(registry, '*')
-        self.mirror_env = self.registry.settings.get('mirror.env.name', None)
-        self.mirror_health = None
-        if self.mirror_env:  # mirror info does not change. Cache it
-            self.mirror_health = ff_utils.get_health_page(ff_env=self.mirror_env)
-
+        self.mirror = self.registry.settings.get('mirror_health', None) is not None
+        self.mirror_client = None
 
     def _one(self, search):
         # execute search and return a model if there is one hit
@@ -255,26 +252,29 @@ class ElasticSearchStorage(object):
         self.registry[INDEXER].find_and_queue_secondary_items(set([rid]), set(), sid=max_sid)
 
         # if configured, delete the item from the mirrored ES as well
-        if self.mirror_health:
+        if self.mirror:
             mirror_env = self.registry.settings['mirror.env.name']
+            mirror_health = self.registry.settings['mirror_health']
             use_aws_auth = self.registry.settings.get('elasticsearch.aws_auth')
             log.info('PURGE: attempting to purge %s from mirror storage %s' % (rid, mirror_env))
             # if we could not get mirror health, bail here
-            if 'error' in self.mirror_health:
+            if 'error' in mirror_health:
                 log.error('PURGE: Tried to purge %s from mirror storage but couldn\'t get health page. Is staging up?' % rid)
-                log.error('PURGE: Mirror health error: %s' % self.mirror_health)
+                log.error('PURGE: Mirror health error: %s' % mirror_health)
                 log.error('PURGE: Recomputing mirror health...')
-                self.mirror_health = ff_utils.get_health_page(ff_env=self.mirror_env)
+                self.registry.settings['mirror_health'] = ff_utils.get_health_page(ff_env=mirror_env)
                 return
             # make sure use_aws_auth is bool
             if not isinstance(use_aws_auth, bool):
                 use_aws_auth = True if use_aws_auth == 'true' else False
-            mirror_client = es_utils.create_es_client(self.mirror_health['elasticsearch'],
+
+            if not self.mirror_client:  # cached on this object
+                self.mirror_client = es_utils.create_es_client(mirror_health['elasticsearch'],
                                                       use_aws_auth=use_aws_auth)
             try:
                 # assume index is <namespace> + item_type
-                mirror_index = self.mirror_health.get('namespace', '') + item_type
-                mirror_client.delete(id=rid, index=mirror_index, doc_type=item_type)
+                mirror_index = mirror_health.get('namespace', '') + item_type
+                self.mirror_client.delete(id=rid, index=mirror_index, doc_type=item_type)
             except elasticsearch.exceptions.NotFoundError:
                 # Case: Not yet indexed
                 log.error('PURGE: Cannot find %s in mirrored Elasticsearch (%s). Continuing.' % (rid, mirror_env))

--- a/snovault/storage.py
+++ b/snovault/storage.py
@@ -149,7 +149,7 @@ class PickStorage(object):
         """
         # usually check the datastore attribute on request (set on GET/HEAD)
         request = get_current_request()
-        if self.read and request and request.datastore == 'elasticsearch':
+        if self.read is not None and request and request.datastore == 'elasticsearch':
             return self.read
 
         # check the datastore specified by Connection (not always used)
@@ -219,7 +219,7 @@ class PickStorage(object):
         """
         log.warning('PURGE: purging %s' % rid)
         # requires ES for searching item links
-        if self.read:
+        if self.read is not None:
             # model and max_sid are used later, in second `if self.read` block
             model = self.get_by_uuid(rid)
             if not item_type:
@@ -292,7 +292,7 @@ class PickStorage(object):
         Get the ES document by uuid directly for Elasticsearch
         Only functional with self.read
         """
-        if self.read:
+        if self.read is not None:
             # must pass registry for access to settings
             return self.read.get_by_uuid_direct(uuid, item_type)
 
@@ -304,7 +304,7 @@ class PickStorage(object):
         See esstorage.ElasticSearchStorage.find_uuids_linked_to_item
         Only functional with self.read
         """
-        if self.read:
+        if self.read is not None:
             return self.read.find_uuids_linked_to_item(uuid)
 
         return self.write.find_uuids_linked_to_item(uuid)


### PR DESCRIPTION
- Do not do `if self.read` anywhere. It implicitly calls `__len__` which makes an expensive ES API call.
- Do not recompute `get_mirror_health` ever unless needed. Cache this info in the registry instead.
- Do not recreate ES mirror client on every `purge` request. Cache this handler on ESStorage.