### PR TITLE
Make wsgi_server fixture use clear_untrusted_proxy_headers=True (C4-200)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "dcicsnovault"
 # Version 3 drops support for Python 3.4 and 3.5, which neither Fourfront nor CGAP care about any more.
-version = "3.1.2"
+version = "3.1.3b0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "dcicsnovault"
 # Version 3 drops support for Python 3.4 and 3.5, which neither Fourfront nor CGAP care about any more.
-version = "3.1.3b0"
+version = "3.1.4"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/tests/serverfixtures.py
+++ b/snovault/tests/serverfixtures.py
@@ -427,6 +427,7 @@ def wsgi_server(request, wsgi_server_app, wsgi_server_host_port):
         channel_timeout=60,
         cleanup_interval=10,
         expose_tracebacks=True,
+        clear_untrusted_proxy_headers=True,
     )
     assert server.wait()
 


### PR DESCRIPTION
Adjust `wsgi_server` fixture to pass `clear_untrusted_proxy_headers=True` as keyword arguments, which a deprecation warning is telling us will soon become the default.

Traditionally, this value has been unspecified, and we've been just quietly accepting the default (of `False`) but the default will be at some point incompatibly changed to `True`. The warning is telling us that we can set it explicitly to `False` if we want, but my hunch is that we don't mind this being `True`. It seems safer to do that. I don't like the idea of trusting untrusted proxy headers. :)

This fixture is not really used in `snovault` but is used by import in `cgap-portal` (and probably in `fourfront` as well). I've got a `cgap-portal` branch testing this (as v3.1.3b0) to make sure we're OK with it. I'll do the same with `fourfront` before assuming it's properly tested.