### PR TITLE
C4-319 Disable nested if specified

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.0.3"
+version = "4.0.4"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/test_schemas/TestingDisableNested.json
+++ b/snovault/test_schemas/TestingDisableNested.json
@@ -1,0 +1,27 @@
+{
+  "title": "Testing Disable Nested",
+  "description": "Test object that has an array of object field that passes the DISABLE_NESTED parameter.",
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "uniqueKey": true
+    },
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "disable_nested": true,
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number"
+          }
+        }
+      }
+    }
+  }
+}

--- a/snovault/tests/test_create_mapping.py
+++ b/snovault/tests/test_create_mapping.py
@@ -60,6 +60,19 @@ def test_type_mapping_nested(registry):
         assert mapping['properties']['reverse_es']['type'] == 'nested'  # should occur here
 
 
+def test_type_mapping_nested_with_disabled_parameter(registry):
+    """ Tests that mapping a type with an object field with nested disabled correctly maps
+        without nested.
+    """
+    with mappings_use_nested(True):
+        mapping = type_mapping(registry[TYPES], 'TestingDisableNested')
+        assert mapping
+        assert 'properties' in mapping
+        assert 'type' not in mapping['properties']['options']  # would only be specified if nested desired
+        assert 'type' not in mapping['properties']['disabled_array_of_objects_in_calc_prop']
+        assert mapping['properties']['array_of_objects_in_calc_prop']['type'] == 'nested'  # not disabled on this field
+
+
 def test_merge_schemas(registry):
     """ Tests merging schemas with EmbeddingTest """
     test_schema = registry[TYPES][unit_test_type].schema

--- a/snovault/tests/testing_views.py
+++ b/snovault/tests/testing_views.py
@@ -663,7 +663,7 @@ class TestingMixins(Item):
 @collection('testing-disable-nested', unique_key='testing_disable_nested:name')
 class TestingDisableNested(Item):
     """ Type intended to test disabling nested mappings. """
-    item_type = 'testing_mixins'
+    item_type = 'testing_disable_nested'
     name_key = 'name'
     schema = load_schema('snovault:test_schemas/TestingDisableNested.json')
 

--- a/snovault/tests/testing_views.py
+++ b/snovault/tests/testing_views.py
@@ -658,3 +658,58 @@ class TestingMixins(Item):
     item_type = 'testing_mixins'
     name_key = 'name'
     schema = load_schema('snovault:test_schemas/TestingMixins.json')
+
+
+@collection('testing-disable-nested', unique_key='testing_disable_nested:name')
+class TestingDisableNested(Item):
+    """ Type intended to test disabling nested mappings. """
+    item_type = 'testing_mixins'
+    name_key = 'name'
+    schema = load_schema('snovault:test_schemas/TestingDisableNested.json')
+
+    @calculated_property(schema={
+        "title": "disabled_array_of_objects_in_calc_prop",
+        "description": "Tests mapping calculated properties with disable_nested works correctly",
+        "type": "array",
+        "items": {
+            "type": "object",
+            "disable_nested": True,
+            "properties": {
+                "string_field": {
+                    "type": "string"
+                },
+                "numerical_field": {
+                    "type": "integer"
+                }
+            }
+        }
+    })
+    def disabled_array_of_objects_in_calc_prop(self):
+        """ This one will not get mapped with nested """
+        return [{
+            'string_field': 'hello',
+            'numerical_field': 0
+        }]
+
+    @calculated_property(schema={
+        "title": "array_of_objects_in_calc_prop",
+        "description": "Tests mapping calculated properties with disable_nested works correctly",
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "string_field": {
+                    "type": "string"
+                },
+                "numerical_field": {
+                    "type": "integer"
+                }
+            }
+        }
+    })
+    def array_of_objects_in_calc_prop(self):
+        """ This one will get mapped with nested since it was not explicitly disabled """
+        return [{
+            'string_field': 'world',
+            'numerical_field': 100
+        }]


### PR DESCRIPTION
- Allow `disable_nested` to be specified on schemas to not map certain array of object fields with nested