### PR TITLE
Indexer namespace support for testing in the pytest 4.5.0 upgrade (C4-183)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -50,10 +50,10 @@ description = "Universal Command Line Environment for AWS."
 name = "awscli"
 optional = false
 python-versions = "*"
-version = "1.18.209"
+version = "1.18.217"
 
 [package.dependencies]
-botocore = "1.19.49"
+botocore = "1.19.57"
 docutils = ">=0.10,<0.16"
 s3transfer = ">=0.3.0,<0.4.0"
 
@@ -108,10 +108,10 @@ description = "The AWS SDK for Python"
 name = "boto3"
 optional = false
 python-versions = "*"
-version = "1.16.49"
+version = "1.16.57"
 
 [package.dependencies]
-botocore = ">=1.19.49,<1.20.0"
+botocore = ">=1.19.57,<1.20.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.3.0,<0.4.0"
 
@@ -121,7 +121,7 @@ description = "Low-level, data-driven core of boto 3."
 name = "botocore"
 optional = false
 python-versions = "*"
-version = "1.19.49"
+version = "1.19.57"
 
 [package.dependencies]
 jmespath = ">=0.7.1,<1.0.0"
@@ -199,7 +199,7 @@ description = "Show coverage stats online via coveralls.io"
 name = "coveralls"
 optional = false
 python-versions = ">= 3.5"
-version = "2.2.0"
+version = "3.0.0"
 
 [package.dependencies]
 coverage = ">=4.1,<6.0"
@@ -234,7 +234,7 @@ description = "Utility package for interacting with the 4DN Data Portal and othe
 name = "dcicutils"
 optional = false
 python-versions = ">=3.4,<3.8"
-version = "1.8.3"
+version = "1.10.0"
 
 [package.dependencies]
 aws-requests-auth = ">=0.4.2,<1"
@@ -438,7 +438,7 @@ marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = ">=3.6"
-version = "3.3.0"
+version = "3.4.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -448,8 +448,8 @@ python = "<3.8"
 version = ">=3.6.4"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 category = "main"
@@ -458,7 +458,7 @@ marker = "python_version < \"3.7\""
 name = "importlib-resources"
 optional = false
 python-versions = ">=3.6"
-version = "4.1.1"
+version = "5.1.0"
 
 [package.dependencies]
 [package.dependencies.zipp]
@@ -466,8 +466,8 @@ python = "<3.8"
 version = ">=0.4"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
 category = "main"
@@ -516,7 +516,7 @@ description = "Python library for serializing any arbitrary object graph into JS
 name = "jsonpickle"
 optional = false
 python-versions = ">=2.7"
-version = "1.4.2"
+version = "1.5.0"
 
 [package.dependencies]
 [package.dependencies.importlib-metadata]
@@ -1180,7 +1180,7 @@ description = "An Amazon S3 Transfer Manager"
 name = "s3transfer"
 optional = false
 python-versions = "*"
-version = "0.3.3"
+version = "0.3.4"
 
 [package.dependencies]
 botocore = ">=1.12.36,<2.0a.0"
@@ -1532,6 +1532,7 @@ test = ["zope.testing"]
 
 [metadata]
 content-hash = "35c9d48e02b0267aa09b959ba7ca125a2d6c644528ea72973538c7c193c51808"
+lock-version = "1.0"
 python-versions = ">=3.6,<3.7"
 
 [metadata.files]
