### PR TITLE
Further upgrader version fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+
+# Vim
+*.swp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "5.6.0"
+version = "5.6.1b0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "5.6.1b0"
+version = "5.6.1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/batchupgrade.py
+++ b/snovault/batchupgrade.py
@@ -71,7 +71,7 @@ def worker(batch):
 
 def update_item(storage, context):
     target_version = context.type_info.schema_version
-    current_version = context.properties.get('schema_version', '')
+    current_version = context.properties.get('schema_version', '1')
     update = False
     errors = []
     properties = context.properties

--- a/snovault/resources.py
+++ b/snovault/resources.py
@@ -439,7 +439,7 @@ class Item(Resource):
         except KeyError:
             # don't fail if we try to upgrade properties on something not there yet
             return None
-        current_version = properties.get('schema_version', '')
+        current_version = properties.get('schema_version', '1')
         target_version = self.type_info.schema_version
         if target_version is not None and current_version != target_version:
             upgrader = self.registry[UPGRADER]


### PR DESCRIPTION
The recent upgrader fix (in v.5.6.0) added the default version of `1` for upgrader calls, but not all calls to the upgrader were included in the fix. Specifically, the upgrader call within `resources.py` is still resulting in errors. We fix that here, as well as the call within the possibly defunct `batchupgrade.py` for good measure. Grepping snovault for `upgrader.upgrade` didn't reveal any other instances of calls to the upgrader to fix.