### PR TITLE
Revert Validation Change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.8.1b0"
+version = "4.8.1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.8.0"
+version = "4.8.1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.8.1"
+version = "4.8.1b0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/elasticsearch/indexer_queue.py
+++ b/snovault/elasticsearch/indexer_queue.py
@@ -392,7 +392,7 @@ class QueueManager(object):
                                 QueueName=queue_name,
                                 Attributes=queue_attrs
                             )
-                        except self.client.exceptions.QueueAlreadyExists:
+                        except self.client.exceptions.QueueNameExists:
                             # try to get queue url again
                             queue_url = self.get_queue_url(queue_name)
                             if queue_url:

--- a/snovault/validators.py
+++ b/snovault/validators.py
@@ -70,11 +70,11 @@ def delete_fields(request, data, schema):
     # data. If validated, return that validated value
     # Note 1: a deleted field with a default will be replaced with that value;
     #         if same value was already in data, allow regardless of permission
-    # Note 2: previously, validate_current was set to True here - it is unclear why that
-    #         was desired as it prevented you from using ?delete_fields for resolving
-    #         validation errors... although the preferred method is via upgrader, those
-    #         don't seem to function at this time. - Will 5/27/21
-    validated, errors = validate(schema, to_validate, current=data, validate_current=False)
+    # Note 2: setting validate_current = False here creates a vulnerability in
+    # that non-admin users can use delete_fields to revert protected fields to
+    # their defaults - see PR 95 - Will June 29 2021
+    # TODO: validate edit permission on query fields, do not validate current
+    validated, errors = validate(schema, to_validate, current=data, validate_current=True)
     if errors:
         for error in errors:
             if isinstance(error, IgnoreUnchanged):


### PR DESCRIPTION
- Previously I made a small change to validation that would allow us to use `delete_fields` to repair validation errors (since upgraders are broken)
- The previous change however introduced a small issue where non-admin users could reset protected fields back to their defaults by passing the field to `delete_fields`
- This change reverts the previous change, noting that we should instead be validating edit permissions on the query fields, not validating the `current` props (see #95 for explanation)