### PR TITLE
Better argument conventions for make_standalone_app

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.7.2"
+version = "4.7.3"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,8 +9,11 @@ addopts =
 markers =
     es: mark a test as an elastic search test (deselect with '-m "not es"')
     indexing: mark a test as an indexing test (deselect with '-m "not indexing"')
+    integrated: an integration test
+    integratedx: an excludable integration test, redundantly testing functionality also covered by a unit test
     performance: mark a test as a performance test (deselect with '-m "not performance"')
     slow: mark a test as slow (deselect with '-m "not slow"')
     storage: mark a test as about storage (deselect with '-m "not storage"')
+    unit: a proper unit test
     working: mark a test as working (deselect with '-m "not working"')
 norecursedirs = *env site-packages .cache .git .idea *.egg-info

--- a/snovault/standalone_dev.py
+++ b/snovault/standalone_dev.py
@@ -2,13 +2,38 @@ from dcicutils.misc_utils import VirtualApp
 from pyramid.paster import get_app
 
 
-def make_standalone_app():
-    return get_app('development.ini', 'app')  # this file should exist in the main portal repo
+def make_standalone_app(name='app', config_file='development.ini'):
+    """
+    Creates an 'app' suitable for use in creating a testapp or VirtualApp.
+
+    Args:
+        name: a string naming the app (default 'app')
+        config_file: a string naming the configuration file (default 'development.ini')
+
+    Returns:
+
+        An object, probably of type pyramid.router.Router, suitable for use in creating a
+        webtest.TestApp or dcicutils.misc_utils.VirtualApp.
+
+    """
+
+    return get_app(config_file, name)
 
 
 def make_dev_vapp(remote_user=None, environ=None, app=None):
-    """ Creates a VirtualApp simulating the TEST user by default.
-        Intended for use with the local deployment (pserve development.ini).
+    """
+    Creates a VirtualApp that, by default, simulates the TEST user of the development config,
+    i.e., deployment on localhost (pserve development.ini).
+
+    Args:
+        remote_user: an email address or a reserved system token such as 'TEST'
+        environ: a dictionary of environment bindings. The default is {"HTTP_ACCEPT": "application/json"}
+        app: an app object to use instead of the default app newly generated on each call by by make_standalone_app()
+
+    Returns:
+
+        an object of type dcicutils.misc_utils.VirtualApp
+
     """
 
     environ = environ or {'HTTP_ACCEPT': 'application/json'}

--- a/snovault/standalone_dev.py
+++ b/snovault/standalone_dev.py
@@ -2,7 +2,7 @@ from dcicutils.misc_utils import VirtualApp
 from pyramid.paster import get_app
 
 
-def make_standalone_app(name='app', config_file='development.ini'):
+def make_standalone_app(*, config_file='development.ini', name='app'):
     """
     Creates an 'app' suitable for use in creating a testapp or VirtualApp.
 
@@ -20,13 +20,13 @@ def make_standalone_app(name='app', config_file='development.ini'):
     return get_app(config_file, name)
 
 
-def make_dev_vapp(remote_user=None, environ=None, app=None):
+def make_dev_vapp(*, remote_user='TEST', environ=None, app=None, anonymous=False):
     """
     Creates a VirtualApp that, by default, simulates the TEST user of the development config,
     i.e., deployment on localhost (pserve development.ini).
 
     Args:
-        remote_user: an email address or a reserved system token such as 'TEST'
+        remote_user: an email address or a reserved system token such as 'TEST' (the default).
         environ: a dictionary of environment bindings. The default is {"HTTP_ACCEPT": "application/json"}
         app: an app object to use instead of the default app newly generated on each call by by make_standalone_app()
 
@@ -36,9 +36,10 @@ def make_dev_vapp(remote_user=None, environ=None, app=None):
 
     """
 
-    environ = environ or {'HTTP_ACCEPT': 'application/json'}
+    environ = (environ if environ is not None else {'HTTP_ACCEPT': 'application/json'}).copy()
 
-    environ['REMOTE_USER'] = remote_user or 'TEST'
+    if remote_user:
+        environ['REMOTE_USER'] = remote_user
 
     app = app or make_standalone_app()
     return VirtualApp(app, environ)

--- a/snovault/tests/test_standalone_dev.py
+++ b/snovault/tests/test_standalone_dev.py
@@ -5,7 +5,7 @@ from unittest import mock
 from ..standalone_dev import make_standalone_app, make_dev_vapp
 from .. import standalone_dev as standalone_dev_module
 
-pytestmark = [pytest.mark.unit]
+pytestmark = [pytest.mark.working, pytest.mark.unit]
 
 
 class MockWsgiApp():

