### PR TITLE
C4-253 Allow calculated properties on sub-embedded objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
   curl -X POST -d "branches=master" -d "token=$DOCS_TOKEN" https://readthedocs.org/api/v2/webhook/snovault/99596/
   fi
 - echo $TRAVIS_JOB_ID
-- poetry run wipe-test-indices $TRAVIS_JOB_ID search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80
+- poetry run wipe-test-indices $TRAVIS_JOB_ID search-fourfront-testing-hjozudm7pq5wwlssx2pjlsyz7y.us-east-1.es.amazonaws.com:80
 after_script:
 - if [ "$TRAVIS_PYTHON_VERSION" == "3.6" ]; then coveralls; fi
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test:
 	pytest -vv --timeout=200
 
 travis-test:
-	pytest -vv --timeout=200 --aws-auth --cov --es search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80
+	pytest -vv --timeout=200 --aws-auth --cov --es search-fourfront-testing-hjozudm7pq5wwlssx2pjlsyz7y.us-east-1.es.amazonaws.com:80
 
 update:
 	poetry update

--- a/docs/source/object-lifecycle.rst
+++ b/docs/source/object-lifecycle.rst
@@ -31,7 +31,7 @@ This is the default object returned if frame is not specified.  It is the frame=
 
 
 Submission (POST)
-----------
+-----------------
 
 POST /biosample::
 
@@ -55,6 +55,7 @@ Validation
 * Link resolution
 * Value format validation
 * Permission checking
+* Are calculated properties legal?
 
 
 Link resolution
@@ -148,7 +149,7 @@ Rendering
             -> page expansion
 
 
-Link canonicalization
+Link Canonicalization
 ---------------------
 
 Specified in the schema. UUID's are converted to resource paths.
@@ -162,7 +163,7 @@ Specified in the schema. UUID's are converted to resource paths.
     }
 
 
-Calculated properties
+Calculated Properties
 ---------------------
 
 These include the JSON-LD boilerplate along with other dynamically calculated properties such as a consistently formatted title and reverse links pulled from the links table.
@@ -176,6 +177,7 @@ These include the JSON-LD boilerplate along with other dynamically calculated pr
         "characterizations": [],
     }
 
+Calculated properties can be top level fields or sub-embedded object fields. See the end of testing_views.py to see how one would declare a calculated property on a sub-embedded object. 
 
 JSON result
 -----------

--- a/docs/source/object-lifecycle.rst
+++ b/docs/source/object-lifecycle.rst
@@ -177,7 +177,7 @@ These include the JSON-LD boilerplate along with other dynamically calculated pr
         "characterizations": [],
     }
 
-Calculated properties can be top level fields or sub-embedded object fields. See the end of testing_views.py to see how one would declare a calculated property on a sub-embedded object. 
+Calculated properties can be top level fields or sub-embedded object fields. See the end of testing_views.py to see how one would declare a calculated property on a sub-embedded object.
 
 JSON result
 -----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "dcicsnovault"
 # Version 3 drops support for Python 3.4 and 3.5, which neither Fourfront nor CGAP care about any more.
-version = "3.1.9"
+version = "3.2.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/calculated.py
+++ b/snovault/calculated.py
@@ -189,7 +189,6 @@ def calculate_properties(context, request, ns=None, category='object'):
     if isinstance(context, type):
         context = None
     namespace = ItemNamespace(context, request, defined, ns)
