### PR TITLE
Allow utils 2.0 to be considered compatible

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -208,29 +208,31 @@ category = "main"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 name = "dcicutils"
 optional = false
-python-versions = ">=3.4,<3.8"
-version = "1.10.0"
+python-versions = ">=3.5,<3.8"
+version = "2.0.0"
 
 [package.dependencies]
 aws-requests-auth = ">=0.4.2,<1"
 boto3 = ">=1.10.46,<2.0.0"
 botocore = ">=1.13.46,<2.0.0"
+docker = ">=4.4.4,<5.0.0"
 elasticsearch = "6.8.1"
 gitpython = ">=3.1.2,<4.0.0"
 pytz = ">=2016.4"
 requests = ">=2.21.0,<3.0.0"
+rfc3986 = ">=1.4.0,<2.0.0"
 structlog = ">=19.2.0,<20.0.0"
 toml = ">=0.10.0,<1"
 urllib3 = ">=1.24.3,<2.0.0"
 webtest = ">=2.0.34,<3.0.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "A Python library for the Docker Engine API."
 name = "docker"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "4.4.1"
+version = "4.4.4"
 
 [package.dependencies]
 pywin32 = "227"
@@ -1020,7 +1022,7 @@ python-versions = "*"
 version = "2020.5"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python for Window Extensions"
 marker = "sys_platform == \"win32\""
 name = "pywin32"
@@ -1111,6 +1113,17 @@ urllib3 = ">=1.25.10"
 
 [package.extras]
 tests = ["coverage (>=3.7.1,<6.0.0)", "pytest-cov", "pytest-localserver", "flake8", "pytest (>=4.6,<5.0)", "pytest (>=4.6)"]
+
+[[package]]
+category = "main"
+description = "Validating URI References per RFC 3986"
+name = "rfc3986"
+optional = false
+python-versions = "*"
+version = "1.5.0"
+
+[package.extras]
+idna2008 = ["idna"]
 
 [[package]]
 category = "main"
@@ -1337,7 +1350,7 @@ docs = ["Sphinx (>=1.7.5)", "pylons-sphinx-themes"]
 testing = ["pytest (>=3.1.0)", "coverage", "pytest-cov", "pytest-xdist"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "WebSocket client for Python. hybi13 is supported."
 name = "websocket-client"
 optional = false
@@ -1475,8 +1488,7 @@ transaction = ">=1.6.0"
 test = ["zope.testing"]
 
 [metadata]
-content-hash = "b38faa6107ee2cc4783109fbfc49fa9b19c01ed2f0e7d2d1a6a861c26f5a1071"
-lock-version = "1.0"
+content-hash = "c81824a58196ccf67040a3ab691f632ecfd707f150a5890d5d13cd55d420a8a4"
 python-versions = ">=3.6,<3.7"
 
 [metadata.files]
@@ -1644,12 +1656,12 @@ cryptography = [
     {file = "cryptography-3.3.1.tar.gz", hash = "sha256:7e177e4bea2de937a584b13645cab32f25e3d96fc0bc4a4cf99c27dc77682be6"},
 ]
 dcicutils = [
-    {file = "dcicutils-1.10.0-py3-none-any.whl", hash = "sha256:79757f6ae722c6d17c4cedc1f1742782c51ec927de5add7539eaa220adc7e545"},
-    {file = "dcicutils-1.10.0.tar.gz", hash = "sha256:655e2041e0bbdf089a66942c3af2bc985fea347f890cea5b5681570a28424445"},
+    {file = "dcicutils-2.0.0-py3-none-any.whl", hash = "sha256:0995a1e00389fd5fbba9364e3e850f82e9525d4c8ea3bfd4a366571b5a17a2f8"},
+    {file = "dcicutils-2.0.0.tar.gz", hash = "sha256:c5e4d8ef3fec4b06a97921d3ff6e03952d18b8ade86051990305003418d35356"},
 ]
 docker = [
-    {file = "docker-4.4.1-py2.py3-none-any.whl", hash = "sha256:e455fa49aabd4f22da9f4e1c1f9d16308286adc60abaf64bf3e1feafaed81d06"},
-    {file = "docker-4.4.1.tar.gz", hash = "sha256:0604a74719d5d2de438753934b755bfcda6f62f49b8e4b30969a4b0a2a8a1220"},
+    {file = "docker-4.4.4-py2.py3-none-any.whl", hash = "sha256:f3607d5695be025fa405a12aca2e5df702a57db63790c73b927eb6a94aac60af"},
+    {file = "docker-4.4.4.tar.gz", hash = "sha256:d3393c878f575d3a9ca3b94471a3c89a6d960b35feb92f033c0de36cc9d934db"},
 ]
 docopt = [
     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
@@ -2049,6 +2061,10 @@ requests = [
 responses = [
     {file = "responses-0.12.1-py2.py3-none-any.whl", hash = "sha256:ef265bd3200bdef5ec17912fc64a23570ba23597fd54ca75c18650fa1699213d"},
     {file = "responses-0.12.1.tar.gz", hash = "sha256:2e5764325c6b624e42b428688f2111fea166af46623cb0127c05f6afb14d3457"},
+]
+rfc3986 = [
+    {file = "rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},
+    {file = "rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
 ]
 rutter = [
     {file = "rutter-0.3-py2.py3-none-any.whl", hash = "sha256:c42b03da9259666c7e0c2b4a533c61091dba2fd6f372611854165ec99f18a673"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.8.1"
+version = "4.8.2"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -42,7 +42,7 @@ aws_requests_auth = "^0.4.1"
 "backports.statistics" = "0.1.0"
 boto3 = "^1.7.42"
 elasticsearch_dsl = "^6.4.0"
-dcicutils = "^1.8.3"
+dcicutils = ">=1.8.3,<3"  # version 1 to 2 is not an incompatible change
 # TODO: Probably want ">=0.15.2,<1" here since "^" is different for "0.xx" than for higher versions. Changing it
 #       would require re-testing I don't have time for, so it'll have to be a future future change. -kmp 20-Feb-2020
 future = "^0.15.2"


### PR DESCRIPTION
This is a small change to allow `dcicutils>=1.8.3,<3` rather than `^1.8.3` which limited it to `>=1.8.3,<2`.
