### PR TITLE
Miscellaneous small syntactic changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "dcicsnovault"
 # Version 3 drops support for Python 3.4 and 3.5, which neither Fourfront nor CGAP care about any more.
-version = "3.0.4b0"  # will ultimately be "3.1.0", but for now consume betas on a patch version
+version = "3.0.5"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/elasticsearch/indexer_queue.py
+++ b/snovault/elasticsearch/indexer_queue.py
@@ -5,14 +5,15 @@ First round will use a standard SQS queue from AWS without Elasticache.
 
 import datetime
 import json
-import socket
 import os
+import socket
 import time
 from collections import OrderedDict
 
 import boto3
 import structlog
 from dcicutils.env_utils import blue_green_mirror_env
+from dcicutils.misc_utils import ignored
 from pyramid.view import view_config
 
 from .indexer_utils import get_uuids_for_types
@@ -52,6 +53,7 @@ def queue_indexing(context, request):
     or a list of collections under "collections" key of its body. Can also
     optionally take "strict" boolean and "target_queue" string.
     """
+    ignored(context)
     req_uuids = request.json.get('uuids', None)
     req_collections = request.json.get('collections', None)
     # TODO: This variable is unused. Is it work-in-progress or something that should go away? -kmp 7-May-2020
@@ -112,6 +114,7 @@ def indexing_status(context, request):
     """
     Endpoint to check what is currently on the queue. Uses GET requests
     """
+    ignored(context)
     queue_indexer = request.registry[INDEXER_QUEUE]
     response = {}
     try:
@@ -133,6 +136,7 @@ def dlq_to_primary(context, request):
     """
     Endpoint to move all uuids on the DLQ to the primary queue
     """
+    ignored(context)
     queue_indexer = request.registry[INDEXER_QUEUE]
     # What comes out of .receive_messages() looks like:
     # [{
@@ -286,6 +290,7 @@ class QueueManager(object):
         Returns a list of queued uuids and a list of any uuids that failed to
         be queued.
         """
+        ignored(registry)
         curr_time = datetime.datetime.utcnow().isoformat()
         items = []
         for uuid in uuids:

--- a/snovault/tests/test_embed_utils.py
+++ b/snovault/tests/test_embed_utils.py
@@ -1,7 +1,8 @@
+import copy
 import pytest
 
