### PR TITLE
Add Auth0 Config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "5.4.0"
+version = "5.4.1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "5.4.1"
+version = "5.5.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/resource_views.py
+++ b/snovault/resource_views.py
@@ -15,7 +15,6 @@ from pyramid.view import (
     view_config,
 )
 
-import snovault
 from .calculated import calculate_properties
 from .resources import (
     AbstractCollection,
@@ -316,4 +315,3 @@ def item_view_raw(context, request):
     # add uuid to raw view
     props['uuid'] = str(context.uuid)
     return props
-

--- a/snovault/resource_views.py
+++ b/snovault/resource_views.py
@@ -15,6 +15,7 @@ from pyramid.view import (
     view_config,
 )
 
+import snovault
 from .calculated import calculate_properties
 from .resources import (
     AbstractCollection,
@@ -311,7 +312,8 @@ def item_view_raw(context, request):
     props = context.properties
     # only upgrade properties if explicitly requested
     if asbool(request.params.get('upgrade', True)):
-        props =  context.upgrade_properties()
+        props = context.upgrade_properties()
     # add uuid to raw view
     props['uuid'] = str(context.uuid)
     return props
+

--- a/snovault/resources.py
+++ b/snovault/resources.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 
 def includeme(config):
+    config.include(auth0_config)
     config.scan(__name__)
 
 
@@ -119,6 +120,33 @@ class Root(Resource):
     })
     def jsonld_type(self):
         return ['Portal']
+
+
+def auth0_config(config):
+    """ Route that exposes the auth0 domain and client ID for this app. """
+    config.add_route(
+        'auth0-config',
+        '/auth0_config'
+    )
+    auth0_config_values = {  # determines which values are echoed
+        'auth0.client': 'auth0Client',
+        'auth0.domain': 'auth0Domain',
+        'auth0.options': 'auth0Options'
+    }
+
+    def auth0_config_view(request):
+        response = request.response
+        response.content_type = 'application/json; charset=utf-8'
+        response_dict = {
+            'title': 'Auth0 Config',
+        }
+        settings = config.registry.settings
+        for config_key, result_key in auth0_config_values.items():
+            if config_key in settings:
+                response_dict[result_key] = settings[config_key]
+        return response_dict
+
+    config.add_view(auth0_config_view, route_name='auth0-config')
 
 
 class AbstractCollection(Resource, Mapping):

--- a/snovault/tests/test_views.py
+++ b/snovault/tests/test_views.py
@@ -417,3 +417,21 @@ def test_item_revision_history(testapp, registry):
     # they should be ordered by sid, recall the patch order above
     for patched_metadata, revision in zip([objv1, objv2, objv3, objv2, objv1], revisions):
         assert revision['title'] == patched_metadata['title']
+
+
+def _test_auth_config(testapp, registry):
+    cfg = testapp.get('/auth0_config').json
+    assert cfg['title'] == 'Auth0 Config'
+    assert cfg['auth0Client'] == registry.settings['auth0.client']
+    assert cfg['auth0Domain'] == registry.settings['auth0.domain']
+    assert cfg['auth0Options'] == registry.settings['auth0.options']
+
+
+def test_auth0_config_admin(testapp, registry):
+    """ Tests that acquiring auth0 config gives the expected values from settings. """
+    _test_auth_config(testapp, registry)
+
+
+def test_auth0_config_anon(anontestapp, registry):
+    """ Tests that acquiring auth0 config gives the expected values from settings. """
+    _test_auth_config(anontestapp, registry)

--- a/snovault/tests/test_views.py
+++ b/snovault/tests/test_views.py
@@ -428,10 +428,10 @@ def _test_auth_config(testapp, registry):
 
 
 def test_auth0_config_admin(testapp, registry):
-    """ Tests that acquiring auth0 config gives the expected values from settings. """
+    """ Tests that acquiring auth0 config gives the expected values from settings for admins. """
     _test_auth_config(testapp, registry)
 
 
 def test_auth0_config_anon(anontestapp, registry):
-    """ Tests that acquiring auth0 config gives the expected values from settings. """
+    """ Tests that acquiring auth0 config gives the expected values from settings for anonymous users. """
     _test_auth_config(anontestapp, registry)

--- a/snovault/tests/testappfixtures.py
+++ b/snovault/tests/testappfixtures.py
@@ -16,6 +16,22 @@ _app_settings = {
     'retry.attempts': 3,
     'production': True,
     'structlog.dir': '/tmp/',
+    'auth0.client': 'dummy-client',
+    'auth0.domain': 'dummy.domain',
+    'auth0.options': {
+        'auth': {
+            'sso': False,
+            'redirect': False,
+            'responseType': 'token',
+            'params': {
+                'scope': 'openid email',
+                'prompt': 'select_account'
+            }
+        },
+        'allowedConnections': [
+            'github', 'google-oauth2', 'partners'
+        ]
+    },
     'multiauth.policies': 'session remoteuser accesskey webuser',
     'multiauth.groupfinder': 'snovault.tests.authorization.groupfinder',
     'multiauth.policy.session.use': 'snovault.tests.authentication.NamespacedAuthenticationPolicy',


### PR DESCRIPTION
- Provides `/auth0_config`, which will echo back `auth0` configuration values that are configured from the backend (GAC).