### PR TITLE
Add a github action to auto-publish tagged branches (C4-527)

### DIFF
--- a/.github/workflows/main-publish.yml
+++ b/.github/workflows/main-publish.yml
@@ -1,0 +1,36 @@
+# PyPi publish for dcicsnovault
+
+name: publish 
+
+# Controls when the action will run. 
+on:
+
+  # Publish on all tags
+  push:
+    tags:
+    - '*'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-18.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Publish
+        env:
+          PYPI_USER: ${{ secrets.PYPI_USER }}
+          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: | 
+          make configure
+          make publish-for-ga

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ update:
 publish:
 	scripts/publish
 
+publish-for-ga:
+	scripts/publish --noconfirm
+
 help:
 	@make info
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ clean:
 
 configure:  # does any pre-requisite installs
 	pip install --upgrade pip
-	pip install poetry
+	pip install poetry==1.0.10  # pinned to avoid build problems we cannot fix in pyproject.toml
 
 moto-setup:
 	poetry run python -m pip install "moto[server]==1.3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-# I skipped from 4.1.2 to 4.3.0 because there was a 4.2.0b0 beta on pypi that was not related to this
-# and I didn't want them confused. -kmp 20-Jan-2021
-version = "4.3.0"
+version = "4.3.0.1b0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.3.0.1b0"
+version = "4.3.1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+do_confirm=yes
+
+while true; do
+    if [ "$1" = "--help" ]; then
+       echo "Syntax: $0 [ --noconfirm | --help ]*"
+       echo ""
+       echo "Publishes the repository to pypi, after doing various consistency checks."
+       echo ""
+       echo "By default, if all looks good, you will be asked interactively for confirmation."
+       echo "In a script, you may want --noconfirm to suppress this query."
+       exit 1
+    elif [ "$1" = "--noconfirm" ]; then
+       do_confirm=no
+       shift 1
+    elif [ $# -ne 0 ]; then
+       echo "Unexpected argument: $1"
+       exit 1
+    else
+       break
+    fi
+done
+
 if [ -z "$PYPI_USER" ]; then
     echo '$PYPI_USER is not set.'
     exit 1
@@ -32,12 +54,14 @@ if [ -z "$tagged" ]; then
   exit 1
 fi
 
-read -p "Are you sure you want to publish $(poetry version) to PyPi? "
-REPLY=`echo "$REPLY" | tr '[:upper:]' '[:lower:]'`
-if [ "$REPLY" != 'y' ] && [ "$REPLY" != "yes" ]
-then
-  echo "Publishing aborted."
-  exit 1
+if [ "${do_confirm}" = "yes" ]; then
+  read -p "Are you sure you want to publish $(poetry version) to PyPi? "
+  REPLY=`echo "$REPLY" | tr '[:upper:]' '[:lower:]'`
+  if [ "$REPLY" != 'y' ] && [ "$REPLY" != "yes" ]
+  then
+    echo "Publishing aborted."
+    exit 1
+  fi
 fi
 
 poetry publish --no-interaction --build --username=$PYPI_USER --password=$PYPI_PASSWORD


### PR DESCRIPTION
This does the same thing `dcicutils` does in order to auto-publish.

This also pins the `poetry` version to 1.0.10, as `cgap-portal` does.