### PR TITLE
C4-358 Fix ES Bottleneck

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.0.10"
+version = "4.0.11"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.0.11"
+version = "4.0.12"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/connection.py
+++ b/snovault/connection.py
@@ -66,7 +66,6 @@ class Connection(object):
         model.used_for(item)
         return item
 
-
     def get_by_uuid(self, uuid, default=None, datastore=None):
         """
         Gets model from storage and returns Item. Uses item cache.
@@ -102,7 +101,7 @@ class Connection(object):
         self.item_cache[uuid] = item
         return item
 
-    def get_by_unique_key(self, unique_key, name, default=None, datastore=None):
+    def get_by_unique_key(self, unique_key, name, default=None, datastore=None, item_type=None):
         """
         Gets model from storage and returns Item.
         Uses unique_key_cache and item_cache.
@@ -114,7 +113,8 @@ class Connection(object):
         if cached is not None:
             return self.get_by_uuid(cached, datastore=datastore)
 
-        model = self.storage.get_by_unique_key(unique_key, name, datastore)
+        # pass item type info in case we are going to ES
+        model = self.storage.get_by_unique_key(unique_key, name, datastore, item_type=item_type)
         if model is None:
             return default
 

--- a/snovault/elasticsearch/esstorage.py
+++ b/snovault/elasticsearch/esstorage.py
@@ -183,20 +183,24 @@ class ElasticSearchStorage(object):
         """
         # find the term with the specific type
         term = 'embedded.' + key + '.raw'
-        search = Search(using=self.es, index=self.index)
+        index = get_namespaced_index(self.registry, item_type)
+        search = Search(using=self.es, index=index)
         search = search.filter('term', **{term: value})
         search = search.filter('type', value=item_type)
         return self._one(search)
 
-    def get_by_unique_key(self, unique_key, name):
+    def get_by_unique_key(self, unique_key, name, item_type=None):
         """
         Perform a search against unique keys with given unique_key (field) and
         name (value).
         Returns CachedModel if found, otherwise None
         """
         term = 'unique_keys.' + unique_key
+        index = self.index
+        if item_type:
+            index = get_namespaced_index(self.registry, item_type)
         # had to use ** kw notation because of variable in field name
-        search = Search(using=self.es, index=self.index)
+        search = Search(using=self.es, index=index)
         search = search.filter('term', **{term: name})
         search = search.extra(version=True)
         return self._one(search)

--- a/snovault/resources.py
+++ b/snovault/resources.py
@@ -205,7 +205,7 @@ class AbstractCollection(Resource, Mapping):
                 return default
             return resource
         if self.unique_key is not None:
-            item_type_snake_case = self.type_info.item_type
+            item_type_snake_case = getattr(self.type_info, 'item_type', None)
             resource = self.connection.get_by_unique_key(self.unique_key, name,
                                                          datastore=self.properties_datastore,
                                                          item_type=item_type_snake_case)

--- a/snovault/resources.py
+++ b/snovault/resources.py
@@ -205,8 +205,10 @@ class AbstractCollection(Resource, Mapping):
                 return default
             return resource
         if self.unique_key is not None:
+            item_type_snake_case = self.unique_key.split(':')[0]  # 'testing_link_target_sno:name' for example
             resource = self.connection.get_by_unique_key(self.unique_key, name,
-                                                         datastore=self.properties_datastore)
+                                                         datastore=self.properties_datastore,
+                                                         item_type=item_type_snake_case)
             if resource is not None:
                 if not self._allow_contained(resource):
                     return default

--- a/snovault/resources.py
+++ b/snovault/resources.py
@@ -205,7 +205,7 @@ class AbstractCollection(Resource, Mapping):
                 return default
             return resource
         if self.unique_key is not None:
-            item_type_snake_case = self.unique_key.split(':')[0]  # 'testing_link_target_sno:name' for example
+            item_type_snake_case = self.type_info.item_type
             resource = self.connection.get_by_unique_key(self.unique_key, name,
                                                          datastore=self.properties_datastore,
                                                          item_type=item_type_snake_case)

--- a/snovault/storage.py
+++ b/snovault/storage.py
@@ -35,6 +35,7 @@ from .interfaces import (
     DBSESSION,
     STORAGE,
 )
+from dcicutils.misc_utils import ignored
 from pyramid.threadlocal import get_current_request
 import boto3
 import uuid
@@ -197,7 +198,7 @@ class PickStorage(object):
         # if not specifically specifying datastore=elasticsearch, always fall back to DB
         if not datastore == 'elasticsearch':
             if model is None:
-                return self.write.get_by_unique_key(unique_key, name)  # no need to pass item_type here since its write
+                return self.write.get_by_unique_key(unique_key, name)  # no need to pass item_type since it's write
         return model
 
     def get_by_json(self, key, value, item_type, default=None, datastore=None):
@@ -357,6 +358,8 @@ class RDBStorage(object):
         Returns:
             default
         """
