### PR TITLE
ES fixture support for CGAP workbook tests (C4-29, C4-312)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.3.1"
+version = "4.4.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/tests/elasticsearch_fixture.py
+++ b/snovault/tests/elasticsearch_fixture.py
@@ -31,6 +31,7 @@ def server_process(datadir, host='localhost', port=9200, prefix='', echo=False):
         '-Ehttp.port=%d' % port,
         '-Epath.data=%s' % os.path.join(datadir, 'data'),
         '-Epath.logs=%s' % os.path.join(datadir, 'logs'),
+        '-Epath.repo=%s' % os.path.join(datadir, 'snapshots'),
     ]
     # elasticsearch for travis
     if os.environ.get('TRAVIS'):

--- a/snovault/tests/serverfixtures.py
+++ b/snovault/tests/serverfixtures.py
@@ -78,16 +78,19 @@ def elasticsearch_host_port():
     return webtest.http.get_free_port()
 
 
+@pytest.fixture(scope='session')
+def elasticsearch_server_dir(tmpdir_factory):
+    return str(tmpdir_factory.mktemp('elasticsearch', numbered=True))
+
+
 @pytest.mark.fixture_cost(10)
 @pytest.yield_fixture(scope='session')
-def elasticsearch_server(tmpdir_factory, elasticsearch_host_port, remote_es):
-    notice_pytest_fixtures(tmpdir_factory, elasticsearch_host_port, remote_es)
+def elasticsearch_server(elasticsearch_server_dir, elasticsearch_host_port, remote_es):
+    notice_pytest_fixtures(elasticsearch_host_port, remote_es)
     if not remote_es:
         # spawn a new one
         host, port = elasticsearch_host_port
-        tmpdir = tmpdir_factory.mktemp('elasticsearch', numbered=True)
-        tmpdir = str(tmpdir)
-        process = elasticsearch_server_process(str(tmpdir), host=host, port=port)
+        process = elasticsearch_server_process(elasticsearch_server_dir, host=host, port=port)
 
         yield 'http://%s:%d' % (host, port)
 


### PR DESCRIPTION
This does several things. They are small but important foundation for some stuff I want to put in `cgap-portal`.

* Arranges for ElasticSearch to declare a `path.repo` that is a 'snapshots' directory. As far as I can tell, this doesn't actually _create_ the `snapshots` folder, but it does allow it to be created. ES likes you to only save to places you've predeclared as OK probably to avoid it doing damage to areas you didn't mean to, so this is a small but essential detail.
* Add an `elasticsearch_server_dir` fixture that knows where the ElasticSearch data is getting put. This part is a convenience but not the part that's essential to the layered stuff I need. (In fact, I don't quite get why es_testapp doesn't come with all the settings es_app_settings in its registry. Is that a bug? If the settings were where I feel like they should be, I could just fetch them from there. But this is harmless to have as well.)
* Arrange for the `elasticsearch_server` fixture to use the new `elasticsearch_server_dir` fixture. Using the new fixture right away avoids code duplication ([DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)).
* Bump minor version for new functionality.