### PR TITLE
C4-89 Always use S3BlobStorage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "2.0.3"
+version = "2.0.4"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/storage.py
+++ b/snovault/storage.py
@@ -98,7 +98,10 @@ def register_storage(registry, write_override=None, read_override=None):
     _DBSESSION = registry[DBSESSION]
 
     # set up blob storage if not configured already
-    registry[BLOBS] = S3BlobStorage(registry.settings['blob_bucket'])
+    try:
+        registry[BLOBS] = S3BlobStorage(registry.settings['blob_bucket'])
+    except KeyError:  # only use this if blob_bucket is not set
+        registry[BLOBS] = RDBBlobStorage(registry[DBSESSION])
 
 
 Base = declarative_base()

--- a/snovault/storage.py
+++ b/snovault/storage.py
@@ -1,4 +1,3 @@
-
 from pyramid.httpexceptions import (
     HTTPConflict,
     HTTPLocked,
@@ -99,10 +98,7 @@ def register_storage(registry, write_override=None, read_override=None):
     _DBSESSION = registry[DBSESSION]
 
     # set up blob storage if not configured already
-    if not registry.get(BLOBS) and registry.settings.get('blob_bucket'):
-        registry[BLOBS] = S3BlobStorage(registry.settings['blob_bucket'])
-    else:
-        registry[BLOBS] = RDBBlobStorage(registry[DBSESSION])
+    registry[BLOBS] = S3BlobStorage(registry.settings['blob_bucket'])
 
 
 Base = declarative_base()

--- a/snovault/storage.py
+++ b/snovault/storage.py
@@ -98,10 +98,10 @@ def register_storage(registry, write_override=None, read_override=None):
     _DBSESSION = registry[DBSESSION]
 
     # set up blob storage if not configured already
-    try:
-        registry[BLOBS] = S3BlobStorage(registry.settings['blob_bucket'])
-    except KeyError:  # only use this if blob_bucket is not set
-        registry[BLOBS] = RDBBlobStorage(registry[DBSESSION])
+    blob_bucket = registry.settings.get('blob_bucket', None)
+    registry[BLOBS] = (S3BlobStorage(blob_bucket)
+                   if blob_bucket
+                   else RDBBlobStorage(registry[DBSESSION]))
 
 
 Base = declarative_base()


### PR DESCRIPTION
- At some point `registry.settings[BLOBS]` became set and we stopped using S3BlobStorage. We never use Postgres for blobs so remove code that does this from `register_storage`