### PR TITLE
Use new dcicutils 0.12.0 (or higher)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -28,10 +28,10 @@ description = "Universal Command Line Environment for AWS."
 name = "awscli"
 optional = false
 python-versions = "*"
-version = "1.18.30"
+version = "1.18.31"
 
 [package.dependencies]
-botocore = "1.15.30"
+botocore = "1.15.31"
 docutils = ">=0.10,<0.16"
 rsa = ">=3.1.2,<=3.5.0"
 s3transfer = ">=0.3.0,<0.4.0"
@@ -97,10 +97,10 @@ description = "The AWS SDK for Python"
 name = "boto3"
 optional = false
 python-versions = "*"
-version = "1.12.30"
+version = "1.12.31"
 
 [package.dependencies]
-botocore = ">=1.15.30,<1.16.0"
+botocore = ">=1.15.31,<1.16.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.3.0,<0.4.0"
 
@@ -110,20 +110,13 @@ description = "Low-level, data-driven core of boto 3."
 name = "botocore"
 optional = false
 python-versions = "*"
-version = "1.15.30"
+version = "1.15.31"
 
 [package.dependencies]
 docutils = ">=0.10,<0.16"
 jmespath = ">=0.7.1,<1.0.0"
 python-dateutil = ">=2.1,<3.0.0"
-
-[[package.dependencies.urllib3]]
-python = ">=3.4,<3.5"
-version = ">=1.20,<1.25.8"
-
-[[package.dependencies.urllib3]]
-python = "<3.4.0 || >=3.5.0"
-version = ">=1.20,<1.26"
+urllib3 = ">=1.20,<1.26"
 
 [[package]]
 category = "main"
@@ -203,7 +196,7 @@ description = "Utility package for interacting with the 4DN Data Portal and othe
 name = "dcicutils"
 optional = false
 python-versions = ">=3.4,<3.7"
-version = "0.11.0"
+version = "0.12.0b1"
 
 [package.dependencies]
 aws-requests-auth = ">=0.4.2,<1"
@@ -1493,7 +1486,7 @@ transaction = ">=1.6.0"
 test = ["zope.testing"]
 
 [metadata]
-content-hash = "b9d1aa95f2213dc3a995793655b2e40e9f3e986c056636d7977e924ffcdfd074"
+content-hash = "12996937c0e149e35351f29389944724e2ce35a1d43beadf62d2464e1c09f24d"
 python-versions = ">=3.4,<3.7"
 
 [metadata.files]
