### PR TITLE
C4-133 Check result of ES deletion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "2.2.0"
+version = "2.2.2"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/elasticsearch/esstorage.py
+++ b/snovault/elasticsearch/esstorage.py
@@ -232,10 +232,10 @@ class ElasticSearchStorage(object):
         return None
 
     @staticmethod
-    def delete_from_es(es, rid, index_name, item_type):
+    def _delete_from_es(es, rid, index_name, item_type):
         """
-        Helper method that deletes an item from Elasticsearch, returning True if the given rid
-        no longer/does not exist in ES and False otherwise.
+        Helper method that deletes an item from Elasticsearch, returning a boolean success value.
+        Success means the given rid did not exist or no longer exists in ES.
 
         :param es: es client to use
         :param rid: resource id to purge
@@ -256,7 +256,33 @@ class ElasticSearchStorage(object):
             log.info('PURGE: successfully deleted %s in ElasticSearch' % rid)
         return True
 
-    def purge_uuid_from_mirror(self, rid, item_type):
+    def _get_cached_mirror_health(self, mirror_env):
+
+        cached_mirror_health = self.registry.settings['mirror_health']
+        if 'error' not in cached_mirror_health:
+            return cached_mirror_health
+
+        mirror_env = self.registry.settings['mirror.env.name']
+        mirror_health_now = ff_utils.get_health_page(ff_env=mirror_env)
+        if 'error' not in mirror_health_now:
+            return mirror_health_now
+
+        raise RuntimeError('PURGE: Could not resolve mirror health on retry with error: %s' % mirror_health_now)
+
+    def _assure_mirror_client(self, es_mirror_server_and_port):
+        if not self.mirror:
+            raise RuntimeError("Attempt to call ._assure_mirror_client() when there is no self.mirror.")
+
+        use_aws_auth = self.registry.settings.get('elasticsearch.aws_auth')
+
+        # make sure use_aws_auth is bool
+        if not isinstance(use_aws_auth, bool):
+            use_aws_auth = True if use_aws_auth == 'true' else False
+
+        if not self.mirror_client:  # only recompute if we've never done this before
+            self.mirror_client = es_utils.create_es_client(es_mirror_server_and_port, use_aws_auth=use_aws_auth)
+
+    def _purge_uuid_from_mirror_es(self, rid, item_type):
         """
         Helper method for purge_uuid that purges rid from the mirror on ESStorage
 
@@ -265,55 +291,53 @@ class ElasticSearchStorage(object):
         :returns: result of 'delete_from_es'
         :raises: RuntimeError if we are unable to get the mirror health page
         """
+
+        if not self.mirror:
+            raise RuntimeError("Attempt to call ._purge_uuid_from_mirror_es() when there is no self.mirror.")
+
         mirror_env = self.registry.settings['mirror.env.name']
-        cached_mirror_health = self.registry.settings['mirror_health']
-        use_aws_auth = self.registry.settings.get('elasticsearch.aws_auth')
         log.info('PURGE: attempting to purge %s from mirror storage %s' % (rid, mirror_env))
 
-        # if we could not get mirror health, bail here
-        if 'error' in cached_mirror_health:
-            log.error(
-                'PURGE: Tried to purge %s from mirror storage but couldn\'t get health page. Is staging up?' % rid)
-            log.error('PURGE: Mirror health error: %s' % cached_mirror_health)
-            log.error('PURGE: Recomputing mirror health...')
-            cached_mirror_health = ff_utils.get_health_page(ff_env=mirror_env)
-            if 'error' in cached_mirror_health:
-                raise RuntimeError('PURGE: Could not resolve mirror health on retry with error: %s'
-                                   % cached_mirror_health)
-            self.registry.settings['mirror_health'] = cached_mirror_health
+        try:
+            mirror_health = self._get_cached_mirror_health()
+        except RuntimeError:
+            log.error("PURGE: Tried to purge %s from mirror storage but couldn't get health page. Is staging up?" % rid)
+            raise
 
-        # make sure use_aws_auth is bool
-        if not isinstance(use_aws_auth, bool):
-            use_aws_auth = True if use_aws_auth == 'true' else False
+        self._assure_mirror_client(es_mirror_server_and_port=mirror_health['elasticsearch'])
 
-        if not self.mirror_client:  # only recompute if we've never done this before
-            self.mirror_client = es_utils.create_es_client(cached_mirror_health['elasticsearch'],
-                                                           use_aws_auth=use_aws_auth)
+        mirror_index_name = namespace_index_from_health(health=mirror_health, index=item_type)
+        return self._delete_from_es(es=self.mirror_client, rid=rid, index_name=mirror_index_name, item_type=item_type)
 
-        mirror_index = namespace_index_from_health(cached_mirror_health, item_type)
-        return self.delete_from_es(self.mirror_client, rid, mirror_index, item_type)
+    def _purge_uuid_from_primary_es(self, rid, item_type, max_sid=None):
+
+        index_name = get_namespaced_index(config=self.registry, index=item_type)
+        if not self._delete_from_es(es=self.es, rid=rid, index_name=index_name, item_type=item_type):
+            return False
+
+        # queue related items for reindexing if deletion was successful
+        self.registry[INDEXER].find_and_queue_secondary_items({rid}, set(), sid=max_sid)
+
+        return True
 
     def purge_uuid(self, rid, item_type, max_sid=None):
         """
         Purge a uuid from the write storage (Elasticsearch)
