### PR TITLE
Fix Serializer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "5.4.0.0b0"
+version = "5.4.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "5.3.0"
+version = "5.4.0.0b0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/json_renderer.py
+++ b/snovault/json_renderer.py
@@ -44,7 +44,10 @@ class JSONResult(object):
             return BinaryFromJSON(fp.app_iter)
 
 
-json_renderer = JSON(serializer=JSONResult.serializer)
+# Previous - override the serializer behavior
+# New - do not do this as it produces small _app_iter chunks internally
+# See https://github.com/Pylons/waitress/issues/373
+json_renderer = JSON()
 
 
 def uuid_adapter(obj, request):


### PR DESCRIPTION
- Undo `JSON` serializer override, falling back to the `pyramid` default which appears to be ~10x more performant with `waitress`