### PR TITLE
C4-137 MPIndexer config for Indexer Application

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "2.2.0"
+version = "2.2.1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/elasticsearch/mpindexer.py
+++ b/snovault/elasticsearch/mpindexer.py
@@ -165,7 +165,7 @@ class MPIndexer(Indexer):
         in which case we will 1.5x the number of indexing processes.
         """
         num_cpu = cpu_count()
-        if registry.settings.get('ENCODED_INDEXER', ''):
+        if registry.settings.get('indexer', ''):
             return round((num_cpu - 2) * 1.5)  # done somewhat arbitrarily, should be benchmarked -Will 04/30/2020
         return num_cpu - 2 if num_cpu - 2 > 1 else 1
 

--- a/snovault/elasticsearch/mpindexer.py
+++ b/snovault/elasticsearch/mpindexer.py
@@ -166,7 +166,7 @@ class MPIndexer(Indexer):
         """
         num_cpu = cpu_count()
         if registry.settings.get('indexer', ''):
-            return round((num_cpu - 2) * 1.5)  # done somewhat arbitrarily, should be benchmarked -Will 04/30/2020
+            return round((num_cpu - 2) * 1.5) + 1  # done somewhat arbitrarily, should be benchmarked -Will 04/30/2020
         return num_cpu - 2 if num_cpu - 2 > 1 else 1
 
     def init_pool(self):

--- a/snovault/elasticsearch/mpindexer.py
+++ b/snovault/elasticsearch/mpindexer.py
@@ -166,7 +166,7 @@ class MPIndexer(Indexer):
         """
         num_cpu = cpu_count()
         cpus_to_use = num_cpu
-        if registry.settings.get('INDEX_SERVER', ''):
+        if registry.settings.get('index_server', 'false').upper() == 'TRUE':  # XXX: option should be imported
             # done somewhat arbitrarily, should be benchmarked -Will 04/30/2020
             cpus_to_use = round((num_cpu - 2) * 1.5) + 1
         return max(cpus_to_use, 1)

--- a/snovault/elasticsearch/mpindexer.py
+++ b/snovault/elasticsearch/mpindexer.py
@@ -166,7 +166,7 @@ class MPIndexer(Indexer):
         """
         num_cpu = cpu_count()
         cpus_to_use = num_cpu
-        if registry.settings.get('indexer', ''):
+        if registry.settings.get('INDEX_SERVER', ''):
             # done somewhat arbitrarily, should be benchmarked -Will 04/30/2020
             cpus_to_use = round((num_cpu - 2) * 1.5) + 1
         return max(cpus_to_use, 1)

--- a/snovault/elasticsearch/mpindexer.py
+++ b/snovault/elasticsearch/mpindexer.py
@@ -155,19 +155,21 @@ class MPIndexer(Indexer):
     def __init__(self, registry):
         super(MPIndexer, self).__init__(registry)
         self.chunksize = int(registry.settings.get('indexer.chunk_size', 1024))
-        self.processes = self.configure_processes(registry)
+        self.processes = self.suggested_number_of_processes(registry)
         self.initargs = (registry[APP_FACTORY], registry.settings,)
 
     @staticmethod
-    def configure_processes(registry):
+    def suggested_number_of_processes(registry):
         """
         Called by the initializer. Will check the application registry for the 'ENCODED_INDEXER' option,
         in which case we will 1.5x the number of indexing processes.
         """
         num_cpu = cpu_count()
+        cpus_to_use = num_cpu
         if registry.settings.get('indexer', ''):
-            return round((num_cpu - 2) * 1.5) + 1  # done somewhat arbitrarily, should be benchmarked -Will 04/30/2020
-        return num_cpu - 2 if num_cpu - 2 > 1 else 1
+            # done somewhat arbitrarily, should be benchmarked -Will 04/30/2020
+            cpus_to_use = round((num_cpu - 2) * 1.5) + 1
+        return max(cpus_to_use, 1)
 
     def init_pool(self):
         """

--- a/snovault/tests/test_indexing.py
+++ b/snovault/tests/test_indexing.py
@@ -60,7 +60,7 @@ def app_settings(wsgi_server_host_port, elasticsearch_server, postgresql_server,
     settings['sqlalchemy.url'] = postgresql_server
     settings['collection_datastore'] = 'elasticsearch'
     settings['item_datastore'] = 'elasticsearch'
-    settings['indexer'] = True
+    settings['indexer'] = False  # when testing, do not test as if we are an indexer application
     settings['indexer.namespace'] = os.environ.get('TRAVIS_JOB_ID', '')
 
     # use aws auth to access elasticsearch

--- a/snovault/tests/test_indexing.py
+++ b/snovault/tests/test_indexing.py
@@ -60,7 +60,7 @@ def app_settings(wsgi_server_host_port, elasticsearch_server, postgresql_server,
     settings['sqlalchemy.url'] = postgresql_server
     settings['collection_datastore'] = 'elasticsearch'
     settings['item_datastore'] = 'elasticsearch'
-    settings['indexer'] = False  # when testing, do not test as if we are an indexer application
+    settings['indexer'] = True
     settings['indexer.namespace'] = os.environ.get('TRAVIS_JOB_ID', '')
 
     # use aws auth to access elasticsearch


### PR DESCRIPTION
- Modifies the MPIndexer to up the number of processes if we are running an indexer application
- Since indexing is at least partially I/O bound, there should be a threshold beyond the number of cpus on the machine that will give us the best performance. 
- We know from previous benchmarking that num_cpus - 2 will cap us at ~40% CPU, so I estimate a ~1.5x increase in allotted processes will give us better indexing performance without bounding the CPU. It's possible a smaller increase is needed, but we can tweak that as needed.