### PR TITLE
Tentatively fix the purge queue sleep in deployed situations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "dcicsnovault"
 # Version 3 drops support for Python 3.4 and 3.5, which neither Fourfront nor CGAP care about any more.
-version = "3.0.2"
+version = "3.0.3"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/tests/conftest.py
+++ b/snovault/tests/conftest.py
@@ -5,6 +5,8 @@ import pytest
 import logging
 import subprocess
 
+from ..elasticsearch.indexer_queue import QueueManager
+
 
 pytest_plugins = [
     'snovault.tests.serverfixtures',
@@ -71,3 +73,4 @@ def start_moto_server_sqs():
 def pytest_configure():
     logging.basicConfig()
     logging.getLogger('snovault').setLevel(logging.INFO)
+    QueueManager.PURGE_QUEUE_SLEEP_FOR_SAFETY = True

--- a/snovault/tests/test_indexing.py
+++ b/snovault/tests/test_indexing.py
@@ -41,6 +41,7 @@ from ..elasticsearch.create_mapping import (
     type_mapping,
 )
 from ..elasticsearch.indexer import check_sid, SidException
+from ..elasticsearch.indexer_queue import QueueManager
 from ..elasticsearch.interfaces import ELASTIC_SEARCH, INDEXER_QUEUE, INDEXER_QUEUE_MIRROR
 from .pyramidfixtures import dummy_request
 from .testappfixtures import _app_settings
@@ -1646,6 +1647,132 @@ def test_assert_transactions_table_is_gone(app):
     assert not any(column.name == 'tid' for column in meta.tables['propsheets'].columns)
     # make sure fkey constraint is also removed
     assert not any(constraint.name == 'propsheets_tid_fkey' for constraint in meta.tables['propsheets'].constraints)
+
+
+def test_queue_manager_creation():
+
+    with mock.patch("boto3.client") as mock_boto3_client:
+        with mock.patch.object(QueueManager, "initialize") as mock_initialize:
+            with mock.patch("socket.gethostname") as mock_gethostname:
+
+                def test_it(myenv, mirror_env=None, override_url=None):
+
+                    # Allow this test to be called more than once.
+                    mock_boto3_client.reset_mock()
+                    mock_initialize.reset_mock()
+                    mock_gethostname.reset_mock()
+
+                    class MockRegistry:
+                        settings = {'env.name': myenv}
+
+                    host_len80_hyph = "myhostname-111111111-222222222-333333333-444444444-555555555-666666666-777777777"
+                    host_len80_dots = "myhostname.111111111.222222222.333333333.444444444.555555555.666666666.777777777"
+                    full_host = host_len80_dots + ".888888888.cgap.hms.harvard.edu"
+                    # If myenv is None, QueueManager generates its own env name one by
+                    #  - truncating hostname to 80 chars
+                    #  - changing dot (.) to hyphen (-)
+                    mock_gethostname.return_value = full_host
+
+                    if mirror_env:
+                        expected_env = mirror_env
+                    elif myenv is None:
+                        expected_env = host_len80_hyph
+                    else:
+                        expected_env = myenv
+
+                    # Set up expectations for mock return values
+
+                    expected_primary_queue_name = expected_env + '-indexer-queue'
+                    expected_secondary_queue_name = expected_env + '-secondary-indexer-queue'
+                    expected_dlq_name = expected_env + '-indexer-queue-dlq'
+
+                    mocked_primary_queue_url = 'http://primary'
+                    mocked_secondary_queue_url = 'http://secondary'
+                    mocked_dlq_url = 'http://dlq'
+
+                    expected_queue_urls = {
+                        expected_primary_queue_name: mocked_primary_queue_url,
+                        expected_secondary_queue_name: mocked_secondary_queue_url,
+                        expected_dlq_name: mocked_dlq_url,
+                    }
+                    mock_initialize.return_value = expected_queue_urls
+
+                    registry = MockRegistry()
+
+                    with mock.patch.object(QueueManager, "get_queue_url") as mock_get_queue_url:
+                        mock_get_queue_url.side_effect = lambda queue_name: expected_queue_urls.get(queue_name)
+
+                        # Finally all the mocking is set up, now do the QueueManager call we're testing.
+
+                        manager = QueueManager(registry, mirror_env=mirror_env, override_url=override_url)
+
+                    # Check the aftermath...
+
+                    # Values that would have been due to class variables
+                    assert manager.PURGE_QUEUE_SLEEP_FOR_SAFETY is True
+                    assert manager.PURGE_QUEUE_TIMESTAMP0 < datetime(datetime.now().year - 2, 1, 1)  # long ago
+                    assert (manager.PURGE_QUEUE_EFFECTIVE_LOCKOUT_TIME
+                            > manager.PURGE_QUEUE_LOCKOUT_TIME_ACCORDING_TO_AMAZON)
+
+                    assert manager.env_name == expected_env
+
+                    assert mock_boto3_client.call_count == 1
+                    if override_url:
+                        assert manager.override_url == override_url
+                        mock_boto3_client.assert_called_with('sqs', region_name='us-east-1', endpoint_url=override_url)
+                    else:
+                        assert manager.override_url is None
+                        mock_boto3_client.assert_called_with('sqs', region_name='us-east-1')
+
+                    if mirror_env:
+                        assert mock_initialize.call_count == 0
+                    else:
+                        assert mock_initialize.call_count == 1
+                        mock_initialize.assert_called_with(dlq=True)
+
+                    assert manager.queue_attrs == {
+                        expected_primary_queue_name: {
+                            'DelaySeconds': '1',
+                            'MessageRetentionPeriod': '1209600',
+                            'ReceiveMessageWaitTimeSeconds': '2',
+                            'VisibilityTimeout': '600'
+                        },
+                        expected_secondary_queue_name: {
+                            'MessageRetentionPeriod': '1209600',
+                            'ReceiveMessageWaitTimeSeconds': '2',
+                            'VisibilityTimeout': '600'
+                        },
+                        expected_dlq_name: {
+                            'MessageRetentionPeriod': '1209600',
+                            'ReceiveMessageWaitTimeSeconds': '2',
+                            'VisibilityTimeout': '600'
+                        }
+                    }
+
+                    # manager.queue_targets is an OrderedDict but we don't care. Just make sure data is right:
+                    assert json.loads(json.dumps(manager.queue_targets)) == {
+                        'primary': mocked_primary_queue_url,
+                        'secondary': mocked_secondary_queue_url,
+                        'dlq': mocked_dlq_url,
+                    }
+
+                # These are the arg configurations we probably care about ...
+                test_it('some-env')  # Normal case of setting up an env
+                test_it('some-env', mirror_env='emos-env')  # Normal case of setting up a mirror
+                test_it(None)  # Weird case we allow who knows why
+                test_it('some-env', override_url="http://foo")  # Another override option we allow
+
+
+def test_chunk_messages():
+
+    # Really this could be anything generated series we're chunking
+
+    assert list(QueueManager.chunk_messages(list(range(0)), 5)) == []
+    assert list(QueueManager.chunk_messages(list(range(3)), 5)) == [[0, 1, 2]]
+    assert list(QueueManager.chunk_messages(list(range(5)), 5)) == [[0, 1, 2, 3, 4]]
+    assert list(QueueManager.chunk_messages(list(range(6)), 5)) == [[0, 1, 2, 3, 4], [5]]
+    assert list(QueueManager.chunk_messages(list(range(10)), 5)) == [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]
+    assert list(QueueManager.chunk_messages(list(range(11)), 5)) == [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10]]
 
 
 def test_wait_until_purge_queue_allowed():


