### PR TITLE
C4-159 Explicitly disallow type=string in get_uuids_for_types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "dcicsnovault"
 # Version 3 drops support for Python 3.4 and 3.5, which neither Fourfront nor CGAP care about any more.
-version = "3.0.1"
+version = "3.0.1b0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "dcicsnovault"
 # Version 3 drops support for Python 3.4 and 3.5, which neither Fourfront nor CGAP care about any more.
-version = "3.0.0b0"
+version = "3.0.1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/elasticsearch/indexer_utils.py
+++ b/snovault/elasticsearch/indexer_utils.py
@@ -84,6 +84,8 @@ def get_uuids_for_types(registry, types=[]):
     Yields:
         str: uuid of item in collections
     """
+    if not isinstance(types, list):  # passing in a single type as a string triggers undefined behavior -Will 5/13/2020
+        raise TypeError('Excpeted type=list for argument "types"')  # explicitly disallow
     collections = registry[COLLECTIONS]
     # might as well sort collections alphatbetically, as this was done earlier
     for coll_name in sorted(collections.by_item_type):

--- a/snovault/elasticsearch/indexer_utils.py
+++ b/snovault/elasticsearch/indexer_utils.py
@@ -84,8 +84,8 @@ def get_uuids_for_types(registry, types=[]):
     Yields:
         str: uuid of item in collections
     """
-    if not isinstance(types, list):  # passing in a single type as a string triggers undefined behavior -Will 5/13/2020
-        raise TypeError('Excpeted type=list for argument "types"')  # explicitly disallow
+    if not isinstance(types, list) or not all(isinstance(t, str) for t in types):  # type check for safety
+        raise TypeError('Expected type=list (of strings) for argument "types"')
     collections = registry[COLLECTIONS]
     # might as well sort collections alphatbetically, as this was done earlier
     for coll_name in sorted(collections.by_item_type):


### PR DESCRIPTION
- If you pass a string to `get_uuids_for_types`, undefined behavior occurs in which uuids it returns. Explicitly disallow this.
- Note that branch is mislabeled - the actual ticket is C4-159.