@@ -1505,8 +1498,8 @@ aws-xray-sdk = [
     {file = "aws_xray_sdk-0.95-py2.py3-none-any.whl", hash = "sha256:72791618feb22eaff2e628462b0d58f398ce8c1bacfa989b7679817ab1fad60c"},
 ]
 awscli = [
-    {file = "awscli-1.18.30-py2.py3-none-any.whl", hash = "sha256:f85d538d2dcc130734dd4b2582b7e7dd945e7ce9e6373e67b12498ccc0c73f0a"},
-    {file = "awscli-1.18.30.tar.gz", hash = "sha256:14623fce97ca16b76484709827e547b210987368c91d8f722d163fb3e09cc139"},
+    {file = "awscli-1.18.31-py2.py3-none-any.whl", hash = "sha256:21c89495f508dcdb806bf16962a5d5546817c683f485cf53cb7d64eefbbf7011"},
+    {file = "awscli-1.18.31.tar.gz", hash = "sha256:8672d8875d2769f8db4456ae1ce08f675479292e549dd1d5d2de5856ebbf8d3c"},
 ]
 "backports.ssl-match-hostname" = [
     {file = "backports.ssl_match_hostname-3.7.0.1.tar.gz", hash = "sha256:bb82e60f9fbf4c080eabd957c39f0641f0fc247d9a16e31e26d594d8f42b9fd2"},
@@ -1525,12 +1518,11 @@ boto = [
     {file = "boto-2.49.0.tar.gz", hash = "sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a"},
 ]
 boto3 = [
-    {file = "boto3-1.12.30-py2.py3-none-any.whl", hash = "sha256:7f6d41d6e5b763914e867ece72b049476b75093bcb801afeae2aebd20d7f61c8"},
-    {file = "boto3-1.12.30.tar.gz", hash = "sha256:b464586003bdfb9ee92463013650f5b62935a7870ed3e8a32aa9111aa142c3f7"},
+    {file = "boto3-1.12.31-py2.py3-none-any.whl", hash = "sha256:8bf7e3611d46e8214bf225169ac55de762d9d341514f81ebae885dd601138fcf"},
+    {file = "boto3-1.12.31.tar.gz", hash = "sha256:913fc7bbb9df147ed6fa0bd2b391469652ee8cad3e26ca2355e6ff774d9516fb"},
 ]
 botocore = [
-    {file = "botocore-1.15.30-py2.py3-none-any.whl", hash = "sha256:d71f22e81bb17d92a6c3aad9ff04ca79af5f053ac35f6d6f16e1f002aa0655af"},
-    {file = "botocore-1.15.30.tar.gz", hash = "sha256:38eef2271ab908979ad7ec7a5cdf334c2a5a0b5e8fe37937c8a76e3ed9c18940"},
+    {file = "botocore-1.15.31.tar.gz", hash = "sha256:3d4684f61ff07aa1b4cd30d13a6b8e6416142be5a2a55aedcc1d7974b9415bb1"},
 ]
 certifi = [
     {file = "certifi-2019.11.28-py2.py3-none-any.whl", hash = "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3"},
@@ -1634,8 +1626,8 @@ cryptography = [
     {file = "cryptography-2.8.tar.gz", hash = "sha256:3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651"},
 ]
 dcicutils = [
-    {file = "dcicutils-0.11.0-py3-none-any.whl", hash = "sha256:f2b5cb7b0903b4069a918468e094fefd247939dddcbf39cded0c906e7c4fcee3"},
-    {file = "dcicutils-0.11.0.tar.gz", hash = "sha256:77db968865afcca0f5a753dbdef276be308010c01374d7929513d26d2b0c129e"},
+    {file = "dcicutils-0.12.0b1-py3-none-any.whl", hash = "sha256:a9cfcbf3e268337c08761a2e32ecb43be5bb040783e37ba81ca7de7aef541c69"},
+    {file = "dcicutils-0.12.0b1.tar.gz", hash = "sha256:8da8711168bb2639b2b64a70bab6762ff1bba1917d8563d7199bc213064ab24d"},
 ]
 docker = [
     {file = "docker-3.7.3-py2.py3-none-any.whl", hash = "sha256:2434b396e616a5ef682fbf80e04839a59e8b81880ece5662c33dff34b8863519"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -196,7 +196,7 @@ description = "Utility package for interacting with the 4DN Data Portal and othe
 name = "dcicutils"
 optional = false
 python-versions = ">=3.4,<3.7"
-version = "0.12.0b1"
+version = "0.12.0"
 
 [package.dependencies]
 aws-requests-auth = ">=0.4.2,<1"
@@ -1486,7 +1486,7 @@ transaction = ">=1.6.0"
 test = ["zope.testing"]
 
 [metadata]
-content-hash = "12996937c0e149e35351f29389944724e2ce35a1d43beadf62d2464e1c09f24d"
+content-hash = "66cdd1145e4a06ddd4edc66721ada1af381b0ce6fab81df92fd0a27ad06a7900"
 python-versions = ">=3.4,<3.7"
 
 [metadata.files]
@@ -1626,8 +1626,8 @@ cryptography = [
     {file = "cryptography-2.8.tar.gz", hash = "sha256:3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651"},
 ]
 dcicutils = [
-    {file = "dcicutils-0.12.0b1-py3-none-any.whl", hash = "sha256:a9cfcbf3e268337c08761a2e32ecb43be5bb040783e37ba81ca7de7aef541c69"},
-    {file = "dcicutils-0.12.0b1.tar.gz", hash = "sha256:8da8711168bb2639b2b64a70bab6762ff1bba1917d8563d7199bc213064ab24d"},
+    {file = "dcicutils-0.12.0-py3-none-any.whl", hash = "sha256:36b1dd96e7f61057a6d91eaf7fc84cffbfa3d7a8e6c15b46c05ceb5f6ca643d9"},
+    {file = "dcicutils-0.12.0.tar.gz", hash = "sha256:b68d6aa02028b090af8038dfbee65728ca73343ab15caf8a7dd40ffe2b94fda5"},
 ]
 docker = [
     {file = "docker-3.7.3-py2.py3-none-any.whl", hash = "sha256:2434b396e616a5ef682fbf80e04839a59e8b81880ece5662c33dff34b8863519"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,11 +39,6 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.4,<3.7"
-#
-# NOTE: For now I have retained (commented out) information about libraries that we no longer require
-#       just in case problems result that are due to missing support not immediately detected in testing.
-#       After recent changes have stabilized, I think it's OK to remove those comments. -kmp 20-Feb-2020
-#
 aws_requests_auth = "^0.4.1"
 # Not sure this is strictly needed but it seems useful.
 # It might be a dev dependency, but with a server there's not much distinction. -kmp 20-Feb-2020
@@ -52,20 +47,8 @@ awscli = "^1.15.42"
 #       so may no longer be needed. Something to investigate later. -kmp 20-Feb-2020
 "backports.statistics" = "0.1.0"
 boto3 = "^1.7.42"
-# botocore = "^1.10.42"
-# certifi = ">=2018.4.16"
-# cffi = "^1.6.0"
-# chardet = "3.0.4"
-# colorama = "^0.3.3"
-# coverage = "^4.0.3"
-# We don't need this.
-# TODO: Probably we should be adding a "^" here to get new versions, but for now since we're debugging
-#       our whole ecosystem, I left this temporarily pinned. -kmp 20-Feb-2020
-dcicutils = "0.12.0b1"
-# docutils = "0.12"
+dcicutils = ">=0.12.0,<1"
 elasticsearch_dsl = "^5.3.0"
-# flaky = "3.6.1"
-# future = "0.18.2"
 # TODO: Probably want ">=0.15.2,<1" here since "^" is different for "0.xx" than for higher versions. Changing it
 #       would require re-testing I don't have time for, so it'll have to be a future future change. -kmp 20-Feb-2020
 future = "^0.15.2"
@@ -73,27 +56,17 @@ futures = "^3.1.1"
 # Version 1.0b8 is the same as 0.9999999.
 html5lib = "0.9999999"
 humanfriendly = "^1.44.5"
-# hupper = "1.4.2"
-# idna = "2.7"
-# isodate = "0.5.4"
-# jmespath = "0.9.0"
 jsonschema_serialize_fork = "2.1.1"
 keepalive = "0.5"
 loremipsum = "1.0.5"
 MarkupSafe = ">=0.23,<1"
-# "mr.developer" = "1.38"
 netaddr = ">=0.7.18,<1"
 passlib = "^1.6.5"
-# PasteDeploy = "1.5.2"
 Pillow = "^3.1.1"
-# plaster = "1.0"
-# plaster-pastedeploy = "0.6"
 # TODO: Investigate whether a major version upgrade is allowable for 'psutil'.
 psutil = ">=4.3.0,<5"
 # psycopg2 = "2.8.4"
 psycopg2 = "^2.7.3"
-# py = "1.4.31"
-# pyasn1 = "0.1.9"
 PyBrowserID = "^0.10.0"
 pyramid = "1.10.4"
 pyramid_localroles = ">=0.1,<1"
@@ -113,43 +86,32 @@ pytz = ">=2016.4"
 PyYAML = ">=5.1,<5.3"
 rdflib = "^4.2.2"
 rdflib-jsonld = ">=0.3.0,<1.0.0"
-# requests = "^2.20.0"
 rfc3987 = "^1.3.6"
-# rsa = "^3.4.2"
 rutter = ">=0.2,<1"
-# s3transfer = "0.1.13"
 # setuptools = "^36.6.0"
 simplejson = "3.17.0"
-# six = "1.14.0"
 SPARQLWrapper = "^1.7.6"
 SQLAlchemy = "^1.2.16"
 strict-rfc3339 = ">=0.7,<1"
 # Our use of structlog is pretty vanilla, so we should be OK with changes across the 18-19 major version boundary.
 structlog = ">=18.1.0,<20"
-# subprocess32 = "3.5.4"
 subprocess_middleware = ">=0.3,<1"
 # TODO: Investigate whether a major version upgrade is allowable for 'transaction'.
 transaction = "^2.4.0"
-# translationstring = "1.3"
-# urllib3 = "1.25.8"
 # TODO: Investigate whether a major version upgrade is allowable for 'venusian'.
 venusian = "^1.2.0"
 WebOb = "^1.8.5"
 WebTest = "^2.0.21"
 WSGIProxy2 = "0.4.2"
 xlrd = "^1.0.0"
-# zc.buildout = "^2.13.2"
-# zc.recipe.egg = "^2.0.5"
 # zope = "^4.2.1"
 "zope.deprecation" = "^4.4.0"
 "zope.interface" = "^4.6.0"
 "zope.sqlalchemy" = "^1.2"
 
 [tool.poetry.dev-dependencies]
-# TODO: Do we care about any particular version for 'coverage'?
 coverage = "^4.1"
 moto = "1.3.7"
-# TODO: Do we care about any particular version for 'flake8'?
 flake8 = "^3.7.8"
 flaky = "3.6.1"
 # TODO: Investigate whether a major version upgrade is allowable for 'pytest', which is several versions behind.
@@ -163,7 +125,6 @@ pytest-mock = ">=0.11.0,<1"
 pytest-runner = "^4.0"
 pytest-timeout = "^1.0.0"
 "repoze.debug" = "^1.0.2"
-# "repoze.lru" = "^0.6"
 responses = "^0"
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "2.1.0"
+version = "2.1.1b1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -61,7 +61,7 @@ boto3 = "^1.7.42"
 # We don't need this.
 # TODO: Probably we should be adding a "^" here to get new versions, but for now since we're debugging
 #       our whole ecosystem, I left this temporarily pinned. -kmp 20-Feb-2020
-dcicutils = "0.11.0"
+dcicutils = "0.12.0b1"
 # docutils = "0.12"
 elasticsearch_dsl = "^5.3.0"
 # flaky = "3.6.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "2.1.1b1"
+version = "2.1.1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
This picks up the new `dcicutils 0.12.0`, but sets it up to allow higher versions.
I also removed some no-longer-needed comments in `pyproject.toml`'s requirements.