+        ignored(rid)
+        ignored(item_type)
         return default
 
     def find_uuids_linked_to_item(self, rid):
@@ -364,10 +367,12 @@ class RDBStorage(object):
         This method is meant to only work with ES, so return empty list for
         DB implementation. See ElasticSearchStorage.find_uuids_linked_to_item.
         """
+        ignored(rid)
         return []
 
     def get_by_unique_key(self, unique_key, name, default=None, item_type=None):
         """ Postgres implementation of get_by_unique_key - Item type arg is not used here """
+        ignored(item_type)
         session = self.DBSession()
         try:
             key = baked_query_unique_key(session).params(name=unique_key, value=name).one()

--- a/snovault/storage.py
+++ b/snovault/storage.py
@@ -372,7 +372,7 @@ class RDBStorage(object):
 
     def get_by_unique_key(self, unique_key, name, default=None, item_type=None):
         """ Postgres implementation of get_by_unique_key - Item type arg is not used here """
-        ignored(item_type)
+        ignored(item_type)  # TODO: unique keys are globally unique - could modify baked_query_unique_key to change this
         session = self.DBSession()
         try:
             key = baked_query_unique_key(session).params(name=unique_key, value=name).one()

--- a/snovault/storage.py
+++ b/snovault/storage.py
@@ -189,7 +189,6 @@ class PickStorage(object):
         """
         Get write/read model by given unique key with value (name)
         """
-        import pdb; pdb.set_trace()
         storage = self.storage(datastore)
         model = storage.get_by_unique_key(unique_key, name)
         # unless forcing ES datastore, check write storage if not found in read

--- a/snovault/storage.py
+++ b/snovault/storage.py
@@ -185,19 +185,19 @@ class PickStorage(object):
                 return self.write.get_by_uuid(uuid)
         return model
 
-    def get_by_unique_key(self, unique_key, name, datastore=None):
+    def get_by_unique_key(self, unique_key, name, datastore=None, item_type=None):
         """
         Get write/read model by given unique key with value (name)
         """
         storage = self.storage(datastore)
-        model = storage.get_by_unique_key(unique_key, name)
+        model = storage.get_by_unique_key(unique_key, name, item_type=item_type)
         # unless forcing ES datastore, check write storage if not found in read
         # if datastore == 'database' and storage is self.read:
         # Old is above - See C4-30
         # if not specifically specifying datastore=elasticsearch, always fall back to DB
         if not datastore == 'elasticsearch':
             if model is None:
-                return self.write.get_by_unique_key(unique_key, name)
+                return self.write.get_by_unique_key(unique_key, name)  # no need to pass item_type here since its write
         return model
 
     def get_by_json(self, key, value, item_type, default=None, datastore=None):

--- a/snovault/storage.py
+++ b/snovault/storage.py
@@ -189,6 +189,7 @@ class PickStorage(object):
         """
         Get write/read model by given unique key with value (name)
         """
+        import pdb; pdb.set_trace()
         storage = self.storage(datastore)
         model = storage.get_by_unique_key(unique_key, name)
         # unless forcing ES datastore, check write storage if not found in read
@@ -319,7 +320,6 @@ class PickStorage(object):
         return self.write.find_uuids_linked_to_item(uuid)
 
 
-
 class RDBStorage(object):
     """
     Storage class used to interface with the relational database.
@@ -363,11 +363,12 @@ class RDBStorage(object):
     def find_uuids_linked_to_item(self, rid):
         """
         This method is meant to only work with ES, so return empty list for
-        DB implementation. See ElasticSearchStorage.find_uuids_linked_to_item
+        DB implementation. See ElasticSearchStorage.find_uuids_linked_to_item.
         """
         return []
 
-    def get_by_unique_key(self, unique_key, name, default=None):
+    def get_by_unique_key(self, unique_key, name, default=None, item_type=None):
+        """ Postgres implementation of get_by_unique_key - Item type arg is not used here """
         session = self.DBSession()
         try:
             key = baked_query_unique_key(session).params(name=unique_key, value=name).one()
@@ -377,6 +378,7 @@ class RDBStorage(object):
             return key.resource
 
     def get_by_json(self, key, value, item_type, default=None):
+        """ Postgres implementation of get_by_json (used for lookup keys) """
         session = self.DBSession()
         try:
             # baked query seem to not work with json


### PR DESCRIPTION
- We are bottlenecking ES by searching over the entire cluster when doing `get_by_json` or `get_by_unique_key`
- Fix this by using already present item type information in `get_by_json` to restrict the search to single index
- Accept item type information in `get_by_unique_key` (since it is already available anyway) and restrict search to single index if passed
- Pass this info down from relevant entry points in snovault that use `get_by_unique_key` (requires more inspection + tracking down in FF/CGAP as well when integrating)