@@ -1552,8 +1553,8 @@ aws-xray-sdk = [
     {file = "aws_xray_sdk-0.95-py2.py3-none-any.whl", hash = "sha256:72791618feb22eaff2e628462b0d58f398ce8c1bacfa989b7679817ab1fad60c"},
 ]
 awscli = [
-    {file = "awscli-1.18.209-py2.py3-none-any.whl", hash = "sha256:1d821ea5689ab4190b0c809adad4b6bab3b30114be7499e4e000e7e6242cd1e7"},
-    {file = "awscli-1.18.209.tar.gz", hash = "sha256:2defaf8cb757aae66214fb8ef6fef7be6d7f8850da4423438d75fbd7d02d0311"},
+    {file = "awscli-1.18.217-py2.py3-none-any.whl", hash = "sha256:4559741fed6500fa7ef8e32f8ea720da57cbf9cd41a1f29e47da98415f8df89b"},
+    {file = "awscli-1.18.217.tar.gz", hash = "sha256:6d1ac414345c72494cddfe8afc7029b4a62b3e79c23ccdc9a38bcdb03b7716ea"},
 ]
 "backports.statistics" = [
     {file = "backports.statistics-0.1.0-py2.py3-none-any.whl", hash = "sha256:2732e003151620762ba3ea25b881b5ca0debe2fcbf41b32b6eaff5842a8b99d7"},
@@ -1569,12 +1570,12 @@ boto = [
     {file = "boto-2.49.0.tar.gz", hash = "sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a"},
 ]
 boto3 = [
-    {file = "boto3-1.16.49-py2.py3-none-any.whl", hash = "sha256:999e01f2e8a6a83e4c3942cf94ba18965af23e7a370b1c7b0c3afdc6f7a1a317"},
-    {file = "boto3-1.16.49.tar.gz", hash = "sha256:4dc8f76109891d916b894209865f4d968e64aaffa4c92147ff027cf4d557ac6c"},
+    {file = "boto3-1.16.57-py2.py3-none-any.whl", hash = "sha256:2fd3c2f42006988dc8ddae43c988aea481d11e2af7ab1deb83b293640357986c"},
+    {file = "boto3-1.16.57.tar.gz", hash = "sha256:4a499cc2f53dd557a88c6db6a552748a2abd83ffeda70ceb71dc8db39a027314"},
 ]
 botocore = [
-    {file = "botocore-1.19.49-py2.py3-none-any.whl", hash = "sha256:badb01925850fe51d51b9cbbe9144cebcc34b9aed2bb29cddd26c123a9e92fca"},
-    {file = "botocore-1.19.49.tar.gz", hash = "sha256:eecc611ed386dec8e47ca087f45e65c1337946c4b5b33af71325ef9a49ae70dd"},
+    {file = "botocore-1.19.57-py2.py3-none-any.whl", hash = "sha256:cf7d108a4d67a0fe670379111927b5d9e0ff1160146c81c326bb9e54c2b8cb19"},
+    {file = "botocore-1.19.57.tar.gz", hash = "sha256:c756d65ffa989c5c0e92178175e41abf7b18ad19b2fe2e82e192f085e264e03a"},
 ]
 certifi = [
     {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
@@ -1602,11 +1603,13 @@ cffi = [
     {file = "cffi-1.14.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a7711edca4dcef1a75257b50a2fbfe92a65187c47dab5a0f1b9b332c5919a3fb"},
     {file = "cffi-1.14.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:00e28066507bfc3fe865a31f325c8391a1ac2916219340f87dfad602c3e48e5d"},
     {file = "cffi-1.14.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:798caa2a2384b1cbe8a2a139d80734c9db54f9cc155c99d7cc92441a23871c03"},
+    {file = "cffi-1.14.4-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:a5ed8c05548b54b998b9498753fb9cadbfd92ee88e884641377d8a8b291bcc01"},
     {file = "cffi-1.14.4-cp37-cp37m-win32.whl", hash = "sha256:00a1ba5e2e95684448de9b89888ccd02c98d512064b4cb987d48f4b40aa0421e"},
     {file = "cffi-1.14.4-cp37-cp37m-win_amd64.whl", hash = "sha256:9cc46bc107224ff5b6d04369e7c595acb700c3613ad7bcf2e2012f62ece80c35"},
     {file = "cffi-1.14.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:df5169c4396adc04f9b0a05f13c074df878b6052430e03f50e68adf3a57aa28d"},
     {file = "cffi-1.14.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:9ffb888f19d54a4d4dfd4b3f29bc2c16aa4972f1c2ab9c4ab09b8ab8685b9c2b"},
     {file = "cffi-1.14.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8d6603078baf4e11edc4168a514c5ce5b3ba6e3e9c374298cb88437957960a53"},
+    {file = "cffi-1.14.4-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:d5ff0621c88ce83a28a10d2ce719b2ee85635e85c515f12bac99a95306da4b2e"},
     {file = "cffi-1.14.4-cp38-cp38-win32.whl", hash = "sha256:b4e248d1087abf9f4c10f3c398896c87ce82a9856494a7155823eb45a892395d"},
     {file = "cffi-1.14.4-cp38-cp38-win_amd64.whl", hash = "sha256:ec80dc47f54e6e9a78181ce05feb71a0353854cc26999db963695f950b5fb375"},
     {file = "cffi-1.14.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:840793c68105fe031f34d6a086eaea153a0cd5c491cde82a74b420edd0a2b909"},
@@ -1680,8 +1683,8 @@ coverage = [
     {file = "coverage-5.3.1.tar.gz", hash = "sha256:38f16b1317b8dd82df67ed5daa5f5e7c959e46579840d77a67a4ceb9cef0a50b"},
 ]
 coveralls = [
-    {file = "coveralls-2.2.0-py2.py3-none-any.whl", hash = "sha256:2301a19500b06649d2ec4f2858f9c69638d7699a4c63027c5d53daba666147cc"},
-    {file = "coveralls-2.2.0.tar.gz", hash = "sha256:b990ba1f7bc4288e63340be0433698c1efe8217f78c689d254c2540af3d38617"},
+    {file = "coveralls-3.0.0-py2.py3-none-any.whl", hash = "sha256:f8384968c57dee4b7133ae701ecdad88e85e30597d496dcba0d7fbb470dca41f"},
+    {file = "coveralls-3.0.0.tar.gz", hash = "sha256:5399c0565ab822a70a477f7031f6c88a9dd196b3de2877b3facb43b51bd13434"},
 ]
 cryptography = [
     {file = "cryptography-3.3.1-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:c366df0401d1ec4e548bebe8f91d55ebcc0ec3137900d214dd7aac8427ef3030"},
@@ -1700,8 +1703,8 @@ cryptography = [
     {file = "cryptography-3.3.1.tar.gz", hash = "sha256:7e177e4bea2de937a584b13645cab32f25e3d96fc0bc4a4cf99c27dc77682be6"},
 ]
 dcicutils = [
-    {file = "dcicutils-1.8.3-py3-none-any.whl", hash = "sha256:74100490846b43354d5ee7f1cc79fc2c89a4efe9947a282f95946391b0e02283"},
-    {file = "dcicutils-1.8.3.tar.gz", hash = "sha256:26512a514f9268eb13705c49af6c7416e31f9ef0b5b0c790d4bb1ba3d697d120"},
+    {file = "dcicutils-1.10.0-py3-none-any.whl", hash = "sha256:79757f6ae722c6d17c4cedc1f1742782c51ec927de5add7539eaa220adc7e545"},
+    {file = "dcicutils-1.10.0.tar.gz", hash = "sha256:655e2041e0bbdf089a66942c3af2bc985fea347f890cea5b5681570a28424445"},
 ]
 docker = [
     {file = "docker-4.4.1-py2.py3-none-any.whl", hash = "sha256:e455fa49aabd4f22da9f4e1c1f9d16308286adc60abaf64bf3e1feafaed81d06"},
@@ -1767,12 +1770,12 @@ idna = [
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-3.3.0-py3-none-any.whl", hash = "sha256:bf792d480abbd5eda85794e4afb09dd538393f7d6e6ffef6e9f03d2014cf9450"},
-    {file = "importlib_metadata-3.3.0.tar.gz", hash = "sha256:5c5a2720817414a6c41f0a49993908068243ae02c1635a228126519b509c8aed"},
+    {file = "importlib_metadata-3.4.0-py3-none-any.whl", hash = "sha256:ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771"},
+    {file = "importlib_metadata-3.4.0.tar.gz", hash = "sha256:fa5daa4477a7414ae34e95942e4dd07f62adf589143c875c133c1e53c4eff38d"},
 ]
 importlib-resources = [
-    {file = "importlib_resources-4.1.1-py3-none-any.whl", hash = "sha256:0a948d0c8c3f9344de62997e3f73444dbba233b1eaf24352933c2d264b9e4182"},
-    {file = "importlib_resources-4.1.1.tar.gz", hash = "sha256:6b45007a479c4ec21165ae3ffbe37faf35404e2041fac6ae1da684f38530ca73"},
+    {file = "importlib_resources-5.1.0-py3-none-any.whl", hash = "sha256:885b8eae589179f661c909d699a546cf10d83692553e34dca1bf5eb06f7f6217"},
+    {file = "importlib_resources-5.1.0.tar.gz", hash = "sha256:bfdad047bce441405a49cf8eb48ddce5e56c696e185f59147a8b79e75e9e6380"},
 ]
 isodate = [
     {file = "isodate-0.6.0-py2.py3-none-any.whl", hash = "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"},
@@ -1790,8 +1793,8 @@ jsondiff = [
     {file = "jsondiff-1.1.1.tar.gz", hash = "sha256:2d0437782de9418efa34e694aa59f43d7adb1899bd9a793f063867ddba8f7893"},
 ]
 jsonpickle = [
-    {file = "jsonpickle-1.4.2-py2.py3-none-any.whl", hash = "sha256:2ac5863099864c63d7f0c367af5e512c94f3384977dd367f2eae5f2303f7b92c"},
-    {file = "jsonpickle-1.4.2.tar.gz", hash = "sha256:c9b99b28a9e6a3043ec993552db79f4389da11afcb1d0246d93c79f4b5e64062"},
+    {file = "jsonpickle-1.5.0-py2.py3-none-any.whl", hash = "sha256:423d7b5e6c606d4c0efd93819913191e375f3a23c0874f39df94d2e20dd21c93"},
+    {file = "jsonpickle-1.5.0.tar.gz", hash = "sha256:1bd34a2ae8e51d3adbcafe83dc2d5cc81be53ada8bb16959ca6aca499bceada2"},
 ]
 jsonschema-serialize-fork = [
     {file = "jsonschema_serialize_fork-2.1.1.tar.gz", hash = "sha256:49b502326ac408729f72c95db018bf0e4d47860e3cd76e944f368f41a5483ed5"},
@@ -2131,8 +2134,8 @@ rutter = [
     {file = "rutter-0.3.tar.gz", hash = "sha256:2607d3c3843f0e6094e62235b7a587b0603bf3985dd3522ee3f739648790bd5c"},
 ]
 s3transfer = [
-    {file = "s3transfer-0.3.3-py2.py3-none-any.whl", hash = "sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13"},
-    {file = "s3transfer-0.3.3.tar.gz", hash = "sha256:921a37e2aefc64145e7b73d50c71bb4f26f46e4c9f414dc648c6245ff92cf7db"},
+    {file = "s3transfer-0.3.4-py2.py3-none-any.whl", hash = "sha256:1e28620e5b444652ed752cf87c7e0cb15b0e578972568c6609f0f18212f259ed"},
+    {file = "s3transfer-0.3.4.tar.gz", hash = "sha256:7fdddb4f22275cf1d32129e21f056337fd2a80b6ccef1664528145b72c49e6d2"},
 ]
 simplejson = [
     {file = "simplejson-3.17.0-cp27-cp27m-macosx_10_13_x86_64.whl", hash = "sha256:87d349517b572964350cc1adc5a31b493bbcee284505e81637d0174b2758ba17"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.1.2"
+version = "4.2.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.1.2.1b1"
+# I skipped from 4.1.2 to 4.3.0 because there was a 4.2.0b0 beta on pypi that was not related to this
+# and I didn't want them confused. -kmp 20-Jan-2021
+version = "4.3.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.2.0"
+version = "4.1.2.1b0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.1.2.1b0"
+version = "4.1.2.1b1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/util.py
+++ b/snovault/util.py
@@ -1,12 +1,13 @@
 import contextlib
+import datetime as datetime_module
 import functools
 import json
+import os
 import sys
 from copy import copy
 from datetime import datetime, timedelta
 
 import structlog
-from past.builtins import basestring
 from pyramid.httpexceptions import HTTPForbidden
 from pyramid.threadlocal import manager as threadlocal_manager
 
@@ -53,7 +54,7 @@ def dictionary_lookup(dictionary, key):
     if not isinstance(dictionary, dict) or (key not in dictionary):
         log.error('Got dictionary KeyError with %s and %s' % (dictionary, key))
         return None
-        #raise DictionaryKeyError(dictionary=dictionary, key=key)  this causes MPIndexer exception - will 3/10/2020
+        # raise DictionaryKeyError(dictionary=dictionary, key=key)  this causes MPIndexer exception - will 3/10/2020
     else:
         return dictionary[key]
 
@@ -115,7 +116,7 @@ def log_function_call(log_ref, func_name, extra=None):
 
 
 def select_distinct_values(request, value_path, *from_paths):
-    if isinstance(value_path, basestring):
+    if isinstance(value_path, str):
         value_path = value_path.split('.')
 
     values = from_paths
@@ -137,13 +138,13 @@ def get_root_request():
 
 
 def ensurelist(value):
-    if isinstance(value, basestring):
+    if isinstance(value, str):
         return [value]
     return value
 
 
 def uuid_to_path(request, obj, path):
-    if isinstance(path, basestring):
+    if isinstance(path, str):
         path = path.split('.')
     if not path:
         return
@@ -170,7 +171,7 @@ def uuid_to_path(request, obj, path):
 
 
 def simple_path_ids(obj, path):
-    if isinstance(path, basestring):
+    if isinstance(path, str):
         path = path.split('.')
     if not path:
         yield obj
@@ -191,7 +192,7 @@ def expand_path(request, obj, path):
     """
     Used with ?expand=... view. See resource_views.item_view_expand
     """
-    if isinstance(path, basestring):
+    if isinstance(path, str):
         path = path.split('.')
     if not path:
         return
@@ -235,7 +236,7 @@ def find_collection_subtypes(registry, item_type, types_covered=None):
         # this works for item name (MyItem) and item type (my_name)
         registry_type = registry[TYPES][item_type]
     except KeyError:
-        return [] # no types found
+        return []  # no types found
     # add the item_type of this collection if applicable
     if hasattr(registry_type, 'item_type'):
         if registry_type.name not in types_covered:
@@ -280,13 +281,15 @@ def crawl_schema(types, field_path, schema_cursor, split_path=None):
     curr_field = split_path[0]
     schema_cursor = schema_cursor.get(curr_field)
     if not schema_cursor:
-        raise Exception('Could not find schema field for: %s. Field not found. Failed at: %s' % (field_path, curr_field))
+        raise Exception('Could not find schema field for: %s. Field not found. Failed at: %s'
+                        % (field_path, curr_field))
 
     # schema_cursor should always be a dictionary
     if not isinstance(schema_cursor, dict):
-        raise Exception('Could not find schema field for: %s. Non-dictionary schema. Failed at: %s' % (field_path, curr_field))
+        raise Exception('Could not find schema field for: %s. Non-dictionary schema. Failed at: %s'
+                        % (field_path, curr_field))
 
-    ## base case. We have found the desired schema
+    # base case. We have found the desired schema
     if len(split_path) == 1:
         return schema_cursor
 
@@ -303,7 +306,8 @@ def crawl_schema(types, field_path, schema_cursor, split_path=None):
         try:
             linkTo_type = types.all[linkTo]
         except KeyError:
-            raise Exception('Could not find schema field for: %s. Invalid linkTo. Failed at: %s' % (field_path, curr_field))
+            raise Exception('Could not find schema field for: %s. Invalid linkTo. Failed at: %s'
+                            % (field_path, curr_field))
         linkTo_schema = linkTo_type.schema
         schema_cursor = linkTo_schema['properties'] if 'properties' in linkTo_schema else linkTo_schema
 
@@ -456,7 +460,7 @@ def expand_val_for_embedded_model(request, obj_val, downstream_model, field_name
             new_agg = {'parent': parent_path, 'embedded_path': agg_emb_path, 'item': obj_embedded}
             agg_items[field_name]['items'].append(new_agg)
         return obj_embedded
-    elif isinstance(obj_val, basestring):
+    elif isinstance(obj_val, str):
         # get the @@object view of obj to embed
         # TODO: per-field invalidation by adding uuids to request._linked_uuids
         # ONLY if the field is used in downstream_model (i.e. in embedded_list)
@@ -480,7 +484,6 @@ def expand_val_for_embedded_model(request, obj_val, downstream_model, field_name
     else:
         # this means the object should be returned as-is
         return obj_val
-
 
 
 def build_embedded_model(fields_to_embed):
@@ -519,7 +522,7 @@ def build_embedded_model(fields_to_embed):
     return embedded_model
 
 
-def add_default_embeds(item_type, types, embeds, schema={}):
+def add_default_embeds(item_type, types, embeds, schema=None):
     """
     Perform default processing on the embedded_list of an item_type.
     Three part process that automatically builds a list of embed paths using
@@ -527,6 +530,8 @@ def add_default_embeds(item_type, types, embeds, schema={}):
     and then finally adding the default embeds to all the linkTo paths generated.
     Used in fourfront/../types/base.py AND snovault create mapping
     """
+    if schema is None:
+        schema = {}
     # remove duplicate embeds
     embeds = list(set(list(embeds)))
     embeds.sort()
@@ -560,7 +565,7 @@ def expand_embedded_list(item_type, types, embeds, schema, processed_embeds):
             # be cases of fields that are not valid for default embeds
             # but are still themselves valid fields
             processed_embeds.remove(embed_path)
-            print(error_message, file = sys.stderr)
+            print(error_message, file=sys.stderr)
         else:
             embeds_to_add.extend(path_embeds_to_add)
     return embeds_to_add, processed_embeds
@@ -633,7 +638,8 @@ def crawl_schemas_by_embeds(item_type, types, split_path, schema):
     error_message = None
     linkTo_path = '.'.join(split_path)
     if len(split_path) == 1:
-        error_message = '{} has a bad embed: {} is a top-level field. Did you mean: "{}.*"?.'.format(item_type, split_path[0], split_path[0])
+        error_message = ('{} has a bad embed: {} is a top-level field. Did you mean: "{}.*"?.'
+                         .format(item_type, split_path[0], split_path[0]))
     for idx in range(len(split_path)):
         element = split_path[idx]
         # schema_cursor should always be a dictionary if we have more split_fields
@@ -671,7 +677,8 @@ def crawl_schemas_by_embeds(item_type, types, split_path, schema):
                 linkTo_schema = linkTo_type.schema
                 schema_cursor = linkTo_schema['properties'] if 'properties' in linkTo_schema else linkTo_schema
                 if '@id' not in schema_cursor or 'display_title' not in schema_cursor:
-                    error_message = '{} has a bad embed: {} object does not have @id/display_title.'.format(item_type, linkTo_path)
+                    error_message = ('{} has a bad embed: {} object does not have @id/display_title.'
+                                     .format(item_type, linkTo_path))
                     return error_message, embeds_to_add
                 # we found a terminal linkTo embed
                 if idx == len(split_path) - 1:
@@ -691,7 +698,8 @@ def crawl_schemas_by_embeds(item_type, types, split_path, schema):
                         embeds_to_add.append(linkTo_path)
                     return error_message, embeds_to_add
         else:
-            error_message = '{} has a bad embed: {} is not contained within the parent schema. See {}.'.format(item_type, element, linkTo_path)
+            error_message = ('{} has a bad embed: {} is not contained within the parent schema. See {}.'
+                             .format(item_type, element, linkTo_path))
             return error_message, embeds_to_add
     # really shouldn't hit this return, but leave as a back up
     return error_message, embeds_to_add
@@ -735,7 +743,8 @@ def process_aggregated_items(request):
                 found_value = recursively_process_field(pointer, split_field)
                 # terminal dicts will create issues with the mapping. Print a warning and skip
                 if isinstance(found_value, dict):
-                    log.error('ERROR. Found dictionary terminal value for field %s when aggregating %s items. Context is: %s'
+                    log.error('ERROR. Found dictionary terminal value for field %s when aggregating %s items.'
+                              ' Context is: %s'
                               % (field, agg_on, str(request.context.uuid)))
                     continue
                 proc_pointer = proc_item
@@ -951,3 +960,14 @@ class CachedField:
             self.name, self._update_function, self.timeout
         )
 
+
+def generate_indexer_namespace_for_testing():
+    travis_job_id = os.environ.get('TRAVIS_JOB_ID')
+    if travis_job_id:
+        return travis_job_id
+    else:
+        # We've experimentally determined that it works pretty well to just use the timestamp.
+        return "sno-test-%s" % int(datetime_module.datetime.now().timestamp() * 1000000)
+
+
+INDEXER_NAMESPACE_FOR_TESTING = generate_indexer_namespace_for_testing()

--- a/snovault/util.py
+++ b/snovault/util.py
@@ -961,13 +961,13 @@ class CachedField:
         )
 
 
-def generate_indexer_namespace_for_testing():
+def generate_indexer_namespace_for_testing(prefix='sno'):
     travis_job_id = os.environ.get('TRAVIS_JOB_ID')
     if travis_job_id:
         return travis_job_id
     else:
         # We've experimentally determined that it works pretty well to just use the timestamp.
-        return "sno-test-%s" % int(datetime_module.datetime.now().timestamp() * 1000000)
+        return "%s-test-%s" % (prefix, int(datetime_module.datetime.now().timestamp() * 1000000))
 
 
 INDEXER_NAMESPACE_FOR_TESTING = generate_indexer_namespace_for_testing()


### PR DESCRIPTION
As part of my upgrade of `cgap-portal` for `pytest 4.5.0`, I needed to borrow this functionality, so I want to move it out of testing files and into the main part of the repo:

* Move `generate_indexer_namespace_for_testing` and `INDEXER_NAMESPACE_FOR_TESTING` from `snovault/tests/test_indexing.py` to `snovault/util.py`

This PR also does these more minor/administrative things:

* Bump minor version for newly advertised functionality to be inherited by `cgap-portal` and `fourfront`.
* Also misc PEP8.

The most controversial thing I did was, in one file, change
```
from past.builtins import basestring
...
... isinstance(x, basestring) ...
```
to
```
... isinstance(x, str) ...
```
But the conversion wisdom on the web and a number of cross-checks I did say that’s a safe change. The recommendation is to do
```
import six
...
... isinstance(x, six.string_types) ...
```
if still using Python2, but we are not. In Python3 `six.string_types` is the same as `(str,)`.