-from copy import deepcopy
-from .. import TYPES
+from dcicutils.qa_utils import notice_pytest_fixtures
+from .. import TYPES  # noqa - PyCharm wrongly fusses that we're trying to use an obsolete 'types' library here.
 from ..util import (
     build_default_embeds,
     find_default_embeds_for_schema,
@@ -12,11 +13,15 @@ from ..util import (
 from .toolfixtures import registry
 
 
+notice_pytest_fixtures(registry)
+
+
 def test_find_collection_subtypes(app):
     test_item_type = 'AbstractItemTest'
     expected_types = ['abstract_item_test_second_sub_item', 'abstract_item_test_sub_item']
     res = find_collection_subtypes(app.registry, test_item_type)
     assert sorted(res) == expected_types
+
 
 def test_build_default_embeds():
     embeds_to_add = ['obj1.obj2', 'obj1', 'obj1.obj3.*']
@@ -33,6 +38,7 @@ def test_build_default_embeds():
     ]
     assert(set(final_embeds) == set(expected_embeds))
 
+
 def test_find_default_embeds_and_expand_emb_list(registry):
     # use EmbeddingTest as test case
     # 'attachment' -> linkTo TestingDownload
@@ -43,9 +49,18 @@ def test_find_default_embeds_and_expand_emb_list(registry):
     assert(set(default_embeds) == set(expected_embeds))
 
     # get expansions from 'attachment'
-    dummy_emb_list = [emb + '.*' if not emb.endswith('*') else emb for emb in expected_embeds ]
+    dummy_emb_list = [
+        emb + '.*'
+        if not emb.endswith('*') else emb
+        for emb in expected_embeds
+    ]
     embs_to_add, _ = expand_embedded_list('EmbeddingTest', registry[TYPES], dummy_emb_list, schema_props, set())
-    expected_to_add = ['attachment', 'attachment.attachment.*', 'attachment.attachment2.*', 'attachment.principals_allowed.*']
+    expected_to_add = [
+        'attachment',
+        'attachment.attachment.*',
+        'attachment.attachment2.*',
+        'attachment.principals_allowed.*'
+    ]
     assert(set(embs_to_add) == set(expected_to_add))
 
     # add default embeds for all items 'attachment'
@@ -54,12 +69,15 @@ def test_find_default_embeds_and_expand_emb_list(registry):
     expected_to_add2 = ['attachment']
     assert(set(embs_to_add2) == set(expected_to_add2))
     # lastly check the built embeds
-    expected_built = ['attachment.display_title',
-                      'attachment.@type',
-                      'attachment.uuid',
-                      'attachment.@id',
-                      'attachment.principals_allowed.*']
+    expected_built = [
+        'attachment.display_title',
+        'attachment.@type',
+        'attachment.uuid',
+        'attachment.@id',
+        'attachment.principals_allowed.*'
+    ]
     assert set(expected_built) == set(build_default_embeds(embs_to_add2, set()))
+
 
 def test_crawl_schema(registry):
     field_path = 'attachment.@type'
@@ -88,7 +106,7 @@ def test_crawl_schema(registry):
 
     # screw with the schema to create an invalid linkTo
     embedding_schema = registry[TYPES].by_item_type['embedding_test'].schema
-    schema_copy = deepcopy(embedding_schema)
+    schema_copy = copy.deepcopy(embedding_schema)
     schema_copy['properties']['attachment']['linkTo'] = 'NotAnItem'
     with pytest.raises(Exception) as exec_info4:
         crawl_schema(registry[TYPES], field_path, schema_copy)

--- a/snovault/tests/test_embedding.py
+++ b/snovault/tests/test_embedding.py
@@ -1,11 +1,15 @@
 import pytest
 
+from dcicutils.qa_utils import ignored, notice_pytest_fixtures
 from re import findall
-from .. import TYPES
+from .. import TYPES  # noqa - PyCharm wrongly fusses that we're trying to use an obsolete 'types' library here.
 from ..util import add_default_embeds, crawl_schemas_by_embeds
 from .pyramidfixtures import dummy_request, threadlocals
 from .test_views import PARAMETERIZED_NAMES
 from .toolfixtures import registry, root
+
+
+notice_pytest_fixtures(dummy_request, threadlocals, registry, root)
 
 
 targets = [
@@ -39,6 +43,7 @@ def convert_names_to_snake():
         res.append(snake)
     return res
 
+
 SNAKE_NAMES = convert_names_to_snake()
 
 
@@ -58,6 +63,7 @@ def test_add_default_embeds(registry, item_type):
     """
     Ensure default embedding matches the schema for each object
     """
+    notice_pytest_fixtures(registry)
     type_info = registry[TYPES].by_item_type[item_type]
     schema = type_info.schema
     embeds = add_default_embeds(item_type, registry[TYPES], type_info.embedded_list, schema)
@@ -77,6 +83,7 @@ def test_manual_embeds(registry, item_type):
     """
     Ensure manual embedding in the types files are valid
     """
+    notice_pytest_fixtures(registry)
     type_info = registry[TYPES].by_item_type[item_type]
     schema = type_info.schema
     embeds = type_info.embedded_list
@@ -85,7 +92,9 @@ def test_manual_embeds(registry, item_type):
         error, _ = crawl_schemas_by_embeds(item_type, registry[TYPES], split_embed, schema['properties'])
         assert error is None
 
+
 def test_linked_uuids_unset(content, dummy_request, threadlocals):
+    notice_pytest_fixtures(content, dummy_request, threadlocals)
     # without setting _indexing_view = True on the request,
     # _linked_uuids not tracked and _sid_cache not populated in resource.py
     dummy_request.embed('/testing-link-sources-sno/', sources[0]['uuid'], '@@object')
@@ -94,6 +103,7 @@ def test_linked_uuids_unset(content, dummy_request, threadlocals):
 
 
 def test_linked_uuids_object(content, dummy_request, threadlocals):
+    notice_pytest_fixtures(content, dummy_request, threadlocals)
     # needed to track _linked_uuids
     dummy_request._indexing_view = True
     dummy_request.embed('/testing-link-sources-sno/', sources[0]['uuid'], '@@object')
@@ -103,10 +113,14 @@ def test_linked_uuids_object(content, dummy_request, threadlocals):
 
 
 def test_linked_uuids_embedded(content, dummy_request, threadlocals):
+    notice_pytest_fixtures(content, dummy_request, threadlocals)
     # needed to track _linked_uuids
     dummy_request._indexing_view = True
     dummy_request.embed('/testing-link-sources-sno/', sources[0]['uuid'], '@@embedded')
-    assert dummy_request._linked_uuids == {'16157204-8c8f-4672-a1a4-14f4b8021fcd', '775795d3-4410-4114-836b-8eeecf1d0c2f'}
+    assert dummy_request._linked_uuids == {
+        '16157204-8c8f-4672-a1a4-14f4b8021fcd',
+        '775795d3-4410-4114-836b-8eeecf1d0c2f'
+    }
     # _rev_linked_uuids_by_item is in form {target uuid: set(source uuid)}
     assert dummy_request._rev_linked_uuids_by_item == {
         '775795d3-4410-4114-836b-8eeecf1d0c2f': {'reverse': ['16157204-8c8f-4672-a1a4-14f4b8021fcd']}
@@ -115,10 +129,14 @@ def test_linked_uuids_embedded(content, dummy_request, threadlocals):
 
 
 def test_linked_uuids_page(content, dummy_request, threadlocals):
+    notice_pytest_fixtures(content, dummy_request, threadlocals)
     # needed to track _linked_uuids
     dummy_request._indexing_view = True
     dummy_request.embed('/testing-link-sources-sno/', sources[0]['uuid'], '@@page')
-    assert dummy_request._linked_uuids == {'16157204-8c8f-4672-a1a4-14f4b8021fcd', '775795d3-4410-4114-836b-8eeecf1d0c2f'}
+    assert dummy_request._linked_uuids == {
+        '16157204-8c8f-4672-a1a4-14f4b8021fcd',
+        '775795d3-4410-4114-836b-8eeecf1d0c2f'
+    }
     assert dummy_request._rev_linked_uuids_by_item == {
         '775795d3-4410-4114-836b-8eeecf1d0c2f': {'reverse': ['16157204-8c8f-4672-a1a4-14f4b8021fcd']}
     }
@@ -126,11 +144,15 @@ def test_linked_uuids_page(content, dummy_request, threadlocals):
 
 
 def test_linked_uuids_expand_target(content, dummy_request, threadlocals):
+    notice_pytest_fixtures(content, dummy_request, threadlocals)
     # needed to track _linked_uuids
     dummy_request._indexing_view = True
     dummy_request.embed('/testing-link-sources-sno/', sources[0]['uuid'], '@@expand?expand=target')
     # expanding does not add to the embedded_list
-    assert dummy_request._linked_uuids == {'16157204-8c8f-4672-a1a4-14f4b8021fcd', '775795d3-4410-4114-836b-8eeecf1d0c2f'}
+    assert dummy_request._linked_uuids == {
+        '16157204-8c8f-4672-a1a4-14f4b8021fcd',
+        '775795d3-4410-4114-836b-8eeecf1d0c2f'
+    }
     assert dummy_request._rev_linked_uuids_by_item == {
         '775795d3-4410-4114-836b-8eeecf1d0c2f': {'reverse': ['16157204-8c8f-4672-a1a4-14f4b8021fcd']}
     }
@@ -138,6 +160,7 @@ def test_linked_uuids_expand_target(content, dummy_request, threadlocals):
 
 
 def test_linked_uuids_index_data(content, dummy_request, threadlocals):
+    notice_pytest_fixtures(content, dummy_request, threadlocals)
     # this is the main view use to create data model for indexing
     # automatically sets request._indexing_view and will populate
     # a number of different attributes on the request
@@ -152,11 +175,11 @@ def test_linked_uuids_index_data(content, dummy_request, threadlocals):
         assert dummy_request._sid_cache.get(rid) == found_sid
 
     # embedded view linked uuids are unchanged
-    assert dummy_request._linked_uuids == set([l['uuid'] for l in res['linked_uuids_embedded']])
+    assert dummy_request._linked_uuids == set([linked['uuid'] for linked in res['linked_uuids_embedded']])
     assert res['rev_link_names'] == {}
     assert res['rev_linked_to_me'] == [targets[0]['uuid']]
     # object view linked uuids are contained within the embedded linked uuids
-    assert set([l['uuid'] for l in res['linked_uuids_object']]) <= dummy_request._linked_uuids
+    assert set([linked['uuid'] for linked in res['linked_uuids_object']]) <= dummy_request._linked_uuids
 
     # now test the target. this will reset all attributes on dummy_request
     res2 = dummy_request.embed('/testing-link-targets-sno/', targets[0]['uuid'], '@@index-data', as_user='INDEXER')
@@ -169,3 +192,4 @@ def test_linked_uuids_index_data(content, dummy_request, threadlocals):
     # sources[1]['uuid'] does not show up because it has status=deleted (no rev_link)
     res3 = dummy_request.embed('/testing-link-targets-sno/', targets[1]['uuid'], '@@index-data', as_user='INDEXER')
     assert {sources[0]['uuid'], targets[0]['uuid'], targets[1]['uuid']} <= set(dummy_request._sid_cache)
+    ignored(res3)

--- a/snovault/tests/test_indexing.py
+++ b/snovault/tests/test_indexing.py
@@ -224,7 +224,7 @@ def test_indexer_queue_adds_telemetry_id(app):
 @pytest.mark.flaky
 def test_indexer_queue(app):
     indexer_queue_mirror = app.registry[INDEXER_QUEUE_MIRROR]
-    # this is only set up for webprod/webprod2
+    # An indexing queue mirror would only be set up for production servers.
     assert indexer_queue_mirror is None
 
     indexer_queue = app.registry[INDEXER_QUEUE]

--- a/snovault/tests/test_key.py
+++ b/snovault/tests/test_key.py
@@ -1,7 +1,13 @@
 import pytest
 
+from dcicutils.qa_utils import notice_pytest_fixtures
 from pyramid.config import Configurator
 from .. import DBSESSION
+from .serverfixtures import DBSession
+from .testappfixtures import testapp
+
+
+notice_pytest_fixtures(DBSession, testapp)
 
 
 # Test for storage.keys
@@ -19,6 +25,7 @@ bad_items = [
 
 @pytest.fixture(scope='session')
 def app(DBSession):
+    notice_pytest_fixtures(DBSession)
     config = Configurator()
     config.registry[DBSESSION] = DBSession
     config.include('snovault')
@@ -28,6 +35,7 @@ def app(DBSession):
 
 @pytest.fixture
 def content(testapp):
+    notice_pytest_fixtures(testapp)
     url = '/testing-keys/'
     for item in items:
         testapp.post_json(url, item, status=201)
@@ -35,18 +43,21 @@ def content(testapp):
 
 @pytest.mark.parametrize('item', items)
 def test_unique_key(testapp, content, item):
+    notice_pytest_fixtures(testapp, content)
     url = '/testing-keys/' + item['accession']
     res = testapp.get(url).maybe_follow()
     assert res.json['name'] == item['name']
 
 
 def test_keys_bad_items(testapp, content):
+    notice_pytest_fixtures(testapp, content)
     url = '/testing-keys/'
     for item in bad_items:
         testapp.post_json(url, item, status=409)
 
 
 def test_keys_update(testapp):
+    notice_pytest_fixtures(testapp)
     url = '/testing-keys/'
     item = items[0]
     res = testapp.post_json(url, item, status=201)
@@ -58,6 +69,7 @@ def test_keys_update(testapp):
 
 
 def test_keys_conflict(testapp):
+    notice_pytest_fixtures(testapp)
     url = '/testing-keys/'
     item = items[1]
     initial = testapp.get(url).json['@graph']

--- a/snovault/tests/test_schemas.py
+++ b/snovault/tests/test_schemas.py
@@ -1,8 +1,13 @@
 import pytest
-from .. import TYPES
+
+from dcicutils.qa_utils import notice_pytest_fixtures
+from .. import TYPES  # noqa - PyCharm wrongly fusses that we're trying to use an obsolete 'types' library here.
 from ..schema_utils import load_schema
 from .test_views import PARAMETERIZED_NAMES
 from .toolfixtures import registry
+
+
+notice_pytest_fixtures(registry)
 
 
 @pytest.mark.parametrize('schema', PARAMETERIZED_NAMES)

--- a/snovault/tests/test_views.py
+++ b/snovault/tests/test_views.py
@@ -4,7 +4,7 @@ import pytest
 from base64 import b64encode
 from jsonschema_serialize_fork import Draft4Validator
 from pyramid.compat import ascii_native_
-from .. import TYPES
+from .. import TYPES  # noqa - PyCharm wrongly fusses that we're trying to use an obsolete 'types' library here.
 from .toolfixtures import registry, root
 
 
@@ -14,6 +14,7 @@ TYPE_NAMES = ['TestingPostPutPatchSno', 'TestingDownload']
 def get_parameterized_names():
     """ Get all item types from schema names """
     return [name.split('.')[0] for name in os.listdir(os.getcwd() + '/snovault/test_schemas')]
+
 
 PARAMETERIZED_NAMES = get_parameterized_names()
 
@@ -72,15 +73,15 @@ def test_collection_limit(testapp):
     """ Post 3 EmbeddingTests, check that limit=all, limit=2 works """
     obj1 = {
         'title': "Testing1",
-        'description': "This is testig object 1",
+        'description': "This is testing object 1",
     }
     obj2 = {
         'title': "Testing2",
-        'description': "This is testig object 2",
+        'description': "This is testing object 2",
     }
     obj3 = {
         'title': "Testing3",
-        'description': "This is testig object 3",
+        'description': "This is testing object 3",
     }
     testapp.post_json('/embedding-tests', obj1, status=201)
     testapp.post_json('/embedding-tests', obj2, status=201)


### PR DESCRIPTION
I was bringing some old branches up-to-date with recent changes and in the process had various typos and PEP8-related changes I'd made that I wanted to just get merged, separately from anything important. Please tell me if there's anything even slightly suspicious in here, but I intended this to be semantics-preserving. This will make a number of the test files be free of nagging about PEP8 from both PyCharm and (when we eventually start using it) flake8. There are still way too many syntax issues to use flake8 in a real way, but at least this moves us closer.

