### PR TITLE
Remove unnecessary fixture imports (C4-353)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.0.7"
+version = "4.0.8"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/tests/pyramidfixtures.py
+++ b/snovault/tests/pyramidfixtures.py
@@ -8,10 +8,6 @@ from dcicutils.qa_utils import notice_pytest_fixtures
 from pyramid.request import apply_request_extensions
 from pyramid.testing import setUp, tearDown
 from pyramid.threadlocal import manager
-from .toolfixtures import registry
-
-
-notice_pytest_fixtures(registry)
 
 
 @pytest.yield_fixture

--- a/snovault/tests/test_create_mapping.py
+++ b/snovault/tests/test_create_mapping.py
@@ -5,9 +5,7 @@ import mock
 from ..interfaces import TYPES
 from ..elasticsearch.create_mapping import merge_schemas, type_mapping, update_mapping_by_embed
 from ..elasticsearch.interfaces import ELASTIC_SEARCH
-from .pyramidfixtures import dummy_request
 from .test_views import PARAMETERIZED_NAMES
-from .toolfixtures import registry
 from ..settings import Settings
 from ..util import add_default_embeds
 from contextlib import contextmanager

--- a/snovault/tests/test_embedding.py
+++ b/snovault/tests/test_embedding.py
@@ -4,12 +4,7 @@ from dcicutils.qa_utils import ignored, notice_pytest_fixtures
 from re import findall
 from ..interfaces import TYPES
 from ..util import add_default_embeds, crawl_schemas_by_embeds
-from .pyramidfixtures import dummy_request, threadlocals
 from .test_views import PARAMETERIZED_NAMES
-from .toolfixtures import registry, root
-
-
-notice_pytest_fixtures(dummy_request, threadlocals, registry, root)
 
 
 targets = [

--- a/snovault/tests/test_indexing.py
+++ b/snovault/tests/test_indexing.py
@@ -43,13 +43,10 @@ from ..elasticsearch.indexer import check_sid, SidException
 from ..elasticsearch.indexer_queue import QueueManager
 from ..elasticsearch.interfaces import ELASTIC_SEARCH, INDEXER_QUEUE, INDEXER_QUEUE_MIRROR
 from dcicutils.misc_utils import Retry
-from .pyramidfixtures import dummy_request
-from .testappfixtures import _app_settings
 from .testing_views import TestingLinkSourceSno
-from .toolfixtures import registry, root, elasticsearch
 
 
-notice_pytest_fixtures(dummy_request, TestingLinkSourceSno, registry, root, elasticsearch)
+notice_pytest_fixtures(TestingLinkSourceSno)
 
 
 pytestmark = [pytest.mark.indexing]
@@ -75,8 +72,8 @@ INDEXER_NAMESPACE_FOR_TESTING = generate_indexer_namespace_for_testing()
 
 
 @pytest.fixture(scope='session')
-def app_settings(wsgi_server_host_port, elasticsearch_server, postgresql_server, aws_auth):
-    settings = _app_settings.copy()
+def app_settings(basic_app_settings, wsgi_server_host_port, elasticsearch_server, postgresql_server, aws_auth):
+    settings = basic_app_settings
     settings['create_tables'] = True
     settings['elasticsearch.server'] = elasticsearch_server
     settings['sqlalchemy.url'] = postgresql_server

--- a/snovault/tests/test_key.py
+++ b/snovault/tests/test_key.py
@@ -3,11 +3,6 @@ import pytest
 from dcicutils.qa_utils import notice_pytest_fixtures
 from pyramid.config import Configurator
 from ..interfaces import DBSESSION
-from .serverfixtures import DBSession
-from .testappfixtures import testapp
-
-
-notice_pytest_fixtures(DBSession, testapp)
 
 
 # Test for storage.keys

--- a/snovault/tests/test_post_put_patch.py
+++ b/snovault/tests/test_post_put_patch.py
@@ -1,7 +1,5 @@
 import pytest
 
-from .toolfixtures import registry, root
-
 
 targets = [
     {'name': 'one', 'uuid': '775795d3-4410-4114-836b-8eeecf1d0c2f'},

--- a/snovault/tests/test_schemas.py
+++ b/snovault/tests/test_schemas.py
@@ -1,13 +1,8 @@
 import pytest
 
-from dcicutils.qa_utils import notice_pytest_fixtures
 from ..interfaces import TYPES
 from ..schema_utils import load_schema
 from .test_views import PARAMETERIZED_NAMES
-from .toolfixtures import registry
-
-
-notice_pytest_fixtures(registry)
 
 
 @pytest.mark.parametrize('schema', PARAMETERIZED_NAMES)

--- a/snovault/tests/test_storage.py
+++ b/snovault/tests/test_storage.py
@@ -3,7 +3,6 @@ import re
 import transaction as transaction_management
 import uuid
 
-from dcicutils.qa_utils import notice_pytest_fixtures
 from pyramid.threadlocal import manager
 from sqlalchemy import func
 from sqlalchemy.orm.exc import FlushError
@@ -20,11 +19,6 @@ from ..storage import (
     Resource,
     S3BlobStorage,
 )
-from .serverfixtures import session
-from .toolfixtures import registry, storage
-
-
-notice_pytest_fixtures(session, registry, storage)
 
 
 pytestmark = pytest.mark.storage

--- a/snovault/tests/testappfixtures.py
+++ b/snovault/tests/testappfixtures.py
@@ -34,9 +34,15 @@ _app_settings = {
 }
 
 
+@pytest.fixture(scope="session")
+def basic_app_settings():
+    return _app_settings.copy()
+
+
 @pytest.fixture(scope='session')
-def app_settings(request, wsgi_server_host_port, conn, DBSession):
-    settings = _app_settings.copy()
+def app_settings(request, wsgi_server_host_port, conn, DBSession, basic_app_settings):
+    settings = basic_app_settings
+    assert DBSESSION not in settings
     settings[DBSESSION] = DBSession
     return settings
 


### PR DESCRIPTION
This PR is just to get rid of some warnings from `pytest` about redundant fixture imports.

* Remove unnecessary imports
* Convert `_app_settings` var to `basic_app_settings` fixture. This was needed because it was being imported from a file we didn't want to import, so now the value comes in through a fixture instead of an import.