-    import pdb; pdb.set_trace()
     return {
         name: value
         for name, value in (

--- a/snovault/calculated.py
+++ b/snovault/calculated.py
@@ -189,6 +189,7 @@ def calculate_properties(context, request, ns=None, category='object'):
     if isinstance(context, type):
         context = None
     namespace = ItemNamespace(context, request, defined, ns)
+    import pdb; pdb.set_trace()
     return {
         name: value
         for name, value in (

--- a/snovault/resource_views.py
+++ b/snovault/resource_views.py
@@ -29,6 +29,7 @@ from .util import (
     check_es_and_cache_linked_sids,
     validate_es_content,
     debug_log,
+    merge_calculated_into_properties
 )
 from .util import filter_embedded
 
@@ -80,7 +81,7 @@ def collection_view_listing_db(context, request):
 def home(context, request):
     properties = request.embed(request.resource_path(context), '@@object')
     calculated = calculate_properties(context, request, properties, category='page')
-    properties.update(calculated)
+    merge_calculated_into_properties(properties, calculated)
     return properties
 
 
@@ -90,7 +91,7 @@ def home(context, request):
 def collection_view_object(context, request):
     properties = context.__json__(request)
     calculated = calculate_properties(context, request, properties)
-    properties.update(calculated)
+    merge_calculated_into_properties(properties, calculated)
     return properties
 
 
@@ -100,7 +101,7 @@ def collection_list(context, request):
     path = request.resource_path(context)
     properties = request.embed(path, '@@object')
     calculated = calculate_properties(context, request, properties, category='page')
-    properties.update(calculated)
+    merge_calculated_into_properties(properties, calculated)
 
     if request.query_string:
         properties['@id'] += '?' + request.query_string
@@ -168,7 +169,7 @@ def item_view_object(context, request):
 
     properties = context.item_with_links(request)
     calculated = calculate_properties(context, request, properties)
-    properties.update(calculated)
+    merge_calculated_into_properties(properties, calculated)
     return properties
 
 
@@ -236,7 +237,7 @@ def item_view_page(context, request):
     item_path = request.resource_path(context)
     properties = request.embed(item_path, '@@embedded', as_user=True)
     calculated = calculate_properties(context, request, properties, category='page')
-    properties.update(calculated)
+    merge_calculated_into_properties(properties, calculated)
     return properties
 
 

--- a/snovault/schema_utils.py
+++ b/snovault/schema_utils.py
@@ -244,7 +244,14 @@ def validators(validator, validators, instance, schema):
 
 
 def calculatedProperty(validator, linkTo, instance, schema):
-    yield ValidationError('submission of calculatedProperty disallowed')
+    """ This is the validator for calculatedProperty - if we see this field on a submitted item
+        we (normally) emit ValidationError since calculated properties cannot be submitted.
+
+        NEW: allow "submission of calculated properties" if the schema type is object in which case
+        we could be updating sub-embedded-object properties
+    """
+    if schema.get('type', None) != 'object' or not schema.get('sub-embedded', False):
+        yield ValidationError('submission of calculatedProperty disallowed')
 
 
 class SchemaValidator(Draft4Validator):

--- a/snovault/schema_utils.py
+++ b/snovault/schema_utils.py
@@ -250,7 +250,7 @@ def calculatedProperty(validator, linkTo, instance, schema):
         NEW: allow "submission of calculated properties" if the schema type is object in which case
         we could be updating sub-embedded-object properties
     """
-    if schema.get('type', None) != 'object' or not schema.get('sub-embedded', False):
+    if schema.get('type', None) not in ['object', 'array'] or not schema.get('sub-embedded', False):
         yield ValidationError('submission of calculatedProperty disallowed')
 
 

--- a/snovault/schema_utils.py
+++ b/snovault/schema_utils.py
@@ -263,7 +263,7 @@ def calculatedProperty(validator, linkTo, instance, schema):
         return schema.get('type') == 'array' and schema_is_object(schema.get('items', {}))
 
     if not schema_is_sub_embedded(schema) or (
-        not schema_is_array_of_objects(schema) or not schema_is_object(schema)):
+        not schema_is_array_of_objects(schema) and not schema_is_object(schema)):
         yield ValidationError('submission of calculatedProperty disallowed')
 
 

--- a/snovault/test_schemas/TestingCalculatedProperties.json
+++ b/snovault/test_schemas/TestingCalculatedProperties.json
@@ -1,0 +1,33 @@
+{
+  "title": "Testing Calculated Properties",
+  "description": "Test object that has calculated properties to test",
+  "type": "object",
+  "required": ["name", "foo", "bar"],
+  "properties": {
+    "schema_version": {
+      "type": "object",
+      "default": "1"
+    },
+    "name": {
+      "type": "string",
+      "uniqueKey": true
+    },
+    "foo": {
+      "type": "string"
+    },
+    "bar": {
+      "type": "string"
+    },
+    "nested": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/snovault/test_schemas/TestingCalculatedProperties.json
+++ b/snovault/test_schemas/TestingCalculatedProperties.json
@@ -2,7 +2,7 @@
   "title": "Testing Calculated Properties",
   "description": "Test object that has calculated properties to test",
   "type": "object",
-  "required": ["name", "foo", "bar"],
+  "required": ["name", "foo", "bar", "nested", "nested2"],
   "properties": {
     "schema_version": {
       "type": "object",
@@ -26,6 +26,20 @@
         },
         "value": {
           "type": "string"
+        }
+      }
+    },
+    "nested2" : {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
         }
       }
     }

--- a/snovault/tests/test_calculated.py
+++ b/snovault/tests/test_calculated.py
@@ -24,5 +24,5 @@ def test_calculated_build_object(testapp, basic_calculated_item):
     for k in ['name', 'foo', 'bar']:
         assert k in res['combination']
     nested = res['nested']
-    for k in ['key', 'value', 'keyvalue']:  # XXX: get this to work
+    for k in ['key', 'value', 'keyvalue']:
         assert k in nested

--- a/snovault/tests/test_calculated.py
+++ b/snovault/tests/test_calculated.py
@@ -13,7 +13,17 @@ def basic_calculated_item():
         'nested': {
             'key': 'foo',
             'value': 'bar'
-        }
+        },
+        'nested2': [
+            {
+                'key': 'foo',
+                'value': 'bar'
+            },
+            {
+                'key': 'bar',
+                'value': 'foo'
+            }
+        ]
     }
 
 
@@ -26,3 +36,7 @@ def test_calculated_build_object(testapp, basic_calculated_item):
     nested = res['nested']
     for k in ['key', 'value', 'keyvalue']:
         assert k in nested
+    nested2 = res['nested2']
+    for k in ['key', 'value', 'keyvalue']:
+        for entry in nested2:
+            assert k in entry

--- a/snovault/tests/test_calculated.py
+++ b/snovault/tests/test_calculated.py
@@ -20,8 +20,8 @@ def basic_calculated_item():
                 'value': 'bar'
             },
             {
-                'key': 'bar',
-                'value': 'foo'
+                'key': 'apple',
+                'value': 'orange'
             }
         ]
     }
@@ -34,8 +34,8 @@ def test_calculated_build_object(testapp, basic_calculated_item):
     for k in ['name', 'foo', 'bar']:
         assert k in res['combination']
     nested = res['nested']
-    for k in ['key', 'value', 'keyvalue']:
-        assert k in nested
+    for k, v in zip(['key', 'value', 'keyvalue'], ['foo', 'bar', 'foobar']):
+        assert nested[k] == v
     nested2 = res['nested2']
     for k in ['key', 'value', 'keyvalue']:
         for entry in nested2:

--- a/snovault/tests/test_calculated.py
+++ b/snovault/tests/test_calculated.py
@@ -1,0 +1,28 @@
+import pytest
+
+
+CONNECTION_URL = '/TestingCalculatedProperties'
+
+
+@pytest.fixture
+def basic_calculated_item():
+    return {
+        'name': 'cat',
+        'foo': 'dog',
+        'bar': 'mouse',
+        'nested': {
+            'key': 'foo',
+            'value': 'bar'
+        }
+    }
+
+
+def test_calculated_build_object(testapp, basic_calculated_item):
+    """ Tests that we can run calculated properties """
+    [res] = testapp.post_json(CONNECTION_URL, basic_calculated_item, status=201).json['@graph']
+    assert 'combination' in res
+    for k in ['name', 'foo', 'bar']:
+        assert k in res['combination']
+    nested = res['nested']
+    for k in ['key', 'value', 'keyvalue']:  # XXX: get this to work
+        assert k in nested

--- a/snovault/tests/test_create_mapping.py
+++ b/snovault/tests/test_create_mapping.py
@@ -39,6 +39,15 @@ def test_type_mapping(registry, item_type):
         if item_type == 'TestingLinkTargetElasticSearch':
             assert mapping['properties']['reverse_es'].get('type', 'object') != 'nested'  # should not occur here
 
+        # check calculated properties on objects/arrays of objects are mapped correctly
+        if item_type == 'TestingCalculatedProperties':
+            assert mapping['properties']['nested']['properties']['key']['type'] == 'text'
+            assert mapping['properties']['nested']['properties']['value']['type'] == 'text'
+            assert mapping['properties']['nested']['properties']['keyvalue']['type'] == 'text'
+            assert mapping['properties']['nested2']['properties']['key']['type'] == 'text'
+            assert mapping['properties']['nested2']['properties']['value']['type'] == 'text'
+            assert mapping['properties']['nested2']['properties']['keyvalue']['type'] == 'text'
+
 
 def test_type_mapping_nested(registry):
     """

--- a/snovault/tests/test_util.py
+++ b/snovault/tests/test_util.py
@@ -125,3 +125,43 @@ def test_merge_calculated_into_properties(simple_properties, simple_calculated, 
     with pytest.raises(ValueError):
         props_copy = copy.deepcopy(simple_properties)
         merge_calculated_into_properties(props_copy, failure_calculated2)
+
+
+@pytest.fixture
+def complex_properties():
+    return {
+        'abc': 123,
+        'nested': [
+            {
+                'key': 'hello',
+                'value': 'world'
+            },
+            {
+                'key': 'dog',
+                'value': 'cat'
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def calculated_list():
+    return {
+        'nested': [
+            {
+                'keyvalue': 'helloworld'
+            },
+            {
+                'keyvalue': 'dogcat'
+            }
+        ]
+    }
+
+
+def test_merge_calculated_into_properties_array(complex_properties, calculated_list):
+    """ Tests that we can do calculated properties on arrays of sub-embedded objects """
+    props_copy = copy.deepcopy(complex_properties)
+    merge_calculated_into_properties(props_copy, calculated_list)
+    for entry in props_copy['nested']:
+        for field in ['key', 'value', 'keyvalue']:
+            assert field in entry

--- a/snovault/tests/test_util.py
+++ b/snovault/tests/test_util.py
@@ -1,5 +1,7 @@
 import pytest
-from ..util import dictionary_lookup, DictionaryKeyError
+import copy
+from ..util import dictionary_lookup, DictionaryKeyError, merge_calculated_into_properties
+
 
 def test_dictionary_lookup():
 
@@ -38,3 +40,88 @@ def test_dictionary_lookup():
     else:
         pass
         #raise AssertionError("No exception was raised where one was expected.")
+
+
+@pytest.fixture
+def simple_properties():
+    return {
+        'abc': 123,
+        'animal': 'dog',
+        'feline': 'cat',
+        'names': {
+            'will': 'dog',
+            'bob': 'truck'
+        }
+    }
+
+
+@pytest.fixture
+def simple_calculated():
+    return {
+        'abcd': 1234
+    }
+
+
+@pytest.fixture
+def complex_calculated():
+    return {
+        'abcd': 1234,
+        'names': {
+            'dog': 'will',
+            'truck': 'bob'
+        }
+    }
+
+
+@pytest.fixture
+def failure_calculated1():
+    return {
+        'abc': 456
+    }
+
+
+@pytest.fixture
+def failure_calculated2():
+    return {
+        'names': {
+            'will': 'canine'
+        }
+    }
+
+
+def check_original_props(props):
+    """ Helper function that verifies correctness of the original fields, see fixture above """
+    assert 'abc' in props
+    assert 'animal' in props
+    assert 'feline' in props
+    assert 'names' in props
+    assert 'will' in props['names']
+    assert 'bob' in props['names']
+
+
+def test_merge_calculated_into_properties(simple_properties, simple_calculated, complex_calculated,
+                                          failure_calculated1, failure_calculated2):
+    """ Tests some base cases with merging calculated into properties """
+    # merge in one field - all should be the same
+    props_copy = copy.deepcopy(simple_properties)
+    merge_calculated_into_properties(props_copy, simple_calculated)
+    check_original_props(props_copy)
+    assert 'abcd' in props_copy
+
+    # merge calculated sub-embedded fields
+    props_copy = copy.deepcopy(simple_properties)
+    merge_calculated_into_properties(props_copy, complex_calculated)
+    check_original_props(props_copy)
+    assert 'abcd' in props_copy
+    assert 'dog' in props_copy['names']
+    assert 'truck' in props_copy['names']
+
+    # try to overwrite base field
+    with pytest.raises(ValueError):
+        props_copy = copy.deepcopy(simple_properties)
+        merge_calculated_into_properties(props_copy, failure_calculated1)
+
+    # try to override sub-embedded field
+    with pytest.raises(ValueError):
+        props_copy = copy.deepcopy(simple_properties)
+        merge_calculated_into_properties(props_copy, failure_calculated2)

--- a/snovault/tests/testing_views.py
+++ b/snovault/tests/testing_views.py
@@ -559,3 +559,33 @@ class TestingLinkTargetElasticSearch(Item):
     })
     def reverse_es(self, request):
         return self.rev_link_atids(request, "reverse_es")
+
+
+@collection('testing-calculated-properties',
+            unique_key='testing_calculated_properties:name')
+class TestingCalculatedProperties(Item):
+    """ An item type that has calculated properties on it meant for testing. """
+    item_type = 'testing_calculated_properties'
+    name_key = 'name'
+    schema = load_schema('snovault:test_schemas/TestingCalculatedProperties.json')
+
+    @calculated_property(schema={
+        "title": "combination",
+        "type": "object"
+    })
+    def combination(self, name, foo, bar):
+        return {
+            'name': name,
+            'foo': foo,
+            'bar': bar
+        }
+
+    @calculated_property(schema={  # THIS is the schema that will be "seen"
+        "title": "nested",
+        "type": "object",
+        "sub-embedded": True  # REQUIRED TO INDICATE
+    })
+    def nested(self, nested):  # nested is the calculated property path that will update and the input
+        """ Implements sub-embedded-object calculated properties. """
+        # RETURN a dictionary with all sub-embedded key, value pairs on this sub-embedded path
+        return {'keyvalue': nested['key'] + nested['value']}

--- a/snovault/tests/testing_views.py
+++ b/snovault/tests/testing_views.py
@@ -589,3 +589,18 @@ class TestingCalculatedProperties(Item):
         """ Implements sub-embedded-object calculated properties. """
         # RETURN a dictionary with all sub-embedded key, value pairs on this sub-embedded path
         return {'keyvalue': nested['key'] + nested['value']}
+
+    @calculated_property(schema={
+        "title": "nested2",
+        "type": "array",
+        "sub-embedded": True
+    })
+    def nested2(self, nested2):
+        """ Implements sub-embedded object calculated property on array type field """
+        # return an ARRAY of dictionaries
+        result = []
+        for entry in nested2:
+            result.append({
+                'keyvalue': entry['key'] + entry['value']
+            })
+        return result

--- a/snovault/tests/testing_views.py
+++ b/snovault/tests/testing_views.py
@@ -583,7 +583,18 @@ class TestingCalculatedProperties(Item):
     @calculated_property(schema={  # THIS is the schema that will be "seen"
         "title": "nested",
         "type": "object",
-        "sub-embedded": True  # REQUIRED TO INDICATE
+        "sub-embedded": True,  # REQUIRED TO INDICATE
+        "properties": {
+            "key": {
+                "type": "string"
+            },
+            "value": {
+                "type": "string"
+            },
+            "keyvalue": {
+                "type": "string"
+            }
+        }
     })
     def nested(self, nested):  # nested is the calculated property path that will update and the input
         """ Implements sub-embedded-object calculated properties.
@@ -598,10 +609,24 @@ class TestingCalculatedProperties(Item):
         # return a dictionary with all sub-embedded key, value pairs on this sub-embedded path
         return {'keyvalue': nested['key'] + nested['value']}
 
-    @calculated_property(schema={
+    @calculated_property(schema={  # IN ORDER TO GET CORRECT MAPPINGS, YOU MUST SPECIFY THE ENTIRE SCHEMA
         "title": "nested2",
         "type": "array",
-        "sub-embedded": True
+        "sub-embedded": True,
+        "items": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                },
+                "keyvalue": {
+                    "type": "string"
+                }
+            }
+        }
     })
     def nested2(self, nested2):
         """ Implements sub-embedded object calculated property on array (of objects) type field

--- a/snovault/tests/testing_views.py
+++ b/snovault/tests/testing_views.py
@@ -586,8 +586,16 @@ class TestingCalculatedProperties(Item):
         "sub-embedded": True  # REQUIRED TO INDICATE
     })
     def nested(self, nested):  # nested is the calculated property path that will update and the input
-        """ Implements sub-embedded-object calculated properties. """
-        # RETURN a dictionary with all sub-embedded key, value pairs on this sub-embedded path
+        """ Implements sub-embedded-object calculated properties.
+
+            When merged into properties looks like this:
+            {
+                'nested' : {
+                    'keyvalue': val
+                }
+            }
+        """
+        # return a dictionary with all sub-embedded key, value pairs on this sub-embedded path
         return {'keyvalue': nested['key'] + nested['value']}
 
     @calculated_property(schema={
@@ -596,7 +604,21 @@ class TestingCalculatedProperties(Item):
         "sub-embedded": True
     })
     def nested2(self, nested2):
-        """ Implements sub-embedded object calculated property on array type field """
+        """ Implements sub-embedded object calculated property on array (of objects) type field
+
+            When merged into properties looks like this:
+            {
+                'nested2': [
+                    {
+                        keyvalue: val
+                    },
+
+                    {
+                        keyvalue: val
+                    }
+                ]
+            }
+        """
         # return an ARRAY of dictionaries
         result = []
         for entry in nested2:

--- a/snovault/util.py
+++ b/snovault/util.py
@@ -860,3 +860,27 @@ def validate_es_content(context, request, es_res, view='embedded'):
             use_es_result = False
             break
     return use_es_result
+
+
+def merge_calculated_into_properties(properties: dict, calculated: dict):
+    """ Performs a depth 2 dictionary merge into properties.
+
+    :param properties: base item properties
+    :param calculated: calculated properties
+    """
+    for key, value in calculated.items():
+        if key not in properties:
+            properties[key] = value
+        else:  # calculated property is in a sub-embedded object
+            calculated_sub_values = calculated[key]
+            properties_sub_values = properties[key]
+            if not isinstance(calculated_sub_values, dict) or not isinstance(properties_sub_values, dict):
+                raise ValueError('Calculated properties that override base properties disallowed: '
+                                 'calculated: %s \n properties: %s' %
+                                 (calculated_sub_values, properties_sub_values))
+            for k, v in calculated_sub_values.items():
+                if k in properties_sub_values:
+                    raise ValueError('Calculated properties that override base properties in sub-embedded object '
+                                     'disallowed: calculated: %s \n properties: %s' %
+                                     (calculated_sub_values, properties_sub_values))
+                properties_sub_values[k] = v

--- a/snovault/util.py
+++ b/snovault/util.py
@@ -871,16 +871,25 @@ def merge_calculated_into_properties(properties: dict, calculated: dict):
     for key, value in calculated.items():
         if key not in properties:
             properties[key] = value
-        else:  # calculated property is in a sub-embedded object
+        else:
             calculated_sub_values = calculated[key]
             properties_sub_values = properties[key]
-            if not isinstance(calculated_sub_values, dict) or not isinstance(properties_sub_values, dict):
-                raise ValueError('Calculated properties that override base properties disallowed: '
-                                 'calculated: %s \n properties: %s' %
-                                 (calculated_sub_values, properties_sub_values))
-            for k, v in calculated_sub_values.items():
-                if k in properties_sub_values:
-                    raise ValueError('Calculated properties that override base properties in sub-embedded object '
-                                     'disallowed: calculated: %s \n properties: %s' %
-                                     (calculated_sub_values, properties_sub_values))
-                properties_sub_values[k] = v
+            if isinstance(calculated_sub_values, dict) and isinstance(properties_sub_values, dict):
+                for k, v in calculated_sub_values.items():
+                    if k in properties_sub_values:
+                        raise ValueError('Calculated properties that override base properties in sub-embedded object '
+                                         'disallowed: calculated: %s \n properties: %s' %
+                                         (calculated_sub_values, properties_sub_values))
+                    properties_sub_values[k] = v
+            elif isinstance(calculated_sub_values, list) and isinstance(properties_sub_values, list):
+                for calculated_entry, props_entry in zip(calculated_sub_values, properties_sub_values):
+                    for k, v in calculated_entry.items():
+                        if k in props_entry:
+                            raise ValueError(
+                                'Calculated properties that override base properties in sub-embedded object '
+                                'disallowed: calculated: %s \n properties: %s' %
+                                (calculated_sub_values, properties_sub_values))
+                        props_entry[k] = v
+            else:
+                raise ValueError('Got unexpected types for calculated/properties sub-values: '
+                                 'calculated: %s \n properties: %s' % (calculated_sub_values, properties_sub_values))


### PR DESCRIPTION
Makes minimal modifications to snovault core code to allow people to declare calculated properties that modify (but not overwrite) sub-embedded objects. See testing_views code on how to do this.

TODO: update documentation, ensure this is actually working with FF/CGAP. This PR is a draft for now pending review for correctness.