### PR TITLE
Mostly-compatible major snovault version (3.0.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "dcicsnovault"
 # Version 3 drops support for Python 3.4 and 3.5, which neither Fourfront nor CGAP care about any more.
-version = "3.0.0b1"
+version = "3.0.0b2"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "dcicsnovault"
 # Version 3 drops support for Python 3.4 and 3.5, which neither Fourfront nor CGAP care about any more.
-version = "3.0.0b0"
+version = "3.0.0b1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "dcicsnovault"
 # Version 3 drops support for Python 3.4 and 3.5, which neither Fourfront nor CGAP care about any more.
-version = "3.0.0b2"
+version = "3.0.0b3"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "dcicsnovault"
 # Version 3 drops support for Python 3.4 and 3.5, which neither Fourfront nor CGAP care about any more.
-version = "3.0.0b3"
+version = "3.0.0b4"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "dcicsnovault"
 # Version 3 drops support for Python 3.4 and 3.5, which neither Fourfront nor CGAP care about any more.
-version = "3.0.0b4"
+version = "3.0.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/_version.py.DISABLED
+++ b/snovault/_version.py.DISABLED
@@ -1,4 +1,0 @@
-"""Version information."""
-
-# The following line *must* be the last in the module, exactly as formatted:
-__version__ = "2.0.0"

--- a/snovault/elasticsearch/__init__.py
+++ b/snovault/elasticsearch/__init__.py
@@ -1,17 +1,13 @@
 import json
-import sys
 
-from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
+# from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 from dcicutils.es_utils import create_es_client
 from elasticsearch.connection import RequestsHttpConnection
 from elasticsearch.serializer import SerializationError
-from pyramid.settings import asbool, aslist
+from pyramid.settings import asbool
 from ..json_renderer import json_renderer
 from ..util import get_root_request
 from .interfaces import APP_FACTORY, ELASTIC_SEARCH
-
-
-PY2 = sys.version_info.major == 2
 
 
 def includeme(config):
@@ -35,7 +31,7 @@ def includeme(config):
     config.include('.esstorage')
     config.include('.indexer_queue')
     config.include('.indexer')
-    if asbool(settings.get('mpindexer')) and not PY2:
+    if asbool(settings.get('mpindexer')):
         config.include('.mpindexer')
 
 
@@ -45,7 +41,8 @@ class PyramidJSONSerializer(object):
     def __init__(self, renderer):
         self.renderer = renderer
 
-    def loads(self, s):
+    @staticmethod
+    def loads(s):
         try:
             return json.loads(s)
         except (ValueError, TypeError) as e:

--- a/snovault/elasticsearch/__init__.py
+++ b/snovault/elasticsearch/__init__.py
@@ -1,6 +1,5 @@
 import json
 
-# from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 from dcicutils.es_utils import create_es_client
 from elasticsearch.connection import RequestsHttpConnection
 from elasticsearch.serializer import SerializationError

--- a/snovault/elasticsearch/__init__.py
+++ b/snovault/elasticsearch/__init__.py
@@ -81,10 +81,10 @@ class TimedRequestsHttpConnection(RequestsHttpConnection):
 
     def log_request_success(self, method, full_url, path, body, status_code, response, duration):
         self.stats_record(duration)
-        return super(RequestsHttpConnection, self).log_request_success(
+        return super(TimedRequestsHttpConnection, self).log_request_success(
             method, full_url, path, body, status_code, response, duration)
 
-    def log_request_fail(self, method, full_url, path, body, duration, status_code=None, exception=None):
+    def log_request_fail(self, method, full_url, path, body, duration, status_code=None, response=None, exception=None):
         self.stats_record(duration)
-        return super(RequestsHttpConnection, self).log_request_fail(
-            method, full_url, path, body, duration, status_code, exception)
+        return super(TimedRequestsHttpConnection, self).log_request_fail(
+            method, full_url, path, body, duration, status_code=status_code, response=response, exception=exception)

--- a/snovault/elasticsearch/es_index_listener.py
+++ b/snovault/elasticsearch/es_index_listener.py
@@ -31,7 +31,6 @@ log = structlog.getLogger(__name__)
 
 EPILOG = __doc__
 DEFAULT_INTERVAL = 3  # 3 second default
-PY2 = sys.version_info[0] == 2
 
 # We need this because of MVCC visibility.
 # See slide 9 at http://momjian.us/main/writings/pgsql/mvcc.pdf
@@ -90,18 +89,6 @@ def run(testapp, interval=DEFAULT_INTERVAL, dry_run=False, path='/index', update
 
 
 class ErrorHandlingThread(threading.Thread):
-    if PY2:
-        @property
-        def _kwargs(self):
-            return self._Thread__kwargs
-
-        @property
-        def _args(self):
-            return self._Thread__args
-
-        @property
-        def _target(self):
-            return self._Thread__target
 
     def run(self):
         # interval = self._kwargs.get('interval', DEFAULT_INTERVAL)

--- a/snovault/storage.py
+++ b/snovault/storage.py
@@ -114,10 +114,11 @@ baked_query_unique_key = bakery(
         # This formerly called orm.joinedload_all, but that function has been deprecated since sqlalchemy 0.9.
         # The advice in the documentation was to just use orm.joinedload in apparently the same way. -kmp 11-May-2020
         # Ref: https://docs.sqlalchemy.org/en/13/orm/loading_relationships.html#sqlalchemy.orm.joinedload_all
-        # OK, well, we found that the doc was impoverished and that doing it in the same way isn't right.
-        # The release notes for sqlalchemy 0.9, when the change was made, offer better advice which is to rewrite
-        # this as a chain. No advice is given about the keyword arguments (innerjoin=True), but I assume they
-        # must be distributed to each such call. -kmp 14-May-2020
+        # OK, well, I had misread the doc, which agrees with the release notes for sqlalchemy 0.9 (when the change
+        # was made), both say to use a chain. No advice is given about the keyword arguments (innerjoin=True),
+        # but I assume they must be distributed to each such call. It's possible the right result was happening
+        # anyway, but that it took more queries to get that result when not chained properly.
+        # -kmp 14-May-2020
         # Ref: https://docs.sqlalchemy.org/en/13/changelog/migration_09.html
         orm.joinedload(Key.resource, innerjoin=True)
            .joinedload(Resource.data, innerjoin=True)

--- a/snovault/storage.py
+++ b/snovault/storage.py
@@ -114,12 +114,14 @@ baked_query_unique_key = bakery(
         # This formerly called orm.joinedload_all, but that function has been deprecated since sqlalchemy 0.9.
         # The advice in the documentation was to just use orm.joinedload in apparently the same way. -kmp 11-May-2020
         # Ref: https://docs.sqlalchemy.org/en/13/orm/loading_relationships.html#sqlalchemy.orm.joinedload_all
-        orm.joinedload(
-            Key.resource,
-            Resource.data,
-            CurrentPropertySheet.propsheet,
-            innerjoin=True,
-        ),
+        # OK, well, we found that the doc was impoverished and that doing it in the same way isn't right.
+        # The release notes for sqlalchemy 0.9, when the change was made, offer better advice which is to rewrite
+        # this as a chain. No advice is given about the keyword arguments (innerjoin=True), but I assume they
+        # must be distributed to each such call. -kmp 14-May-2020
+        # Ref: https://docs.sqlalchemy.org/en/13/changelog/migration_09.html
+        orm.joinedload(Key.resource, innerjoin=True)
+           .joinedload(Resource.data, innerjoin=True)
+           .joinedload(CurrentPropertySheet.propsheet, innerjoin=True)
     ).filter(Key.name == bindparam('name'), Key.value == bindparam('value'))
 )
 # Baked queries can be used with expanding params (lists)

--- a/snovault/tests/elasticsearch_fixture.py
+++ b/snovault/tests/elasticsearch_fixture.py
@@ -1,9 +1,6 @@
 import os.path
 import sys
-try:
-    import subprocess32 as subprocess
-except ImportError:
-    import subprocess
+import subprocess
 
 
 def server_process(datadir, host='localhost', port=9200, prefix='', echo=False):

--- a/snovault/tests/postgresql_fixture.py
+++ b/snovault/tests/postgresql_fixture.py
@@ -1,10 +1,7 @@
 from urllib.parse import quote
 import os.path
 import sys
-try:
-    import subprocess32 as subprocess
-except ImportError:
-    import subprocess
+import subprocess
 
 
 def initdb(datadir, prefix='', echo=False):

--- a/snovault/tests/serverfixtures.py
+++ b/snovault/tests/serverfixtures.py
@@ -270,7 +270,7 @@ def execute_counter(conn, zsa_savepoints, check_constraints):
             yield
             difference = self.count - start
             assert difference == count, (
-                    "Counter mismatch. Expected %s but got %s:\n%s" % (count, difference, "\n".join(counted)))
+                    "Counter mismatch. Expected %s but got %s:\n%s" % (count, difference, "\n".join(map(str, counted))))
 
     counted = []
 

--- a/snovault/tests/serverfixtures.py
+++ b/snovault/tests/serverfixtures.py
@@ -262,21 +262,53 @@ def check_constraints(conn, _DBSession):
 
 
 class ExecutionWatcher(object):
+
+    """
+    An ExecutionWatcher mediates the counting of something, which can scoped by the .expect() context manager, as in:
+            with <watcher>.expect(expect=n):
+               ...watched stuff happens here...
+    It will report an error if the .notify() method doesn't see exactly n events that later survive filtering.
+    If the right number does not happen, the error message will say what events were seen in
+    the (active) watched region.
+    """
+
     def __init__(self, filter=None):
-        self._active = False
+        """
+        Creates an ExecutionWatcher object with a given filter.
+        """
+
+        # The ._active flag is used to know whether to be recording and also to make sure we don't do nested calls.
+        # We are only recording if we are inside a 'with execute_counter.expect(...):' context, which is to say
+        # this ExecutionWatcher is ordinarily created within a use of the `execute_counter` fixture. See documentation
+        # on that fixture for details of use.
+
+        self._active = False  # The wacher is not reentrant
         self.reset()
-        self.conn = conn
         self.filter = filter
 
     def reset(self):
+        """
+        This can be used to reinitialize counting, though the semantics of that are questionable.
+        It MIGHT have limited utility in the case of a db rollback, but we really don't use that.
+        """
+        # TODO: It might be that this method could usefully go away.
         self.events = []
 
     def notice(self, event):
+        """
+        Whatever it is that's being instrumented should send events here to get them counted.
+        Any filter will be done later, so that if events are being filtered that shouldn't be,
+        they will still show up in the error message.
+        """
         if self._active:
             self.events.append(event)
 
     @contextmanager
     def expect(self, expected_count):
+        """
+        This context manager declares that within a certain scope, only a certain number of events are expected.
+        See documentation on the
+        """
         if self._active:
             raise RuntimeError("Attempt to enter execute_counter.expect(...) while it is already executing.")
         self._active = True
@@ -299,7 +331,32 @@ class ExecutionWatcher(object):
 
 @pytest.yield_fixture
 def execute_counter(conn, zsa_savepoints, check_constraints, filter=None):
-    """ Count calls to execute
+    """
+    This fixture gives you a context manager that can be used to count calls to the SQLAlchemy 'execute' operation.
+
+    Using this allows you to find out how many queries are needed to do a particular inquiry or set of inquiries
+    using the ORM. Such a test is by nature a bit fragile, since it is bypassing abstraction boundaries, but I think
+    the intent is to let the caller check whether joins are happening correctly. If they are not, the likely result
+    is that you'll see more than the expected number of database queries.
+
+    The intended use is in testing, where the fixture gives you a counter object that has a .expect method you can
+    use as a context manager in order to bound the region of code you want to count. For example:
+
+       def test_something(execute_counter):
+           ... do some setup ...
+           execute_counter.expect(2):  # <-- this is where you say how many DB executes you expect
+               ... some ORM operation ...
+
+    You'll get an error if the expectation is violated, and it will tell you what the operations were so that you can
+    sort out whether you think it's an error or just a legit change in the underlying implementation.
+
+    Note that counters are not reentrant. That is, you can't nest these calls with the same fixture. (If you call
+    something else that has its own fixture, it should be fine.) There are no cases we care about where nesting was
+    needed, so it simplifies the implementation.
+
+    There is also now a filter argument to the execute_counter fixture that will allow, in the future if it is needed,
+    for the possibility that some execute operations would be ignored (not counted) during the measured interval.
+    (That was created for debugging and didn't end up being used, but still might be useful in the future.)
     """
     notice_pytest_fixtures(conn, zsa_savepoints, check_constraints)
 

--- a/snovault/tests/test_indexing.py
+++ b/snovault/tests/test_indexing.py
@@ -18,7 +18,7 @@ import yaml
 from datetime import datetime, timedelta
 from dcicutils.lang_utils import n_of
 from dcicutils.misc_utils import ignored
-from dcicutils.qa_utils import ControlledTime
+from dcicutils.qa_utils import ControlledTime, notice_pytest_fixtures
 from elasticsearch.exceptions import NotFoundError
 from pyramid.traversal import traverse
 from sqlalchemy import MetaData
@@ -42,10 +42,13 @@ from ..elasticsearch.create_mapping import (
 )
 from ..elasticsearch.indexer import check_sid, SidException
 from ..elasticsearch.interfaces import ELASTIC_SEARCH, INDEXER_QUEUE, INDEXER_QUEUE_MIRROR
-from .pyramidfixtures import dummy_request  # noqa - this fixture is actually used even if PyCharm doesn't agree
+from .pyramidfixtures import dummy_request
 from .testappfixtures import _app_settings
-from .testing_views import TestingLinkSourceSno  # noqa - data collection is used even if PyCharm doesn't agree
-from .toolfixtures import registry, root, elasticsearch  # noqa - fixtures used even if PyCharm doesn't agree
+from .testing_views import TestingLinkSourceSno
+from .toolfixtures import registry, root, elasticsearch
+
+
+notice_pytest_fixtures(dummy_request, TestingLinkSourceSno, registry, root, elasticsearch)
 
 
 pytestmark = [pytest.mark.indexing]

--- a/snovault/tests/testing_views.py
+++ b/snovault/tests/testing_views.py
@@ -111,7 +111,7 @@ def paths_filtered_by_status(request, paths, exclude=('deleted', 'replaced'), in
 
 class AbstractCollection(BaseAbstractCollection):
     def get(self, name, default=None):
-        resource = super(BaseAbstractCollection, self).get(name, None)
+        resource = super(AbstractCollection, self).get(name, None)
         if resource is not None:
             return resource
         if ':' in name:
@@ -125,7 +125,7 @@ class AbstractCollection(BaseAbstractCollection):
 
 class Collection(BaseCollection):
     def __init__(self, *args, **kw):
-        super(BaseCollection, self).__init__(*args, **kw)
+        super(Collection, self).__init__(*args, **kw)
         if hasattr(self, '__acl__'):
             return
         # XXX collections should be setup after all types are registered.

--- a/snovault/tests/toolfixtures.py
+++ b/snovault/tests/toolfixtures.py
@@ -1,4 +1,5 @@
 import pytest
+from dcicutils.qa_utils import notice_pytest_fixtures
 from ..interfaces import BLOBS, CALCULATED_PROPERTIES, COLLECTIONS, CONNECTION, STORAGE, ROOT, TYPES, UPGRADER
 from ..elasticsearch import ELASTIC_SEARCH
 
@@ -7,49 +8,59 @@ from ..elasticsearch import ELASTIC_SEARCH
 
 @pytest.fixture
 def registry(app):
+    notice_pytest_fixtures(app)
     return app.registry
 
 
 @pytest.fixture
 def blobs(registry):
+    notice_pytest_fixtures(registry)
     return registry[BLOBS]
 
 
 @pytest.fixture
 def calculated_properties(registry):
+    notice_pytest_fixtures(registry)
     return registry[CALCULATED_PROPERTIES]
 
 
 @pytest.fixture
 def collections(registry):
+    notice_pytest_fixtures(registry)
     return registry[COLLECTIONS]
 
 
 @pytest.fixture
 def connection(registry):
+    notice_pytest_fixtures(registry)
     return registry[CONNECTION]
 
 
 @pytest.fixture
 def elasticsearch(registry):
+    notice_pytest_fixtures(registry)
     return registry[ELASTIC_SEARCH]
 
 
 @pytest.fixture
 def storage(registry):
+    notice_pytest_fixtures(registry)
     return registry[STORAGE]
 
 
 @pytest.fixture
 def root(registry):
+    notice_pytest_fixtures(registry)
     return registry[ROOT]
 
 
 @pytest.fixture
 def types(registry):
+    notice_pytest_fixtures(registry)
     return registry[TYPES]
 
 
 @pytest.fixture
 def upgrader(registry):
+    notice_pytest_fixtures(registry)
     return registry[UPGRADER]


### PR DESCRIPTION
This change is largely internal, upgrading testing to newer versions.

The things we changed that are incompatible are small, but worth noting:

* We dropped support for **Python 3.4** and **Python 3.5**, which we were not using anyway.

* Doing that change made more newer library versions become available to use, so things that were using `"^"` or `">="` or `"<"` in the `pyproject.toml` file will have selected different versions, and those versions were not always ones we wanted. We need to explore that and I had to pin some things in Fourfront to make it be able to take this release, but otherwise it mostly took this as-is. CGAP was happier because it already had more things pinned, and I ended up using the CGAP settings to pacify Fourfront.

Other changes:

* This moves us to using **pytest 4.5** for `snovault`.  (That decision is not binding on CGAP and Fourfront, which I'll have to separately upgrade.) There are numerous small changes to use different operators at various places in here that are almost all because of this change. That includes changes to the use of `orm.joinedload` chains instead of `orm.joinedload_all`, the use of a `tmpdir_factory` fixture instead of a `request` fixture when making temporary filenames, the use of a `.reflect()` method by side-effect on ORM `MetaData` objects rather than a `reflect=True` argument when creating the `MetaData}, and rewriting `SNOWHash.encrypt` as SNOWHash.hash in `snovault/tests/test_snowflake_hash.py`.

* Some classes were calling `super` wrong, not naming the parent class but its parent. I added back the lost intermediate class.  This includes `TimedRequestsHttpConnection` in `snovault/elasticsearch/__init__.py` and both `Collection` and `AbstractCollection` in `snovault/tests/testing_views.py`.

* I changed the `@collection` decorator in `snovault/config.py` to add `__test__ = False` so that collections with `"Test"` in their name would not be taken as unit tests if they got defined (as they do) in a test file. There were only a couple of these, and I could have done it one-off for each one, but it seemed unlikely that anything would both a collection and a unit test, so I figured it was best to do it centrally.  (This might have always been a problem or might have been new in pytest 4.5, I'm not sure.)

* There were some. methods of `TimedRequestsHttpConnection` (in particular `log_request_success` and `log_request_fail` that didn't have agreement in arguments among the child classes and were at risk of passing the wrong argument to `super`. PyCharm pointed that out and I just fixed it opportunistically. There are a lot of things PyCharm mentions that I haven't gotten to.

* I reimplmented the `execute_counter` fixture that counts numbers of SQLalchemy `execute` operations but when it fails doesn't tell you what the miscount is about. The new implementation will also allow us filtering in the future, if we need that, but for now was mostly useful in diagnosing the issue with `joinedload` because we were getting separate queries instead of joined ones.

* I dropped some code that was uselessly supporting Python 2, which wasn't supported overall but still had occasional pockets of support. This code was never reached so will not affect anything.

* I added some uses of the new `dcicutils.qa_utils.notice_pytest_fixtures` so that some of the fixtures would be less at risk of being broken by removal of unused variables, and we'll get a cleaner (though still not pristine) rating from flake8 on PEP8 issues in the process. This is not a functional effect on anything.


