### PR TITLE
Add repo name to indexing namespace prefix for GitHub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.4.0"
+version = "4.5.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/tests/test_util.py
+++ b/snovault/tests/test_util.py
@@ -1,8 +1,27 @@
-import pytest
 import copy
+import pytest
 import random
-from ..util import dictionary_lookup, DictionaryKeyError, merge_calculated_into_properties, CachedField
-from .test_indexing import es_based_target
+import re
+
+from dcicutils.qa_utils import override_environ
+from ..util import (
+    dictionary_lookup, DictionaryKeyError, merge_calculated_into_properties, CachedField,
+    generate_indexer_namespace_for_testing,
+)
+
+
+def test_generate_indexer_namespace_for_testing():
+
+    with override_environ(TRAVIS_JOB_ID="17"):
+        ns = generate_indexer_namespace_for_testing()
+        assert ns == "sno-test-17-"
+
+        ns = generate_indexer_namespace_for_testing('foo')
+        assert ns == "foo-test-17-"
+
+    with override_environ(TRAVIS_JOB_ID=None):
+        ns = generate_indexer_namespace_for_testing('foo')
+        assert re.match("foo-test-[0-9]+-", ns)
 
 
 def test_dictionary_lookup():

--- a/snovault/util.py
+++ b/snovault/util.py
@@ -964,10 +964,12 @@ class CachedField:
 def generate_indexer_namespace_for_testing(prefix='sno'):
     travis_job_id = os.environ.get('TRAVIS_JOB_ID')
     if travis_job_id:
-        return travis_job_id
+        # Nowadays, this might be a GitHub run id, which isn't globally unique.
+        # Each repo is monotonic but at different pace and they can collide. Repo prefix is essential.
+        return "%s-test-%s-" % (prefix, travis_job_id)
     else:
         # We've experimentally determined that it works pretty well to just use the timestamp.
-        return "%s-test-%s" % (prefix, int(datetime_module.datetime.now().timestamp() * 1000000))
+        return "%s-test-%s-" % (prefix, int(datetime_module.datetime.now().timestamp() * 1000000))
 
 
 INDEXER_NAMESPACE_FOR_TESTING = generate_indexer_namespace_for_testing()


### PR DESCRIPTION
Per [C4-609](https://hms-dbmi.atlassian.net/browse/C4-609), make {{generate_indexer_namespace_for_testing}} add the repo name to the generated prefix so repos don't generate the same prefixes and end up using each other's data.