### PR TITLE
C4-351 Compute Calc Props Asynchronously

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.0.7"
+version = "4.0.8"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.0.8"
+version = "4.1.0b5"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/app.py
+++ b/snovault/app.py
@@ -37,7 +37,7 @@ def changelogs(config):
 
 def configure_engine(settings):
     """ Configures the SQLAlchemy engine used by the application """
-    # TODO: upgrade sqlalchemy to 1.4
+    # TODO: upgrade sqlalchemy to 1.4 (for async features)
     engine_url = settings['sqlalchemy.url']
     engine_opts = {}
     if engine_url.startswith('postgresql'):

--- a/snovault/app.py
+++ b/snovault/app.py
@@ -36,6 +36,8 @@ def changelogs(config):
 
 
 def configure_engine(settings):
+    """ Configures the SQLAlchemy engine used by the application """
+    # TODO: upgrade sqlalchemy to 1.4
     engine_url = settings['sqlalchemy.url']
     engine_opts = {}
     if engine_url.startswith('postgresql'):

--- a/snovault/calculated.py
+++ b/snovault/calculated.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 import venusian
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, wait
 from pyramid.decorator import reify
 from pyramid.traversal import find_root
 from types import MethodType
@@ -207,7 +207,9 @@ def calculate_properties(context, request, ns=None, category='object'):
 
         def compute(tuple):
             name, prop = tuple[0], tuple[1]
-            calculated[name] = prop(namespace)
+            val = prop(namespace)
+            if val is not None:
+                calculated[name] = val
 
-        executor.map(compute, [(name, prop) for name, prop in props.items()])
+        wait(executor.map(compute, [(name, prop) for name, prop in props.items()]))
     return calculated

--- a/snovault/calculated.py
+++ b/snovault/calculated.py
@@ -192,7 +192,7 @@ def calculated_property(**settings):
 
 def calculate_properties(context, request, ns=None, category='object'):
     """ This function computes calculated properties asynchronously by creating a ThreadPool
-        and scheduling the _build_all_calculated_properties function.
+        and mapping a compute function for all calculated properties collected.
     """
     calculated_properties = request.registry[CALCULATED_PROPERTIES]
     props = calculated_properties.props_for(context, category)
@@ -201,6 +201,7 @@ def calculate_properties(context, request, ns=None, category='object'):
         context = None
     namespace = ItemNamespace(context, request, defined, ns)  # maybe pass
 
+    # create threadpool, map compute
     with ThreadPoolExecutor(max_workers=CALC_PROP_THREAD_COUNT) as executor:
         calculated = {}
 

--- a/snovault/resources.py
+++ b/snovault/resources.py
@@ -327,7 +327,7 @@ class Item(Resource):
     @property
     def db_model(self):
         """
-        Always returns the resource model fom write storage, which is needed
+        Always returns the resource model from write storage, which is needed
         for operations like getting current sid/max_sid, rev_links, and
         updating. Leverage `model.used_datastore` to determine source
         """

--- a/snovault/resources.py
+++ b/snovault/resources.py
@@ -327,7 +327,7 @@ class Item(Resource):
     @property
     def db_model(self):
         """
-        Always returns the resouce model from write storage, which is needed
+        Always returns the resource model fom write storage, which is needed
         for operations like getting current sid/max_sid, rev_links, and
         updating. Leverage `model.used_datastore` to determine source
         """

--- a/snovault/stats.py
+++ b/snovault/stats.py
@@ -50,6 +50,9 @@ def after_cursor_execute(
     if request is None:
         return
 
+    if not hasattr(request, '_stats'):  # does not get added in some cases now, not clear why. - Will 10/20/2020
+        return
+
     stats = request._stats
     stats['db_count'] = stats.get('db_count', 0) + 1
     duration = end - context._query_start_time

--- a/snovault/util.py
+++ b/snovault/util.py
@@ -481,7 +481,6 @@ def expand_val_for_embedded_model(request, obj_val, downstream_model, field_name
         return obj_val
 
 
-
 def build_embedded_model(fields_to_embed):
     """
     Takes a list of fields to embed and builds the framework used to generate


### PR DESCRIPTION
- Implements a light-weight asynchronous wrapper around calculated properties.
- While this may slow down calculated properties that do not make API calls, since these do not have a measurable impact on the indexing time it is not a huge concern. This change should speed up the indexing of items with lots of expensive (ie: makes many API calls) calculated properties.