### PR DESCRIPTION
**Updated Description**

I realized the sleep was in the wrong place in `purge_queue` so I have adjusted the position and that alone may fix the bug. For now I suggest leaving `PURGE_QUEUE_SLEEP_FOR_SAFETY` set to `True` everywhere and we can see how that goes. I think it will now sleep only 0-1 seconds, usually on the zero end. Previously the problem was it was sleeping at least 2 and maybe 3 seconds, leaning toward 2, and I think that was creating the issue. I've verified this hypothesis in unit tests, which were failing until I made this fix.

**Original Description**

This adds and somewhat tests the QueueManager.PURGE_QUEUE_SLEEP_FOR_SAFETY flag, which is now set to `True` only for testing and is left `False` elsewhere.


**Original Rationale**

The sleep time was added because tests were colliding, and this should continue to leave that problem fixed so that tests aren't all flaking out. In a deployed situation, collisions are still a risk, but they are more rare and Will's hypothesis is that we don't need this sleep there, that it's costing us too much time.

**Original Notes**

There is some risk that we won't be testing collisions that _do_ then still happen at runtime, but if so we can tune this further. We lived for a long time without this sleep feature and the system was not ordinarily believed flaky.

**Shared Notes**

There were no unit tests at all of QueueManager, and I didn't write a full suite, but I did a test of the creation just so I could add minimal testing that this flag was getting set, and added one of `purge_queue` because that was really needed. We really should do some better code coverage.

PyCharm was complaining about the mixed use of integers and floats in some of the processing of wait seconds, so I switched some of the 0's to 0.0's to appease it.

The change of chunk to a static was also because it was whining about that. Plus it made it easy to write a small unit test, so I figured why not?