### PR TITLE
PyCharm debugging support (C4-175)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ install:
 - pip install "moto[server]"
 script:
 - |
-  if test -n "$UNIT"; then bin/test -v -v --timeout=400 --aws-auth --cov snovault --es search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80;
+  if test -n "$UNIT"; then pytest -v -v --timeout=400 --aws-auth --cov snovault --es search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80;
   fi
 - |
   if [[ $TRAVIS_BRANCH == 'master' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ install:
 - pip install "moto[server]"
 script:
 - |
-  if test -n "$UNIT"; then pytest -v -v --timeout=400 --aws-auth --cov snovault --es search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80;
+  if test -n "$UNIT"; then pytest -vv --timeout=400 --aws-auth --cov snovault.tests --es search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80;
   fi
 - |
   if [[ $TRAVIS_BRANCH == 'master' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ install:
 - pip install "moto[server]"
 script:
 - |
-  if test -n "$UNIT"; then pytest -vv --timeout=400 --aws-auth --cov snovault.tests --es search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80;
+  if test -n "$UNIT"; then make travis-test;
   fi
 - |
   if [[ $TRAVIS_BRANCH == 'master' ]]; then

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 clean:
 	rm -rf *.egg-info
 
-configure:  # does any pre-requisite installs
+configure:
 	pip install poetry
 
 moto-setup:
@@ -21,12 +21,19 @@ build:
 	make moto-setup
 
 test:
-	bin/test -vv --timeout=400
+	pytest -vv --timeout=400 snovault
+
+update:
+	poetry update
+
+help:
+	@make info
 
 info:
 	@: $(info Here are some 'make' options:)
+	   $(info - Use 'make clean' to clear out (non-python) dependencies)
 	   $(info - Use 'make configure' to install poetry, though 'make build' will do it automatically.)
-	   $(info - Use 'make build' to install dependencies using poetry.)
-	   $(info - Use 'make macbuild' if 'make build' gets errors on MacOS Catalina.)
+	   $(info - Use 'make build' to build only application dependencies (or 'make macbuild' on OSX Catalina))
 	   $(info - Use 'make moto-setup' if you did 'poetry install' but did not set up moto for testing.)
 	   $(info - Use 'make test' to run tests with the normal options we use on travis)
+	   $(info - Use 'make update' to update dependencies (and the lock file))

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ build:
 test:
 	pytest -vv --timeout=400 --pyargs snovault.tests
 
+travis-test:
+	pytest -vv --timeout=400 --aws-auth --cov snovault.tests --es search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80
+
 update:
 	poetry update
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 clean:
 	rm -rf *.egg-info
 
-configure:
+configure:  # does any pre-requisite installs
 	pip install poetry
 
 moto-setup:
@@ -21,7 +21,7 @@ build:
 	make moto-setup
 
 test:
-	pytest -vv --timeout=400 snovault
+	pytest -vv --timeout=400 --pyargs snovault.tests
 
 update:
 	poetry update

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ build:
 	make moto-setup
 
 test:
-	pytest -vv --timeout=400 --pyargs snovault.tests
+	pytest -vv --timeout=400
 
 travis-test:
-	pytest -vv --timeout=400 --aws-auth --cov snovault.tests --es search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80
+	pytest -vv --timeout=400 --aws-auth --cov --es search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80
 
 update:
 	poetry update

--- a/conftest.py
+++ b/conftest.py
@@ -2,14 +2,6 @@ import pytest
 import tempfile
 
 
-# pytest_plugins = [
-#     'snovault.tests.serverfixtures',
-#     'snovault.tests.testappfixtures',
-#     'snovault.tests.toolfixtures',
-#     'snovault.tests.pyramidfixtures',
-# ]
-
-
 def pytest_addoption(parser):
     parser.addoption("--es", action="store", default="", dest='es',
         help="use a remote es for testing")

--- a/conftest.py
+++ b/conftest.py
@@ -2,12 +2,12 @@ import pytest
 import tempfile
 
 
-pytest_plugins = [
-    'snovault.tests.serverfixtures',
-    'snovault.tests.testappfixtures',
-    'snovault.tests.toolfixtures',
-    'snovault.tests.pyramidfixtures',
-]
+# pytest_plugins = [
+#     'snovault.tests.serverfixtures',
+#     'snovault.tests.testappfixtures',
+#     'snovault.tests.toolfixtures',
+#     'snovault.tests.pyramidfixtures',
+# ]
 
 
 def pytest_addoption(parser):

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,14 @@
 import pytest
+import tempfile
+
+
+pytest_plugins = [
+    'snovault.tests.serverfixtures',
+    'snovault.tests.testappfixtures',
+    'snovault.tests.toolfixtures',
+    'snovault.tests.pyramidfixtures',
+]
+
 
 def pytest_addoption(parser):
     parser.addoption("--es", action="store", default="", dest='es',
@@ -15,3 +25,7 @@ def remote_es(request):
 @pytest.fixture(scope='session')
 def aws_auth(request):
     return request.config.getoption("--aws-auth")
+
+
+def pytest_configure():
+    tempfile.tempdir = '/tmp'

--- a/conftest.py
+++ b/conftest.py
@@ -20,4 +20,7 @@ def aws_auth(request):
 
 
 def pytest_configure():
+    # This adjustment is important to set the default choice of temporary filenames to a nice short name
+    # because without it some of the filenames we generate end up being too long, and critical functionality
+    # ends up failing. Some socket-related filenames, for example, seem to have length limits. -kmp 5-Jun-2020
     tempfile.tempdir = '/tmp'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "dcicsnovault"
 # Version 3 drops support for Python 3.4 and 3.5, which neither Fourfront nor CGAP care about any more.
-version = "3.0.3"
+version = "3.1.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "dcicsnovault"
 # Version 3 drops support for Python 3.4 and 3.5, which neither Fourfront nor CGAP care about any more.
-version = "3.1.0"
+version = "3.0.4b0"  # will ultimately be "3.1.0", but for now consume betas on a patch version
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,10 +1,10 @@
 [pytest]
 log_cli_level = INFO
 addopts =
-#   -p snovault.tests.pyramidfixtures
-#   -p snovault.tests.toolfixtures
-#   -p snovault.tests.testappfixtures
-#   -p snovault.tests.serverfixtures
+    -p snovault.tests.pyramidfixtures
+    -p snovault.tests.toolfixtures
+    -p snovault.tests.testappfixtures
+    -p snovault.tests.serverfixtures
     --instafail
 markers =
     es: mark a test as an elastic search test (deselect with '-m "not es"')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,6 @@
 [pytest]
 log_cli_level = INFO
 addopts =
-    --pyargs snovault.tests
     --instafail
 markers =
     es: mark a test as an elastic search test (deselect with '-m "not es"')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,10 @@
 [pytest]
 log_cli_level = INFO
 addopts =
+#   -p snovault.tests.pyramidfixtures
+#   -p snovault.tests.toolfixtures
+#   -p snovault.tests.testappfixtures
+#   -p snovault.tests.serverfixtures
     --instafail
 markers =
     es: mark a test as an elastic search test (deselect with '-m "not es"')

--- a/snovault/tests/__init__.py
+++ b/snovault/tests/__init__.py
@@ -1,0 +1,2 @@
+from .test_indexing import INDEXER_NAMESPACE_FOR_TESTING
+

--- a/snovault/tests/conftest.py
+++ b/snovault/tests/conftest.py
@@ -9,14 +9,6 @@ from dcicutils.qa_utils import notice_pytest_fixtures
 from ..elasticsearch.indexer_queue import QueueManager
 
 
-pytest_plugins = [
-    'snovault.tests.serverfixtures',
-    'snovault.tests.testappfixtures',
-    'snovault.tests.toolfixtures',
-    'snovault.tests.pyramidfixtures',
-]
-
-
 # required so that db transactions are properly rolled back in tests
 @pytest.fixture(autouse=True)
 def autouse_external_tx(external_tx):

--- a/snovault/tests/conftest.py
+++ b/snovault/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 import logging
 import subprocess
 
+from dcicutils.qa_utils import notice_pytest_fixtures
 from ..elasticsearch.indexer_queue import QueueManager
 
 
@@ -19,6 +20,7 @@ pytest_plugins = [
 # required so that db transactions are properly rolled back in tests
 @pytest.fixture(autouse=True)
 def autouse_external_tx(external_tx):
+    notice_pytest_fixtures(external_tx)
     pass
 
 

--- a/snovault/tests/conftest.py
+++ b/snovault/tests/conftest.py
@@ -8,14 +8,6 @@ import subprocess
 from ..elasticsearch.indexer_queue import QueueManager
 
 
-# pytest_plugins = [
-#    'snovault.tests.serverfixtures',
-#    'snovault.tests.testappfixtures',
-#    'snovault.tests.toolfixtures',
-#    'snovault.tests.pyramidfixtures',
-#]
-
-
 # required so that db transactions are properly rolled back in tests
 @pytest.fixture(autouse=True)
 def autouse_external_tx(external_tx):

--- a/snovault/tests/conftest.py
+++ b/snovault/tests/conftest.py
@@ -5,14 +5,20 @@ import pytest
 import logging
 import subprocess
 
-from dcicutils.qa_utils import notice_pytest_fixtures
 from ..elasticsearch.indexer_queue import QueueManager
+
+
+# pytest_plugins = [
+#    'snovault.tests.serverfixtures',
+#    'snovault.tests.testappfixtures',
+#    'snovault.tests.toolfixtures',
+#    'snovault.tests.pyramidfixtures',
+#]
 
 
 # required so that db transactions are properly rolled back in tests
 @pytest.fixture(autouse=True)
 def autouse_external_tx(external_tx):
-    notice_pytest_fixtures(external_tx)
     pass
 
 

--- a/snovault/tests/test_key.py
+++ b/snovault/tests/test_key.py
@@ -6,11 +6,6 @@ from .. import DBSESSION
 
 # Test for storage.keys
 
-# pytest_plugins = [
-#     'snovault.tests.serverfixtures',
-#     'snovault.tests.testappfixtures',
-# ]
-
 items = [
     {'name': 'one', 'accession': 'TEST1'},
     {'name': 'two', 'accession': 'TEST2'},

--- a/snovault/tests/test_key.py
+++ b/snovault/tests/test_key.py
@@ -6,10 +6,10 @@ from .. import DBSESSION
 
 # Test for storage.keys
 
-pytest_plugins = [
-    'snovault.tests.serverfixtures',
-    'snovault.tests.testappfixtures',
-]
+# pytest_plugins = [
+#     'snovault.tests.serverfixtures',
+#     'snovault.tests.testappfixtures',
+# ]
 
 items = [
     {'name': 'one', 'accession': 'TEST1'},

--- a/snovault/tests/test_logging.py
+++ b/snovault/tests/test_logging.py
@@ -2,6 +2,7 @@ import json
 import pytest
 import structlog
 import time
+# import logging
 import yaml
 
 from unittest import mock

--- a/snovault/tests/test_logging.py
+++ b/snovault/tests/test_logging.py
@@ -2,7 +2,6 @@ import json
 import pytest
 import structlog
 import time
-# import logging
 import yaml
 
 from unittest import mock


### PR DESCRIPTION
Changes in this PR in service of making PyCharm debugging work better, per [C4-175](https://hms-dbmi.atlassian.net/browse/C4-175).

In particular, this will allow individual test functions to be executed in-place by context menu in PyCharm, with full display support, rather than having to escape to the command line `pdb`. This should make it easier to author unit tests in some cases, too, because the data needed to support their creation is more accessible in this mode.

The primary changes here are these. These changes are small and strategic, but important:

* Removed the mentions of what to test in `make` targets for testing, and also in the `pytest.ini`. These default reasonably already anyway, but especially it was essential in `pytest.ini` because otherwise attempts to test individual functions wouldn't work when PyCharm tried to, and all you'd get was whole-system or whole-module testing.  This change is the core/essential part of this PR.
* In order to make direct invocation of `pytest` work (without going through `bin/test`) I made two changes: (1) The modifications to `tempfile.tempdir` is needed to avoid too-long temp file names in some contexts, socket-related files for example. This used to be done by making a modification before loading testing, but now is harder to omit. (2) The logic for generating an indexer namespace for testing, and the new variable unsurprisingly named `INDEXER_NAMESPACE_FOR_TESTING` are moved down into the code when they were previously done outside. With these two fixes, `bin/test.py` is optional.
* In a future PR, we can disable and remove `bin/test` and `bin/test.py` as a consequence of these changes. For now I'm leaving them as harmless. (It does still take a command line argument to set up moto, though that can be done by other means.)
* Removed the programmatic mentions of plugins in favor of `-p` options in the `pytest.ini`. I'd rather not have done this, but `pytest` is recently quite fussy about _where_ these options can go anyway, so the idea of distributing them around your system is less of a modular thing than it used to be. It takes the strong position that they should be all in one place, and so I figured a declarative mode in the `pytest.ini` was best, and it seems to serve my goal.

Incidental/opportunistic other changes in this PR:

* Took the incantation for testing snovault on Travis out into a `make` target (`travis-test`). I did not add it to the list of documented things, since I don't think it's ordinarily helpful for people to invoke it. But I did want it to be easier to fish out when comparing behaviors on the local machine to those on Travis.
* Added `help` as a make target synonym for `info`. This is undocumented and mostly there to help people who don't know about `make info` and are just trying things.
* Added `update` as a `make` target to do `poetry update`. This does have doc in the list of things to try.
* Tidied up the `make` doc to align it better with other repos.

Notwithstanding approvals, I don't plan to merge this until I have parallel branches tested in CGAP and Fourfront.
