### PR TITLE
Accept dcicutils 1.3.1 (C4-361)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -233,7 +233,7 @@ description = "Utility package for interacting with the 4DN Data Portal and othe
 name = "dcicutils"
 optional = false
 python-versions = ">=3.4,<3.8"
-version = "1.3.0"
+version = "1.3.1"
 
 [package.dependencies]
 aws-requests-auth = ">=0.4.2,<1"
@@ -1505,8 +1505,7 @@ transaction = ">=1.6.0"
 test = ["zope.testing"]
 
 [metadata]
-content-hash = "c8955cc597a968d8b0ef88069ee0859d1514e995621b5cd574f1012ff4714df3"
-lock-version = "1.0"
+content-hash = "d4e6e70804ce8bdb186aeebf7cba7b476fd32e79a09c190b53e5665ea849a09f"
 python-versions = ">=3.6,<3.7"
 
 [metadata.files]
@@ -1662,8 +1661,8 @@ cryptography = [
     {file = "cryptography-3.1.tar.gz", hash = "sha256:26409a473cc6278e4c90f782cd5968ebad04d3911ed1c402fc86908c17633e08"},
 ]
 dcicutils = [
-    {file = "dcicutils-1.3.0-py3-none-any.whl", hash = "sha256:d6942710eb50f29f5e3afe7989142f717a0899e3f6c8e1e052ec288e270a7b19"},
-    {file = "dcicutils-1.3.0.tar.gz", hash = "sha256:107455d1d7f23de09a85a1148001b3c2b2fdcfa585a43a36855d94b2a1dd4ce1"},
+    {file = "dcicutils-1.3.1-py3-none-any.whl", hash = "sha256:bc788f940efe76f82a4eef13b550d2da968ddd25a4e8ad2f9c247124b7fc5fc9"},
+    {file = "dcicutils-1.3.1.tar.gz", hash = "sha256:5769d62947b24ba86ffb302bc82bcac26203d40d62c12e4295cdfd453229e2fb"},
 ]
 docker = [
     {file = "docker-4.3.1-py2.py3-none-any.whl", hash = "sha256:13966471e8bc23b36bfb3a6fb4ab75043a5ef1dac86516274777576bed3b9828"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.0.10"
+version = "4.0.11"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -45,7 +45,7 @@ awscli = "^1.15.42"
 "backports.statistics" = "0.1.0"
 boto3 = "^1.7.42"
 elasticsearch_dsl = "6.4.0"
-dcicutils = "1.3.0"
+dcicutils = "^1.3.0"
 # TODO: Probably want ">=0.15.2,<1" here since "^" is different for "0.xx" than for higher versions. Changing it
 #       would require re-testing I don't have time for, so it'll have to be a future future change. -kmp 20-Feb-2020
 future = "^0.15.2"


### PR DESCRIPTION
Accept dcicutils 1.3.1 by requiring ^1.3.0 instead of 1.3.0.