### PR TITLE
Add a 'make publish' in case auto-publish fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ travis-test:
 update:
 	poetry update
 
+publish:
+	scripts/publish
+
 help:
 	@make info
 

--- a/bin/publish
+++ b/bin/publish
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+if [ -z "$PYPI_USER" ]; then
+    echo '$PYPI_USER is not set.'
+    exit 1
+fi    
+
+if [ -z "$PYPI_PASSWORD" ]; then
+    echo '$PYPI_PASSWORD is not set.'
+    exit 1    
+fi
+
+changes=`git diff`
+
+if [ -n "${changes}" ]; then
+  echo "You have made changes to this branch that you have not committed."
+  exit 1
+fi
+
+staged_changes=`git diff --staged`
+
+if [ -n "${staged_changes}" ]; then
+  echo "You have staged changes to this branch that you have not committed."
+  exit 1
+fi
+
+tagged=`git log -1 --decorate | head -1 | grep 'tag:'`
+
+if [ -z "$tagged" ]; then
+  # We don't encourage people to tag it unless they have no changes pending.
+  echo "You can only publish a tagged commit."
+  exit 1
+fi
+
+read -p "Are you sure you want to publish $(poetry version) to PyPi? "
+REPLY=`echo "$REPLY" | tr '[:upper:]' '[:lower:]'`
+if [ "$REPLY" != 'y' ] && [ "$REPLY" != "yes" ]
+then
+  echo "Publishing aborted."
+  exit 1
+fi
+
+poetry publish --no-interaction --build --username=$PYPI_USER --password=$PYPI_PASSWORD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "dcicsnovault"
 # Version 3 drops support for Python 3.4 and 3.5, which neither Fourfront nor CGAP care about any more.
-version = "3.1.1"
+version = "3.1.2"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Sometimes 'make publish' fails and it's useful to have an auto-publish script. This same script is used in other repos and is written in an repo-independent way so should work fine here, as well. Feel free to review it anew, but also to compare to what's in, say, the utils library and you'll see it's the same as what's already installed and working there.

I did not adjust the help documentation for 'make' because this is not something commonly to be used and I've been trying to think of that help information as things regular users should use. We might want to consider breaking help into two categories, showing a separate list for maintenance operations. But for now I didn't bother.
