### PR TITLE
Invalidation Scope - Fix Abstract link Target Interaction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,11 @@ publish:
 publish-for-ga:
 	scripts/publish --noconfirm
 
+kill:
+    pkill -f postgres &
+    pkill -f elasticsearch &
+    pkill -f moto_server &
+
 help:
 	@make info
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.7.1"
+version = "4.7.2"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/tests/test_invalidation_scope.py
+++ b/snovault/tests/test_invalidation_scope.py
@@ -2,7 +2,7 @@ import pytest
 import mock
 import copy
 from contextlib import contextmanager
-from ..elasticsearch.indexer_utils import filter_invalidation_scope
+from ..elasticsearch.indexer_utils import filter_invalidation_scope, determine_child_types
 
 
 # Mocked uuids
@@ -336,6 +336,19 @@ class TestInvalidationScopeUnit:
         secondary = {UUID1}
         with invalidation_scope_mocks(test_parent_type_schema, embedded_list, base_types=base_types):
             self.run_test_and_reset_secondary(registry, diff, invalidated, secondary, 1)
+
+    def test_invalidation_scope_get_child_types(self, testapp):
+        """ Tests that we can resolve child types correctly. """
+        item_child_types = determine_child_types(testapp.app.registry, 'Item')
+        assert item_child_types == ['AbstractItemTestSecondSubItem', 'AbstractItemTestSubItem',  # all types defined
+                                    'EmbeddingTest', 'NestedEmbeddingContainer', 'NestedObjectLinkTarget',
+                                    'TestingBiogroupSno', 'TestingBiosampleSno', 'TestingBiosourceSno',
+                                    'TestingCalculatedProperties', 'TestingDependencies', 'TestingDownload',
+                                    'TestingIndividualSno', 'TestingLinkAggregateSno', 'TestingLinkSourceSno',
+                                    'TestingLinkTargetElasticSearch', 'TestingLinkTargetSno', 'TestingMixins',
+                                    'TestingNestedEnabled', 'TestingPostPutPatchSno', 'TestingServerDefault']
+        abstract_item_type_child_types = determine_child_types(testapp.app.registry, 'AbstractItemTest')
+        assert abstract_item_type_child_types == ['AbstractItemTestSecondSubItem', 'AbstractItemTestSubItem']
 
 
 ###########################################################


### PR DESCRIPTION
- Ensures link targets that are abstract are handled correctly by simulating diffs on all child types
- For example, in fourfront if a link target is of type `File`, then we should be looking for a diff on all possible child types of `File` since they all could be a valid linkTo