### PR TITLE
Fix Indexer Main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.7.5"
+version = "4.7.6"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/elasticsearch/es_index_listener.py
+++ b/snovault/elasticsearch/es_index_listener.py
@@ -230,7 +230,7 @@ def main():
 
     # Loading app will have configured from config file. Reconfigure here:
     # Use `es_server=app.registry.settings.get('elasticsearch.server')` when ES logging is working
-    set_logging(in_prod=app.registry.settings.get('production'), level=logging.INFO)
+    set_logging(in_prod=testapp.app.registry.settings.get('production'), level=logging.INFO)
     return run(testapp, args.poll_interval, args.dry_run, args.path)
 
 


### PR DESCRIPTION
- In the ECS setup, the index listener will run via main and there is a syntax error preventing it from starting.