### PR TITLE
Update create_mapping for upgrading items

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "4.8.3"
+version = "4.8.4"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/elasticsearch/create_mapping.py
+++ b/snovault/elasticsearch/create_mapping.py
@@ -866,7 +866,15 @@ def check_and_reindex_existing(app, es, in_type, uuids_to_index, index_diff=Fals
                         % (in_type, diff_uuids), collection=in_type)
     elif es_count is None or es_count != db_count:
         if index_diff:
-            diff_uuids.union(uuids_to_upgrade)
+            if uuids_to_upgrade:
+                diff_uuids.union(uuids_to_upgrade)
+                log.info(
+                    "MAPPING: queueing %s items found in existing index %s requiring an"
+                    " upgrade for reindexing"
+                    % (str(len(uuids_to_upgrade)), in_type), 
+                    items_queued=str(len(uuids_to_upgrade)),
+                    collection=in_type,
+                )
             log.info('MAPPING: queueing %s items found in DB but not ES or in need of'
                         ' upgrade in the index %s for reindexing' 
                         % (str(len(diff_uuids)), in_type), items_queued=str(len(diff_uuids)), collection=in_type)

--- a/snovault/elasticsearch/create_mapping.py
+++ b/snovault/elasticsearch/create_mapping.py
@@ -844,11 +844,10 @@ def check_and_reindex_existing(app, es, in_type, uuids_to_index, index_diff=Fals
     """
     Lastly, check to make sure the item count for the existing index
     matches the database document count and search for items in need of
-    upgrading. Queue any items in the database but not ES
+    upgrading. If found, always queue the latter items for indexing.
 
-    If there's a 
-    in the index for reindexing.
-    If index_diff, store uuids for reindexing that are in DB but not ES
+    If index_diff, only index the items in the database but not in ES
+    as well as the items to upgrade.
     """
     db_count, es_count, db_uuids, diff_uuids = get_db_es_counts_and_db_uuids(app, es, in_type, index_diff)
     uuids_to_upgrade = get_items_to_upgrade(app, es, in_type)

--- a/snovault/tests/test_create_mapping.py
+++ b/snovault/tests/test_create_mapping.py
@@ -3,7 +3,12 @@ import pytest
 import mock
 
 from ..interfaces import TYPES
-from ..elasticsearch.create_mapping import merge_schemas, type_mapping, update_mapping_by_embed
+from ..elasticsearch.create_mapping import (
+    merge_schemas,
+    type_mapping,
+    update_mapping_by_embed,
+    get_items_to_upgrade,
+)
 from ..elasticsearch.interfaces import ELASTIC_SEARCH
 from .test_views import PARAMETERIZED_NAMES
 from ..settings import Settings
@@ -146,3 +151,48 @@ def test_create_mapping_correctly_maps_embeds(registry, item_type):
             else:
                 assert split_ in mapping_pointer['properties']
                 mapping_pointer = mapping_pointer['properties'][split_]
+
+
+@pytest.fixture
+def biosample(testapp):
+    url = "/testing-biosample-sno"
+    item = {
+        "identifier": "test_biosample",
+        "ranking": 5,
+    }
+    return testapp.post_json(url, item, status=201).json["@graph"][0]
+
+
+@pytest.fixture
+def mock_search(biosample):
+    """Mock for ES search which returns list of AttrDict objects."""
+    embedded_item = mock.Mock()
+    embedded_item.schema_version = biosample["schema_version"]
+    embedded_item.uuid = biosample["uuid"]
+    es_item = mock.Mock()
+    es_item.embedded = embedded_item
+    mocked_search = mock.Mock()
+    mocked_search.return_value.source.return_value.scan.return_value = [es_item] 
+    return mocked_search
+
+
+@mock.patch("snovault.elasticsearch.create_mapping.check_if_index_exists", return_value=True)
+def test_get_items_to_upgrade(mock_check_index, mock_search, testapp, biosample):
+    """
+    Test Elasticsearch items requiring an upgrade are identified for
+    indexing. 
+    """
+    app = testapp.app
+    es = None  # ES component mocked
+    item_type = "testing_biosample_sno"
+    biosample_uuid = biosample["uuid"]
+    with mock.patch("snovault.elasticsearch.create_mapping.Search", new=mock_search):
+        # Item posted with schema default version, so no upgrade needed
+        to_upgrade = get_items_to_upgrade(app, es, item_type)
+        assert not to_upgrade
+
+        # Update the schema version in the registry so item needs upgrade
+        registry_schema = app.registry[TYPES][item_type].schema
+        registry_schema["properties"]["schema_version"]["default"] = 2
+        to_upgrade = get_items_to_upgrade(app, es, item_type)
+        assert to_upgrade == {biosample_uuid}

--- a/snovault/tests/test_create_mapping.py
+++ b/snovault/tests/test_create_mapping.py
@@ -163,7 +163,7 @@ def biosample(testapp):
     return testapp.post_json(url, item, status=201).json["@graph"][0]
 
 
-def mock_scan(uuids=[]):
+def mock_scan(uuids=None):
     """Mock for ES scan which returns list of dicts."""
     embedded_item = []
     if uuids:


### PR DESCRIPTION
Currently, items in ES that are in need of upgrading will not be queued for indexing upon deployment if there is no accompanying schema change. As a result, the items in ES are stale (not upgraded) and only views obtained with `database=datastore` will contain the upgraded item view.

This PR adds an additional check function to `create_mapping` such that if there has been no schema change to an item type then all items of that type are processed and added to the indexing queue if in need of upgrading. 

Note that the test included here is rather simple and mocks all of the ES functionality as no testapp with ES exists in this repo. I plan to include a test in the cgap-portal repo in an accompanying PR that tests for more complete functionality with ES once this is set.