### PR TITLE
Require dcicutils 1.3.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -233,7 +233,7 @@ description = "Utility package for interacting with the 4DN Data Portal and othe
 name = "dcicutils"
 optional = false
 python-versions = ">=3.4,<3.8"
-version = "1.0.0b1"
+version = "1.3.0"
 
 [package.dependencies]
 aws-requests-auth = ">=0.4.2,<1"
@@ -1447,7 +1447,6 @@ version = "0.12.0"
 [[package]]
 category = "main"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-marker = "python_version < \"3.8\""
 name = "zipp"
 optional = false
 python-versions = ">=3.6"
@@ -1506,7 +1505,8 @@ transaction = ">=1.6.0"
 test = ["zope.testing"]
 
 [metadata]
-content-hash = "f914aea2fe2cc1a0742844dd155a1e97037635918e792dcf9d5b663278570e88"
+content-hash = "c8955cc597a968d8b0ef88069ee0859d1514e995621b5cd574f1012ff4714df3"
+lock-version = "1.0"
 python-versions = ">=3.6,<3.7"
 
 [metadata.files]
@@ -1662,8 +1662,8 @@ cryptography = [
     {file = "cryptography-3.1.tar.gz", hash = "sha256:26409a473cc6278e4c90f782cd5968ebad04d3911ed1c402fc86908c17633e08"},
 ]
 dcicutils = [
-    {file = "dcicutils-1.0.0b1-py3-none-any.whl", hash = "sha256:bb86f19e5e6ff114b4690a5317d6c7c1919085324f81021840588b3d9c58b965"},
-    {file = "dcicutils-1.0.0b1.tar.gz", hash = "sha256:94f2e5550f40e523cec61c5b5a82605fdd5104b2881d5acd6193af6351a946aa"},
+    {file = "dcicutils-1.3.0-py3-none-any.whl", hash = "sha256:d6942710eb50f29f5e3afe7989142f717a0899e3f6c8e1e052ec288e270a7b19"},
+    {file = "dcicutils-1.3.0.tar.gz", hash = "sha256:107455d1d7f23de09a85a1148001b3c2b2fdcfa585a43a36855d94b2a1dd4ce1"},
 ]
 docker = [
     {file = "docker-4.3.1-py2.py3-none-any.whl", hash = "sha256:13966471e8bc23b36bfb3a6fb4ab75043a5ef1dac86516274777576bed3b9828"},
@@ -1954,7 +1954,6 @@ pycryptodome = [
     {file = "pycryptodome-3.9.8-cp38-cp38-win_amd64.whl", hash = "sha256:55eb61aca2c883db770999f50d091ff7c14016f2769ad7bca3d9b75d1d7c1b68"},
     {file = "pycryptodome-3.9.8-cp39-cp39-manylinux1_i686.whl", hash = "sha256:39ef9fb52d6ec7728fce1f1693cb99d60ce302aeebd59bcedea70ca3203fda60"},
     {file = "pycryptodome-3.9.8-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:de6e1cd75677423ff64712c337521e62e3a7a4fc84caabbd93207752e831a85a"},
-    {file = "pycryptodome-3.9.8.tar.gz", hash = "sha256:0e24171cf01021bc5dc17d6a9d4f33a048f09d62cc3f62541e95ef104588bda4"},
 ]
 pyflakes = [
     {file = "pyflakes-2.2.0-py2.py3-none-any.whl", hash = "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ awscli = "^1.15.42"
 "backports.statistics" = "0.1.0"
 boto3 = "^1.7.42"
 elasticsearch_dsl = "6.4.0"
-dcicutils = "1.0.0b1"
+dcicutils = "1.3.0"
 # TODO: Probably want ">=0.15.2,<1" here since "^" is different for "0.xx" than for higher versions. Changing it
 #       would require re-testing I don't have time for, so it'll have to be a future future change. -kmp 20-Feb-2020
 future = "^0.15.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.0.9"
+version = "4.0.8.1b0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.0.8"
+version = "4.0.9"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.0.8.1b1"
+version = "4.0.9"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.0.8.1b0"
+version = "4.0.8.1b1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/indexing_views.py
+++ b/snovault/indexing_views.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import sys
+
 from contextlib import contextmanager
 from timeit import default_timer as timer
 
@@ -178,6 +179,7 @@ def item_index_data(context, request):
         try:
             request.invoke_subrequest(validate_req)
         except ValidationFailure:
+            # TODO: This should probably be logged. -kmp 22-Oct-2020
             pass
 
     document = {

--- a/snovault/util.py
+++ b/snovault/util.py
@@ -61,6 +61,7 @@ def dictionary_lookup(dictionary, key):
 _skip_fields = ['@type', 'principals_allowed']  # globally accessible if need be in the future
 
 
+# TODO: This is a priority candidate for unit testing. -kmp 27-Jul-2020
 def filter_embedded(embedded, effective_principals):
     """
     Filter the embedded items by principals_allowed, replacing them with


### PR DESCRIPTION
Mainly this is to get snovault to require dcicutils 1.3.0, as we were previously requiring a beta that isn't tagged and for which the source base is hard to track down.

Along the way, there were a couple of `TODO` comments I added to some code.
