### PR TITLE
Make pillow, wheel, and pyyaml be dev dependencies. If the portals wa…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ configure:  # does any pre-requisite installs
 	pip install poetry
 
 moto-setup: # As of 2022-01-13, this loads Jinja2-3.0.3 click-8.0.3 flask-2.0.2 itsdangerous-2.0.1
-	poetry run python -m pip install "moto[server]==1.3.16"
+	poetry run python -m pip install "moto[server]==1.3.7"
 
 macpoetry-install:
 	scripts/macpoetry-install

--- a/poetry.lock
+++ b/poetry.lock
@@ -704,7 +704,7 @@ docs = ["Sphinx (>=1.7.5)", "pylons-sphinx-themes"]
 name = "pillow"
 version = "6.2.2"
 description = "Python Imaging Library (Fork)"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -1097,7 +1097,7 @@ python-versions = "*"
 name = "pyyaml"
 version = "5.4.1"
 description = "YAML parser and emitter for Python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
@@ -1584,7 +1584,7 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.1,<3.8"
-content-hash = "e6a87aaded71b42ab733292aaf8d6aebc89bb6870d023d107b62cdd7a4395393"
+content-hash = "5ea33ff767e3ba28d2322fc9786e6a735983f89c9dd3559dbaa59770068d2b80"
 
 [metadata.files]
 atomicwrites = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -1584,7 +1584,7 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.1,<3.8"
-content-hash = "5ea33ff767e3ba28d2322fc9786e6a735983f89c9dd3559dbaa59770068d2b80"
+content-hash = "c5efc278d30278f1404b71d1e9542104628cb9dd7e9cb26d4c39c1f1a48bf197"
 
 [metadata.files]
 atomicwrites = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -702,11 +702,11 @@ docs = ["Sphinx (>=1.7.5)", "pylons-sphinx-themes"]
 
 [[package]]
 name = "pillow"
-version = "6.2.2"
+version = "8.4.0"
 description = "Python Imaging Library (Fork)"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "pip-licenses"