-        If there is a mirror environment set up for the indexer, also attempt
-        to remove the uuid from the mirror Elasticsearch
+        If the indexer has an ElasticSearch mirror environment, also attempt to remove the uuid from that mirror.
 
-        Returns True if the deletion was successful or the item was not present, False otherwise
+        Returns True if the deletion was successful or the item was not present, and False otherwise.
         """
-        index_name = get_namespaced_index(self.registry, item_type)
-        proceed = self.delete_from_es(self.es, rid, index_name, item_type)
+        if not self._purge_uuid_from_primary_es(rid=rid, item_type=item_type, max_sid=max_sid):
+            return False
 
-        # queue related items for reindexing if deletion was successful
-        if proceed:
-            self.registry[INDEXER].find_and_queue_secondary_items(set([rid]), set(), sid=max_sid)
-
-        # if configured, delete the item from the mirrored ES as well
-        if self.mirror and proceed:
-            return self.purge_uuid_from_mirror(rid, item_type)
-
-        log.info('PURGE: Did not find a mirror env. Continuing.')
-        return proceed
+        # if configured, delete the item from the mirrored ES as well.
+        # If that is successful, we were successful, otherwise not.
+        if self.mirror:
+            return self._purge_uuid_from_mirror_es(rid=rid, item_type=item_type)
+        else:
+            # We don't usually need over and over in logs for cgap, where it's normal for there to be no mirror.
+            log.debug('PURGE: Did not find a mirror env. Continuing.')
+            return True
 
     def __iter__(self, *item_types):
         """

--- a/snovault/elasticsearch/indexer_utils.py
+++ b/snovault/elasticsearch/indexer_utils.py
@@ -17,6 +17,13 @@ def get_namespaced_index(config, index):
     return namespace + index
 
 
+def namespace_index_from_health(health, index):
+    """ Namespaces the given index based on health page data """
+    if 'error' in health:
+        raise RuntimeError('Mirror health unresolved: %s' % health)
+    return health.get('namespace', '') + index
+
+
 def find_uuids_for_indexing(registry, updated, find_index=None):
     """
     Run a search to find uuids of objects with that contain the given set of

--- a/snovault/storage.py
+++ b/snovault/storage.py
@@ -217,6 +217,7 @@ class PickStorage(object):
         and also remove the given item from Elasticsearch
         """
         log.warning('PURGE: purging %s' % rid)
+        proceed = True
         # requires ES for searching item links
         if self.read is not None:
             # model and max_sid are used later, in second `if self.read` block

--- a/snovault/storage.py
+++ b/snovault/storage.py
@@ -232,10 +232,13 @@ class PickStorage(object):
                 )
 
             # delete item from ES and mirrored ES, and queue reindexing
-            self.read.purge_uuid(rid, item_type, max_sid)
+            proceed = self.read.purge_uuid(rid, item_type, max_sid)
 
         # delete the item from DB
-        self.write.purge_uuid(rid)
+        if proceed:
+            self.write.purge_uuid(rid)
+        else:
+            raise HTTPInternalServerError('Deletion of rid %s unsuccessful in Elasticsearch, aborting deletion' % rid)
 
     def get_rev_links(self, model, rel, *item_types):
         """


### PR DESCRIPTION
- Previously, we would blindly delete from the DB regardless of whether the ES deletion was successful or not.
- We no longer do that now depending on the scenario. An internal server error will be thrown if a deletion is unsuccessful in ES, and the purge from the DB is aborted. 