### PR TITLE
Type Specific Index Setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "5.2.0"
+version = "5.3.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/resources.py
+++ b/snovault/resources.py
@@ -32,7 +32,7 @@ from .util import (
     uuid_to_path
 )
 from past.builtins import basestring
-from .util import add_default_embeds
+from .util import add_default_embeds, IndexSettings
 
 logger = logging.getLogger(__name__)
 
@@ -242,6 +242,11 @@ class AbstractCollection(Resource, Mapping):
 
 class Collection(AbstractCollection):
     ''' Separate class so add views do not apply to AbstractCollection '''
+
+    @staticmethod
+    def index_settings():
+        """ Corresponds to the default index settings prior to the existence of this property """
+        return IndexSettings()
 
 
 # Almost every single display_title should have the same

--- a/snovault/tests/testing_views.py
+++ b/snovault/tests/testing_views.py
@@ -22,7 +22,7 @@ from ..config import collection, abstract_collection
 from ..schema_utils import load_schema
 from ..attachment import ItemWithAttachment
 from ..interfaces import CONNECTION
-# from .root import TestRoot
+from ..util import IndexSettings
 
 
 def includeme(config):
@@ -483,6 +483,11 @@ class TestingPostPutPatchSno(Item):
     item_type = 'testing_post_put_patch_sno'
     embedded_list = ['protected_link.*']
     schema = load_schema('snovault:test_schemas/TestingPostPutPatchSno.json')
+
+    class Collection(Item.Collection):
+        """ Overwrite the parent index settings. """
+        def index_settings(self):
+            return IndexSettings(replica_count=2)
 
 
 @collection('testing-server-defaults')


### PR DESCRIPTION
- Implements type specific index setting, documenting the important settings
- Configurable by overriding the `Collection.index_settings` method to return a custom `snovault.util.IndexSettings` object 

```
@collection(
    'testing-post-put-patch-sno',
    acl=[
        (Allow, 'group.submitter', ['add', 'edit', 'view']),
    ],
)
class TestingPostPutPatchSno(Item):
    item_type = 'testing_post_put_patch_sno'
    embedded_list = ['protected_link.*']
    schema = load_schema('snovault:test_schemas/TestingPostPutPatchSno.json')

    class Collection(Item.Collection):
        """ Overwrite the parent index settings. """
        def index_settings(self):
            return IndexSettings(replica_count=2)
```