@@ -1584,7 +1584,7 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.1,<3.8"
-content-hash = "c5efc278d30278f1404b71d1e9542104628cb9dd7e9cb26d4c39c1f1a48bf197"
+content-hash = "9e8c21b2a74ffb8a43dbf728dd7cad6d6be6b5542ac1ea272ca0b44bcde69094"
 
 [metadata.files]
 atomicwrites = [
@@ -1967,36 +1967,47 @@ pastedeploy = [
     {file = "PasteDeploy-2.1.1.tar.gz", hash = "sha256:6dead6ab9823a85d585ef27f878bc647f787edb9ca8da0716aa9f1261b464817"},
 ]
 pillow = [
-    {file = "Pillow-6.2.2-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:834dd023b7f987d6b700ad93dc818098d7eb046bd445e9992b3093c6f9d7a95f"},
-    {file = "Pillow-6.2.2-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:d3a98444a00b4643b22b0685dbf9e0ddcaf4ebfd4ea23f84f228adf5a0765bb2"},
-    {file = "Pillow-6.2.2-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:2b4a94be53dff02af90760c10a2e3634c3c7703410f38c98154d5ce71fe63d20"},
-    {file = "Pillow-6.2.2-cp27-cp27m-win32.whl", hash = "sha256:87ef0eca169f7f0bc050b22f05c7e174a65c36d584428431e802c0165c5856ea"},
-    {file = "Pillow-6.2.2-cp27-cp27m-win_amd64.whl", hash = "sha256:cbd5647097dc55e501f459dbac7f1d0402225636deeb9e0a98a8d2df649fc19d"},
-    {file = "Pillow-6.2.2-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:4adc3302df4faf77c63ab3a83e1a3e34b94a6a992084f4aa1cb236d1deaf4b39"},
-    {file = "Pillow-6.2.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:e3a797a079ce289e59dbd7eac9ca3bf682d52687f718686857281475b7ca8e6a"},
-    {file = "Pillow-6.2.2-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:bb7861e4618a0c06c40a2e509c1bea207eea5fd4320d486e314e00745a402ca5"},
-    {file = "Pillow-6.2.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:535e8e0e02c9f1fc2e307256149d6ee8ad3aa9a6e24144b7b6e6fb6126cb0e99"},
-    {file = "Pillow-6.2.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:bc149dab804291a18e1186536519e5e122a2ac1316cb80f506e855a500b1cdd4"},
-    {file = "Pillow-6.2.2-cp35-cp35m-win32.whl", hash = "sha256:1a3bc8e1db5af40a81535a62a591fafdb30a8a1b319798ea8052aa65ef8f06d2"},
-    {file = "Pillow-6.2.2-cp35-cp35m-win_amd64.whl", hash = "sha256:d6b4dc325170bee04ca8292bbd556c6f5398d52c6149ca881e67daf62215426f"},
-    {file = "Pillow-6.2.2-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:43ef1cff7ee57f9c8c8e6fa02a62eae9fa23a7e34418c7ce88c0e3fe09d1fb38"},
-    {file = "Pillow-6.2.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:900de1fdc93764be13f6b39dc0dd0207d9ff441d87ad7c6e97e49b81987dc0f3"},
-    {file = "Pillow-6.2.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:92b83b380f9181cacc994f4c983d95a9c8b00b50bf786c66d235716b526a3332"},
-    {file = "Pillow-6.2.2-cp36-cp36m-win32.whl", hash = "sha256:00e0bbe9923adc5cc38a8da7d87d4ce16cde53b8d3bba8886cb928e84522d963"},
-    {file = "Pillow-6.2.2-cp36-cp36m-win_amd64.whl", hash = "sha256:5ccfcb0a34ad9b77ad247c231edb781763198f405a5c8dc1b642449af821fb7f"},
-    {file = "Pillow-6.2.2-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:5dcbbaa3a24d091a64560d3c439a8962866a79a033d40eb1a75f1b3413bfc2bc"},
-    {file = "Pillow-6.2.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6e2a7e74d1a626b817ecb7a28c433b471a395c010b2a1f511f976e9ea4363e64"},
-    {file = "Pillow-6.2.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:c424d35a5259be559b64490d0fd9e03fba81f1ce8e5b66e0a59de97547351d80"},
-    {file = "Pillow-6.2.2-cp37-cp37m-win32.whl", hash = "sha256:aa4792ab056f51b49e7d59ce5733155e10a918baf8ce50f64405db23d5627fa2"},
-    {file = "Pillow-6.2.2-cp37-cp37m-win_amd64.whl", hash = "sha256:0d5c99f80068f13231ac206bd9b2e80ea357f5cf9ae0fa97fab21e32d5b61065"},
-    {file = "Pillow-6.2.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:03457e439d073770d88afdd90318382084732a5b98b0eb6f49454746dbaae701"},
-    {file = "Pillow-6.2.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:ccf16fe444cc43800eeacd4f4769971200982200a71b1368f49410d0eb769543"},
-    {file = "Pillow-6.2.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:b72c39585f1837d946bd1a829a4820ccf86e361f28cbf60f5d646f06318b61e2"},
-    {file = "Pillow-6.2.2-cp38-cp38-win32.whl", hash = "sha256:3ba7d8f1d962780f86aa747fef0baf3211b80cb13310fff0c375da879c0656d4"},
-    {file = "Pillow-6.2.2-cp38-cp38-win_amd64.whl", hash = "sha256:3e81485cec47c24f5fb27acb485a4fc97376b2b332ed633867dc68ac3077998c"},
-    {file = "Pillow-6.2.2-pp273-pypy_73-win32.whl", hash = "sha256:aa1b0297e352007ec781a33f026afbb062a9a9895bb103c8f49af434b1666880"},
-    {file = "Pillow-6.2.2-pp373-pypy36_pp73-win32.whl", hash = "sha256:82859575005408af81b3e9171ae326ff56a69af5439d3fc20e8cb76cd51c8246"},
-    {file = "Pillow-6.2.2.tar.gz", hash = "sha256:db9ff0c251ed066d367f53b64827cc9e18ccea001b986d08c265e53625dab950"},
+    {file = "Pillow-8.4.0-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:81f8d5c81e483a9442d72d182e1fb6dcb9723f289a57e8030811bac9ea3fef8d"},
+    {file = "Pillow-8.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3f97cfb1e5a392d75dd8b9fd274d205404729923840ca94ca45a0af57e13dbe6"},
+    {file = "Pillow-8.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb9fc393f3c61f9054e1ed26e6fe912c7321af2f41ff49d3f83d05bacf22cc78"},
+    {file = "Pillow-8.4.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d82cdb63100ef5eedb8391732375e6d05993b765f72cb34311fab92103314649"},
+    {file = "Pillow-8.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:62cc1afda735a8d109007164714e73771b499768b9bb5afcbbee9d0ff374b43f"},
+    {file = "Pillow-8.4.0-cp310-cp310-win32.whl", hash = "sha256:e3dacecfbeec9a33e932f00c6cd7996e62f53ad46fbe677577394aaa90ee419a"},
+    {file = "Pillow-8.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:620582db2a85b2df5f8a82ddeb52116560d7e5e6b055095f04ad828d1b0baa39"},
+    {file = "Pillow-8.4.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:1bc723b434fbc4ab50bb68e11e93ce5fb69866ad621e3c2c9bdb0cd70e345f55"},
+    {file = "Pillow-8.4.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:72cbcfd54df6caf85cc35264c77ede902452d6df41166010262374155947460c"},
+    {file = "Pillow-8.4.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70ad9e5c6cb9b8487280a02c0ad8a51581dcbbe8484ce058477692a27c151c0a"},
+    {file = "Pillow-8.4.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25a49dc2e2f74e65efaa32b153527fc5ac98508d502fa46e74fa4fd678ed6645"},
+    {file = "Pillow-8.4.0-cp36-cp36m-win32.whl", hash = "sha256:93ce9e955cc95959df98505e4608ad98281fff037350d8c2671c9aa86bcf10a9"},
+    {file = "Pillow-8.4.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2e4440b8f00f504ee4b53fe30f4e381aae30b0568193be305256b1462216feff"},
+    {file = "Pillow-8.4.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:8c803ac3c28bbc53763e6825746f05cc407b20e4a69d0122e526a582e3b5e153"},
+    {file = "Pillow-8.4.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8a17b5d948f4ceeceb66384727dde11b240736fddeda54ca740b9b8b1556b29"},
+    {file = "Pillow-8.4.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1394a6ad5abc838c5cd8a92c5a07535648cdf6d09e8e2d6df916dfa9ea86ead8"},
+    {file = "Pillow-8.4.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:792e5c12376594bfcb986ebf3855aa4b7c225754e9a9521298e460e92fb4a488"},
+    {file = "Pillow-8.4.0-cp37-cp37m-win32.whl", hash = "sha256:d99ec152570e4196772e7a8e4ba5320d2d27bf22fdf11743dd882936ed64305b"},
+    {file = "Pillow-8.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:7b7017b61bbcdd7f6363aeceb881e23c46583739cb69a3ab39cb384f6ec82e5b"},
+    {file = "Pillow-8.4.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:d89363f02658e253dbd171f7c3716a5d340a24ee82d38aab9183f7fdf0cdca49"},
+    {file = "Pillow-8.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0a0956fdc5defc34462bb1c765ee88d933239f9a94bc37d132004775241a7585"},
+    {file = "Pillow-8.4.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b7bb9de00197fb4261825c15551adf7605cf14a80badf1761d61e59da347779"},
+    {file = "Pillow-8.4.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:72b9e656e340447f827885b8d7a15fc8c4e68d410dc2297ef6787eec0f0ea409"},
+    {file = "Pillow-8.4.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5a4532a12314149d8b4e4ad8ff09dde7427731fcfa5917ff16d0291f13609df"},
+    {file = "Pillow-8.4.0-cp38-cp38-win32.whl", hash = "sha256:82aafa8d5eb68c8463b6e9baeb4f19043bb31fefc03eb7b216b51e6a9981ae09"},
+    {file = "Pillow-8.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:066f3999cb3b070a95c3652712cffa1a748cd02d60ad7b4e485c3748a04d9d76"},
+    {file = "Pillow-8.4.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:5503c86916d27c2e101b7f71c2ae2cddba01a2cf55b8395b0255fd33fa4d1f1a"},
+    {file = "Pillow-8.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4acc0985ddf39d1bc969a9220b51d94ed51695d455c228d8ac29fcdb25810e6e"},
+    {file = "Pillow-8.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b052a619a8bfcf26bd8b3f48f45283f9e977890263e4571f2393ed8898d331b"},
+    {file = "Pillow-8.4.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:493cb4e415f44cd601fcec11c99836f707bb714ab03f5ed46ac25713baf0ff20"},
+    {file = "Pillow-8.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8831cb7332eda5dc89b21a7bce7ef6ad305548820595033a4b03cf3091235ed"},
+    {file = "Pillow-8.4.0-cp39-cp39-win32.whl", hash = "sha256:5e9ac5f66616b87d4da618a20ab0a38324dbe88d8a39b55be8964eb520021e02"},
+    {file = "Pillow-8.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:3eb1ce5f65908556c2d8685a8f0a6e989d887ec4057326f6c22b24e8a172c66b"},
+    {file = "Pillow-8.4.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:ddc4d832a0f0b4c52fff973a0d44b6c99839a9d016fe4e6a1cb8f3eea96479c2"},
+    {file = "Pillow-8.4.0-pp36-pypy36_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9a3e5ddc44c14042f0844b8cf7d2cd455f6cc80fd7f5eefbe657292cf601d9ad"},
+    {file = "Pillow-8.4.0-pp36-pypy36_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c70e94281588ef053ae8998039610dbd71bc509e4acbc77ab59d7d2937b10698"},
+    {file = "Pillow-8.4.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:3862b7256046fcd950618ed22d1d60b842e3a40a48236a5498746f21189afbbc"},
+    {file = "Pillow-8.4.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4901622493f88b1a29bd30ec1a2f683782e57c3c16a2dbc7f2595ba01f639df"},
+    {file = "Pillow-8.4.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84c471a734240653a0ec91dec0996696eea227eafe72a33bd06c92697728046b"},
+    {file = "Pillow-8.4.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:244cf3b97802c34c41905d22810846802a3329ddcb93ccc432870243211c79fc"},
+    {file = "Pillow-8.4.0.tar.gz", hash = "sha256:b8e2f83c56e141920c39464b852de3719dfbfb6e3c99a2d8da0edf4fb33176ed"},
 ]
 pip-licenses = [
     {file = "pip-licenses-3.5.3.tar.gz", hash = "sha256:f44860e00957b791c6c6005a3328f2d5eaeee96ddb8e7d87d4b0aa25b02252e4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,10 @@ flaky = ">=3.7.0"
 # to be configured, so will require some adaptation. moto 1.3,14 will support python 3.8, but python 3.9 support
 # needs moto 2.2.5. If we do eventually upgrade, there are some tests in test_storage.py that may be possible to
 # simplify. -kmp 5-Feb-2022
-moto = "^1.3.14"  # 2.x is available but needs adaptation. See note above. -kmp 5-Feb-2022
+#
+# We tried 1.3.14 but it adds stuff we don't need (until Python 3.8) and it doesn't work as well.
+# See https://github.com/spulec/moto/blob/master/CHANGELOG.md
+moto = "^1.3.7"  # 2.x is available but needs adaptation. See note above. -kmp 5-Feb-2022
 pip-licenses = "^3.5.3"
 # Not even sure we need an explicit dependence on Pillow, though it might help keep from searching older versions.
 # -kmp 22-Feb-2022

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "5.1.1"
+version = "5.1.1.1b0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -56,7 +56,6 @@ jsonschema_serialize_fork = "^2.1.1"
 # MarkupSafe = ">=0.23,<1"
 netaddr = ">=0.8.0,<1"
 passlib = "^1.7.4"
-Pillow = "^6.2.2"  # later version known to work - Will 11/17/20
 psutil = "^5.9.0"
 psycopg2-binary = "^2.9.1"
 PyBrowserID = ">=0.10.0,<1"
@@ -75,13 +74,6 @@ python-dateutil = "^2.8.2"
 #  - https://github.com/4dn-dcic/snovault/pull/147
 python_magic = ">=0.4.11,<1"
 pytz = ">=2021.3"
-# There was no version 4 of PyYAML. We upgraded today to PyYAML 5 per compatibility info in:
-# https://github.com/yaml/pyyaml/issues/265
-# We must have 5.1 to get the new yaml.safe_load method.
-# awscli appears to add its own restrictions, but our uses are pretty simple.
-# 5.2 had soe bugs that were probably only in Python 2, but we require 5.2 here just in case.
-# The narrowing to 5.3 is just to help 'poetry lock' converge faster. -kmp 1-Mar-2020
-PyYAML = ">=5.1,<5.5"
 rdflib = "^4.2.2"
 rdflib-jsonld = ">=0.5.0,<1.0.0"
 rutter = ">=0.3,<1"
@@ -99,7 +91,6 @@ venusian = "^1.2.0"
 WebOb = "^1.8.7"
 WebTest = "^2.0.35"
 WSGIProxy2 = "0.4.2"
-wheel = ">=0.29.0"
 xlrd = "^1.0.0"
 # zope = "^4.2.1"
 "zope.deprecation" = "^4.4.0"
@@ -118,6 +109,9 @@ flaky = ">=3.7.0"
 # simplify. -kmp 5-Feb-2022
 moto = "^1.3.14"  # 2.x is available but needs adaptation. See note above. -kmp 5-Feb-2022
 pip-licenses = "^3.5.3"
+# Not even sure we need an explicit dependence on Pillow, though it might help keep from searching older versions.
+# -kmp 22-Feb-2022
+Pillow = "^6.2.2"  # later version known to work - Will 11/17/20
 # Experimental upgrade to PyTest 4.5. It may be possible to upgrade further, but I think this is an improvement.
 # -kmp 11-May-2020
 pytest = "4.5.0"
@@ -129,9 +123,19 @@ pytest-mock = ">=0.11.0"
 # TODO: Investigate whether a major version upgrade is allowable for 'pytest-runner'.
 pytest-runner = ">=4.0"
 pytest-timeout = ">=1.0.0"
+# There was no version 4 of PyYAML. We upgraded today to PyYAML 5 per compatibility info in:
+# https://github.com/yaml/pyyaml/issues/265
+# We must have 5.1 to get the new yaml.safe_load method.
+# awscli appears to add its own restrictions, but our uses are pretty simple.
+# 5.2 had soe bugs that were probably only in Python 2, but we require 5.2 here just in case.
+# Any narrowing beyond that is just to help 'poetry lock' converge faster.
+# And we only need .safe_load in testing, so we're moving this to dev dependencies. -kmp 22-Feb-2022
+PyYAML = ">=5.1,<5.5"
 "repoze.debug" = ">=1.0.2"
 # Used only by moto, not explicitly by us.
 # responses = "^0.17.0"  # 0.17.0 is the last version compliant with Python 3.6
+wheel = ">=0.29.0"
+
 
 [tool.poetry.scripts]
 wipe-test-indices = "snovault.commands.wipe_test_indices:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "5.1.1.1b0"
+version = "5.2.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -111,6 +111,8 @@ moto = "^1.3.14"  # 2.x is available but needs adaptation. See note above. -kmp 
 pip-licenses = "^3.5.3"
 # Not even sure we need an explicit dependence on Pillow, though it might help keep from searching older versions.
 # -kmp 22-Feb-2022
+# Might also be a good idea to use >= instead of ^ when we have time to test that. For now am going with what is tested.
+# -kmp 23-Feb-2022
 Pillow = "^6.2.2"  # later version known to work - Will 11/17/20
 # Experimental upgrade to PyTest 4.5. It may be possible to upgrade further, but I think this is an improvement.
 # -kmp 11-May-2020

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,9 +114,7 @@ moto = "^1.3.7"  # 2.x is available but needs adaptation. See note above. -kmp 5
 pip-licenses = "^3.5.3"
 # Not even sure we need an explicit dependence on Pillow, though it might help keep from searching older versions.
 # -kmp 22-Feb-2022
-# Might also be a good idea to use >= instead of ^ when we have time to test that. For now am going with what is tested.
-# -kmp 23-Feb-2022
-Pillow = "^6.2.2"  # later version known to work - Will 11/17/20
+Pillow = ">=6.2.2"  # later version known to work - Will 11/17/20
 # Experimental upgrade to PyTest 4.5. It may be possible to upgrade further, but I think this is an improvement.
 # -kmp 11-May-2020
 pytest = "4.5.0"

--- a/snovault/tests/test_embedding.py
+++ b/snovault/tests/test_embedding.py
@@ -1,10 +1,16 @@
 import pytest
 
-from dcicutils.qa_utils import ignored, notice_pytest_fixtures
+from dcicutils.qa_utils import ignored, notice_pytest_fixtures, Retry
 from re import findall
 from ..interfaces import TYPES
 from ..util import add_default_embeds, crawl_schemas_by_embeds
 from .test_views import PARAMETERIZED_NAMES
+
+
+class DecayingRetry(Retry):
+    DEFAULT_RETRIES_ALLOWED = 3
+    DEFAULT_WAIT_SECONDS = 1
+    DEFAULT_WAIT_MULTIPLIER = 2
 
 
 targets = [
@@ -88,6 +94,7 @@ def test_manual_embeds(registry, item_type):
         assert error is None
 
 
+@DecayingRetry.retry_allowed(retries_allowed=3)
 def test_linked_uuids_unset(content, dummy_request, threadlocals):
     notice_pytest_fixtures(content, dummy_request, threadlocals)
     # without setting _indexing_view = True on the request,
@@ -97,6 +104,7 @@ def test_linked_uuids_unset(content, dummy_request, threadlocals):
     assert dummy_request._sid_cache == {}
 
 
+@DecayingRetry.retry_allowed(retries_allowed=3)
 def test_linked_uuids_object(content, dummy_request, threadlocals):
     notice_pytest_fixtures(content, dummy_request, threadlocals)
     # needed to track _linked_uuids
@@ -106,6 +114,7 @@ def test_linked_uuids_object(content, dummy_request, threadlocals):
     assert dummy_request._rev_linked_uuids_by_item == {}
 
 
+@DecayingRetry.retry_allowed(retries_allowed=3)
 def test_linked_uuids_embedded(content, dummy_request, threadlocals):
     notice_pytest_fixtures(content, dummy_request, threadlocals)
     # needed to track _linked_uuids
@@ -121,6 +130,7 @@ def test_linked_uuids_embedded(content, dummy_request, threadlocals):
     }
 
 
+@DecayingRetry.retry_allowed(retries_allowed=3)
 def test_linked_uuids_page(content, dummy_request, threadlocals):
     notice_pytest_fixtures(content, dummy_request, threadlocals)
     # needed to track _linked_uuids
@@ -135,6 +145,7 @@ def test_linked_uuids_page(content, dummy_request, threadlocals):
     }
 
 
+@DecayingRetry.retry_allowed(retries_allowed=3)
 def test_linked_uuids_expand_target(content, dummy_request, threadlocals):
     notice_pytest_fixtures(content, dummy_request, threadlocals)
     # needed to track _linked_uuids
@@ -150,6 +161,7 @@ def test_linked_uuids_expand_target(content, dummy_request, threadlocals):
     }
 
 
+@DecayingRetry.retry_allowed(retries_allowed=3)
 def test_linked_uuids_index_data(content, dummy_request, threadlocals):
     notice_pytest_fixtures(content, dummy_request, threadlocals)
     # this is the main view use to create data model for indexing


### PR DESCRIPTION
Make `pillow`, `wheel`, and `pyyaml` be dev dependencies. If the portals want them, they can make them be regular dependencies.