### PR TITLE
Fix copyright notice clarify historical notices

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 The MIT License
 
-Copyright (c) 2013 Stanford University
+Copyright (c) 2016-2020 Harvard Medical School
+Portons Copyright (c) 2013 Stanford University
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,20 @@ DCIC Snovault
 .. |Build status| image:: https://travis-ci.org/4dn-dcic/snovault.svg?branch=master
 .. _Build status: https://travis-ci.org/4dn-dcic/snovault
 
+.. Important::
+
+ DCIC Snovault is a FORK of `snovault <https://pypi.org/project/snovault/>`_
+ created at the `ENCODE DCC project at Stanford <https://github.com/ENCODE-DCC>`_.
+ Our fork supports other projects of the
+ `4D Nucleome Data Coordination and Integration Center (4DN-DCIC)
+ <https://github.com/4dn-dcic>`_.
+ Although this software is available as open source software,
+ its primary function is to support our layered projects,
+ and we are not at this time able to offer any active support for other uses.
+ In particular, this fork does not purport to supersede
+ the original `snovault <https://pypi.org/project/snovault/>`_.
+ we just have a different use case that we are actively exploring.
+
 Overview
 ========
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "2.0.2"
+version = "2.0.3"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
This does two things:

 * Updates the copyright notice to clarify that there is substantive new work done at HMS since the time we forked this repo.
 * Updates the README to clarify that this is a fork.
