### PR TITLE
Better handling of TRAVIS_JOB_ID (C4-624)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,4 +66,4 @@ jobs:
           # This will be the new environment variable name.
           TEST_JOB_ID: sno-test-${{ github.run_number }}-
         run: |
-          poetry run wipe-test-indices $TRAVIS_JOB_ID search-fourfront-testing-6-8-kncqa2za2r43563rkcmsvgn2fq.us-east-1.es.amazonaws.com:443
+          poetry run wipe-test-indices $TEST_JOB_ID search-fourfront-testing-6-8-kncqa2za2r43563rkcmsvgn2fq.us-east-1.es.amazonaws.com:443

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,10 @@ jobs:
       - name: QA
         env:
           S3_ENCRYPT_KEY: ${{ secrets.S3_ENCRYPT_KEY }}
-          TRAVIS_JOB_ID: ${{ github.run_number }}
+          # The need for this old environment variable name will go away soon.
+          TRAVIS_JOB_ID: sno-x-test-${{ github.run_number }}-
+          # This will be the new environment variable name.
+          TEST_JOB_ID: sno-test-${{ github.run_number }}-
         run: |
           make travis-test
 
@@ -58,6 +61,9 @@ jobs:
         if: ${{ always() }}
         env:
           S3_ENCRYPT_KEY: ${{ secrets.S3_ENCRYPT_KEY }}
-          TRAVIS_JOB_ID: ${{ github.run_number }}
+          # The need for this old environment variable name will go away soon.
+          TRAVIS_JOB_ID: sno-x-test-${{ github.run_number }}-
+          # This will be the new environment variable name.
+          TEST_JOB_ID: sno-test-${{ github.run_number }}-
         run: |
           poetry run wipe-test-indices $TRAVIS_JOB_ID search-fourfront-testing-6-8-kncqa2za2r43563rkcmsvgn2fq.us-east-1.es.amazonaws.com:443

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.5.0"
+version = "4.6.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/tests/test_util.py
+++ b/snovault/tests/test_util.py
@@ -12,14 +12,35 @@ from ..util import (
 
 def test_generate_indexer_namespace_for_testing():
 
-    with override_environ(TRAVIS_JOB_ID="17"):
+    with override_environ(TRAVIS_JOB_ID="17", TEST_JOB_ID=None):
         ns = generate_indexer_namespace_for_testing()
         assert ns == "sno-test-17-"
 
         ns = generate_indexer_namespace_for_testing('foo')
         assert ns == "foo-test-17-"
 
-    with override_environ(TRAVIS_JOB_ID=None):
+    with override_environ(TRAVIS_JOB_ID=None, TEST_JOB_ID="17"):
+        ns = generate_indexer_namespace_for_testing()
+        assert ns == "sno-test-17-"
+
+        ns = generate_indexer_namespace_for_testing('foo')
+        assert ns == "foo-test-17-"
+
+    with override_environ(TRAVIS_JOB_ID="17", TEST_JOB_ID="18"):
+        ns = generate_indexer_namespace_for_testing()
+        assert ns == "sno-test-18-"
+
+        ns = generate_indexer_namespace_for_testing('foo')
+        assert ns == "foo-test-18-"
+
+    with override_environ(TEST_JOB_ID="snow-test-19"):
+        ns = generate_indexer_namespace_for_testing()
+        assert ns == "snow-test-19"
+
+        ns = generate_indexer_namespace_for_testing('foo')
+        assert ns == "snow-test-19"
+
+    with override_environ(TRAVIS_JOB_ID=None, TEST_JOB_ID=None):
         ns = generate_indexer_namespace_for_testing('foo')
         assert re.match("foo-test-[0-9]+-", ns)
 

--- a/snovault/util.py
+++ b/snovault/util.py
@@ -962,11 +962,16 @@ class CachedField:
 
 
 def generate_indexer_namespace_for_testing(prefix='sno'):
-    travis_job_id = os.environ.get('TRAVIS_JOB_ID')
-    if travis_job_id:
+    test_job_id = os.environ.get('TEST_JOB_ID') or os.environ.get('TRAVIS_JOB_ID')
+    if test_job_id:
+        if '-test-' in test_job_id:
+            # We need to manage some set of ids unchanged at the command line,
+            # so if the caller has segmented things, trust it to have added a repo prefix
+            # and just return it unaltered. -kmp 9-Mar-2021
+            return test_job_id
         # Nowadays, this might be a GitHub run id, which isn't globally unique.
         # Each repo is monotonic but at different pace and they can collide. Repo prefix is essential.
-        return "%s-test-%s-" % (prefix, travis_job_id)
+        return "%s-test-%s-" % (prefix, test_job_id)
     else:
         # We've experimentally determined that it works pretty well to just use the timestamp.
         return "%s-test-%s-" % (prefix, int(datetime_module.datetime.now().timestamp() * 1000000))


### PR DESCRIPTION
In service of [Problems with ES test prefixes (C4-624)](https://hms-dbmi.atlassian.net/browse/C4-624):
* Adjust snovault test prefix generator to allow `TEST_JOB_ID` in lieu of `TRAVIS_JOB_ID` if the caller would rather. For now, both are allowed. `TEST_JOB_ID` will take precedence if both are present.
* As a special case, leave any job id with `'-test-'` in its name alone without trying to further embellish it. So if the `TEST_JOB_ID` is `17`, the actual prefix will be something like `sno-test-17-` whereas if the `TEST_JOB_ID` is `xxx-test-yyy` then the actual prefix will be `xxx-test-yyy` because it's trusting that you did the work to get a unique prefix yourself.