--- a/snovault/tests/test_standalone_dev.py
+++ b/snovault/tests/test_standalone_dev.py
@@ -1,0 +1,103 @@
+import pytest
+
+from pyramid import paster
+from unittest import mock
+from ..standalone_dev import make_standalone_app, make_dev_vapp
+from .. import standalone_dev as standalone_dev_module
+
+pytestmark = [pytest.mark.unit]
+
+
+class MockWsgiApp():
+    def __init__(self, name, config_uri):
+        self.name_for_testing = name
+        self.config_uri_for_testing = config_uri
+
+
+class MockConfigLoader:
+    def __init__(self, config_uri):
+        self.config_uri = config_uri
+
+    def get_wsgi_app(self, name, options=None):
+        assert options is None  # The case we're expecting doesn't pass this argument
+        return MockWsgiApp(name=name, config_uri=self.config_uri)
+
+
+def test_make_standalone_app():
+
+    with mock.patch.object(paster, "get_config_loader", MockConfigLoader):
+
+        with pytest.raises(TypeError):  # positional arguments not allowed
+            testapp = make_standalone_app('foo')  # noQA - this is a negative test case
+
+        testapp = make_standalone_app()
+        assert testapp.name_for_testing == 'app'
+        assert testapp.config_uri_for_testing == 'development.ini'
+
+        testapp = make_standalone_app(name='foo')
+        assert testapp.name_for_testing == 'foo'
+        assert testapp.config_uri_for_testing == 'development.ini'
+
+        testapp = make_standalone_app(config_file='foo.ini')
+        assert testapp.name_for_testing == 'app'
+        assert testapp.config_uri_for_testing == 'foo.ini'
+
+        testapp = make_standalone_app(name='foo', config_file='foo.ini')
+        assert testapp.name_for_testing == 'foo'
+        assert testapp.config_uri_for_testing == 'foo.ini'
+
+
+class MockVirtualApp:
+
+    def __init__(self, app, environ):
+        self.app_for_testing = app
+        self.environ_for_testing = environ
+
+
+def test_make_dev_vapp():
+
+    with mock.patch.object(standalone_dev_module, "VirtualApp", MockVirtualApp):
+        with mock.patch.object(paster, "get_config_loader", MockConfigLoader):
+
+            vapp = make_dev_vapp(app='something')
+            assert vapp.app_for_testing == 'something'  # If we give something, it's just passed straight through
+
+            vapp = make_dev_vapp()
+            assert isinstance(vapp, MockVirtualApp)
+            assert isinstance(vapp.app_for_testing, MockWsgiApp)
+            assert vapp.app_for_testing.name_for_testing == 'app'
+            assert vapp.app_for_testing.config_uri_for_testing == 'development.ini'
+            assert vapp.environ_for_testing == {"HTTP_ACCEPT": "application/json", "REMOTE_USER": "TEST"}
+
+            # The default is {"HTTP_ACCEPT": "application/json"}. If overridden, that must be included explicitly,
+            # just in case the caller wants to omit it.
+            some_environ = {"SOMETHING": "ELSE"}
+
+            vapp = make_dev_vapp(environ=some_environ)
+            assert vapp.app_for_testing.name_for_testing == 'app'
+            assert vapp.environ_for_testing == {"REMOTE_USER": "TEST", "SOMETHING": "ELSE"}
+
+            vapp = make_dev_vapp(environ={})
+            assert vapp.app_for_testing.name_for_testing == 'app'
+            assert vapp.environ_for_testing == {"REMOTE_USER": "TEST"}
+
+            some_user = "some_user@cgap.hms.harvard.edu"
+
+            vapp = make_dev_vapp(environ=some_environ, remote_user=some_user)
+            assert vapp.app_for_testing.name_for_testing == 'app'
+            assert vapp.environ_for_testing == {"REMOTE_USER": some_user, "SOMETHING": "ELSE"}
+
+            vapp = make_dev_vapp(remote_user=some_user)
+            assert vapp.app_for_testing.name_for_testing == 'app'
+            assert vapp.environ_for_testing == {"HTTP_ACCEPT": "application/json", "REMOTE_USER": some_user}
+
+            # It's possible also to get no remote user, by expressly passing None, since the default is TEST.
+            # In that case, we expect no binding for REMOTE_USER in the environ:
+
+            vapp = make_dev_vapp(remote_user=None)
+            assert vapp.app_for_testing.name_for_testing == 'app'
+            assert vapp.environ_for_testing == {"HTTP_ACCEPT": "application/json"}
+
+            vapp = make_dev_vapp(remote_user=None, environ={})
+            assert vapp.app_for_testing.name_for_testing == 'app'
+            assert vapp.environ_for_testing == {}


### PR DESCRIPTION
This one is pretty simple, and is really just follow-up on code review comments from Will that didn't make it into a prior PR:

* Add default arguments to `standalone_dev.make_standalone_app` per Will's code review, allowing the app's `name` and `config_file` to be specified as arguments.
* Add some doc strings.
