### PR TITLE
C4-645 Allow more es_client customization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.7.3"
+version = "4.7.4"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/elasticsearch/__init__.py
+++ b/snovault/elasticsearch/__init__.py
@@ -16,11 +16,13 @@ def includeme(config):
             * elasticsearch.aws_auth - whether or not to use local AWS creds
             * elasticsearch.request_timeout - ES request timeout, defaults to 10 seconds but is
               upped to 20 in our settings if not otherwise specified.
+            * elasticsearch.request_auto_retry - allows us to disable request auto-retry
     """
     settings = config.registry.settings
     address = settings['elasticsearch.server']
     use_aws_auth = settings.get('elasticsearch.aws_auth')
-    es_request_timeout = settings.get('elasticsearch.request_timeout', 20)
+    es_request_timeout = settings.get('elasticsearch.request_timeout', 20)  # only change is here
+    es_request_auto_retry = settings.get('elasticsearch.request_auto_retry', True)
     # make sure use_aws_auth is bool
     if not isinstance(use_aws_auth, bool):
         use_aws_auth = True if use_aws_auth == 'true' else False
@@ -29,7 +31,8 @@ def includeme(config):
     # 'connection_class': TimedUrllib3HttpConnection
     es_options = {'serializer': PyramidJSONSerializer(json_renderer),
                   'connection_class': TimedRequestsHttpConnection,
-                  'timeout': es_request_timeout}
+                  'timeout': es_request_timeout,
+                  'retry_on_timeout': es_request_auto_retry}
 
     config.registry[ELASTIC_SEARCH] = create_es_client(address,
                                                        use_aws_auth=use_aws_auth,

--- a/snovault/elasticsearch/__init__.py
+++ b/snovault/elasticsearch/__init__.py
@@ -10,9 +10,17 @@ from .interfaces import APP_FACTORY, ELASTIC_SEARCH
 
 
 def includeme(config):
+    """ Creates the es_client for use by the application
+        Important options from settings:
+            * elasticsearch.server - URL of the server
+            * elasticsearch.aws_auth - whether or not to use local AWS creds
+            * elasticsearch.request_timeout - ES request timeout, defaults to 10 seconds but is
+              upped to 20 in our settings if not otherwise specified.
+    """
     settings = config.registry.settings
     address = settings['elasticsearch.server']
     use_aws_auth = settings.get('elasticsearch.aws_auth')
+    es_request_timeout = settings.get('elasticsearch.request_timeout', 20)
     # make sure use_aws_auth is bool
     if not isinstance(use_aws_auth, bool):
         use_aws_auth = True if use_aws_auth == 'true' else False
@@ -20,7 +28,8 @@ def includeme(config):
     # this previously-used option was causing problems (?)
     # 'connection_class': TimedUrllib3HttpConnection
     es_options = {'serializer': PyramidJSONSerializer(json_renderer),
-                  'connection_class': TimedRequestsHttpConnection}
+                  'connection_class': TimedRequestsHttpConnection,
+                  'timeout': es_request_timeout}
 
     config.registry[ELASTIC_SEARCH] = create_es_client(address,
                                                        use_aws_auth=use_aws_auth,


### PR DESCRIPTION
- Currently we have been using the default ES request timeout of 10 seconds. 
- However, because we submit bulk requests from the application to the ES cluster, it is likely a good idea to up this value since our queries are computationally intensive. Moreover, the cluster may still be trying to execute the request when a retry occurs compounding the effect.
- Provide the ability to specify 2 new application settings: `elasticsearch.request_timeout` and `elasticsearch.request_auto_retry`