### PR TITLE
Remove embeds of unmappable properties

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "5.6.1"
+version = "5.6.2"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/test_schemas/EmbeddingTest.json
+++ b/snovault/test_schemas/EmbeddingTest.json
@@ -2,7 +2,10 @@
     "title": "EmbeddingTest",
     "description": "Dummy Schema for testing embedding",
     "type": "object",
-    "required": ["title", "description"],
+    "required": [
+        "title",
+        "description"
+    ],
     "properties": {
         "schema_version": {
             "type": "object",
@@ -14,6 +17,64 @@
         },
         "uuid": {
             "type": "string"
+        },
+        "pattern_property_embed": {
+            "type": "object",
+            "patternProperties": {
+                "^testing_": {
+                    "type": "object",
+                    "properties": {
+                        "not_mapped": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "properties": {
+                "should_be_mapped": {
+                    "type": "string"
+                }
+            }
+        },
+        "pattern_property_no_embed": {
+            "type": "object",
+            "patternProperties": {
+                "^testing_": {
+                    "type": "object",
+                    "properties": {
+                        "not_mapped": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "additional_property_embed": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "not_mapped": {
+                        "type": "string"
+                    }
+                }
+            },
+            "properties": {
+                "should_be_mapped": {
+                    "type": "string"
+                }
+            }
+        },
+        "additional_property_no_embed": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "not_mapped": {
+                        "type": "string"
+                    }
+                }
+            }
         }
     },
     "columns": {

--- a/snovault/tests/test_create_mapping.py
+++ b/snovault/tests/test_create_mapping.py
@@ -153,6 +153,24 @@ def test_create_mapping_correctly_maps_embeds(registry, item_type):
                 mapping_pointer = mapping_pointer['properties'][split_]
 
 
+def test_create_mapping_drops_unmappable_properties(registry):
+    """Use EmbeddingTest schema to ensure unmappable properties under
+    patternProperties and additionalProperties are not mapped.
+    """
+    test_item_type = "embedding_test"
+    expected_embeds = ["pattern_property_embed", "additional_property_embed"]
+    expected_mapped_property = "should_be_mapped"
+    mapping = type_mapping(registry[TYPES], test_item_type)
+    mapped_properties = mapping.get("properties")
+    assert mapped_properties
+    for expected_embed in expected_embeds:
+        mapped_embed = mapped_properties.get(expected_embed)
+        assert mapped_embed
+        mapped_embed_properties = mapped_embed.get("properties", {})
+        assert len(mapped_embed_properties.keys()) == 1
+        assert mapped_embed_properties.get(expected_mapped_property)
+
+
 @pytest.fixture
 def biosample(testapp):
     url = "/testing-biosample-sno"

--- a/snovault/tests/test_embed_utils.py
+++ b/snovault/tests/test_embed_utils.py
@@ -42,13 +42,28 @@ def test_build_default_embeds():
 
 
 def test_find_default_embeds_and_expand_emb_list(registry):
-    # use EmbeddingTest as test case
-    # 'attachment' -> linkTo TestingDownload
+    """Use EmbeddingTest schema as test case.
+
+    Ensure objects with patternProperties or additionalProperties
+    sub-objects are only embedded if parent objects also include
+    other properties.
+    """
     type_info = registry[TYPES].by_item_type['embedding_test']
     schema_props = type_info.schema.get('properties')
     default_embeds = find_default_embeds_for_schema('', schema_props)
-    expected_embeds = ['attachment', 'principals_allowed.*']
+    expected_embeds = [
+        'attachment',  # 'attachment' -> linkTo TestingDownload
+        'principals_allowed.*',
+        'pattern_property_embed.*',
+        'additional_property_embed.*',
+    ]
+    expected_not_embeds = [  # In props but not default embeds == success
+        "pattern_property_no_embed",
+        "additional_property_no_embed",
+    ]
     assert(set(default_embeds) == set(expected_embeds))
+    for expected_not_embed in expected_not_embeds:
+        assert expected_not_embed in schema_props
 
     # get expansions from 'attachment'
     dummy_emb_list = [

--- a/snovault/util.py
+++ b/snovault/util.py
@@ -38,6 +38,12 @@ NESTED_ENABLED = 'enable_nested'
 # global index.refresh_interval - currently the default of 1s
 REFRESH_INTERVAL = '1s'
 
+# Schema keys to ignore when finding embeds
+SCHEMA_KEYS_TO_IGNORE_FOR_EMBEDS = [
+    "items", "properties", "additionalProperties", "patternProperties"
+]
+
+
 
 class IndexSettings:
     """ Object wrapping important ElasticSearch index settings. Previously these
@@ -676,8 +682,7 @@ def find_default_embeds_for_schema(path_thus_far, subschema):
         props_linkTos = find_default_embeds_for_schema(path_thus_far, subschema['properties'])
         linkTo_paths += props_linkTos
     for key, val in subschema.items():
-        keys_to_ignore = ["items", "properties", "additionalProperties", "patternProperties"]
-        if key in keys_to_ignore:
+        if key in SCHEMA_KEYS_TO_IGNORE_FOR_EMBEDS:
             continue
         elif key == 'linkTo':
             linkTo_paths.append(path_thus_far)

--- a/snovault/util.py
+++ b/snovault/util.py
@@ -676,7 +676,8 @@ def find_default_embeds_for_schema(path_thus_far, subschema):
         props_linkTos = find_default_embeds_for_schema(path_thus_far, subschema['properties'])
         linkTo_paths += props_linkTos
     for key, val in subschema.items():
-        if key in ["items", "properties", "additionalProperties", "patternProperties"]:
+        keys_to_ignore = ["items", "properties", "additionalProperties", "patternProperties"]
+        if key in keys_to_ignore:
             continue
         elif key == 'linkTo':
             linkTo_paths.append(path_thus_far)

--- a/snovault/util.py
+++ b/snovault/util.py
@@ -39,10 +39,9 @@ NESTED_ENABLED = 'enable_nested'
 REFRESH_INTERVAL = '1s'
 
 # Schema keys to ignore when finding embeds
-SCHEMA_KEYS_TO_IGNORE_FOR_EMBEDS = [
+SCHEMA_KEYS_TO_IGNORE_FOR_EMBEDS = set([
     "items", "properties", "additionalProperties", "patternProperties"
-]
-
+])
 
 
 class IndexSettings:

--- a/snovault/util.py
+++ b/snovault/util.py
@@ -676,7 +676,7 @@ def find_default_embeds_for_schema(path_thus_far, subschema):
         props_linkTos = find_default_embeds_for_schema(path_thus_far, subschema['properties'])
         linkTo_paths += props_linkTos
     for key, val in subschema.items():
-        if key == 'items' or key == 'properties':
+        if key in ["items", "properties", "additionalProperties", "patternProperties"]:
             continue
         elif key == 'linkTo':
             linkTo_paths.append(path_thus_far)


### PR DESCRIPTION
Here, we remove embeds of properties that cannot be mapped within our system, namely those that fall under `additionalProperties` or `patternProperties` in our schema.

As far as I understand things, since these fields cannot be mapped, adding them to an item's embedding list will not work regardless of the changes here, specifically the explicit removal of the properties from the default embeds in `find_default_embeds_for_schema`. Thus, no properties in the schema defined under `additionalProperties` or `patternProperties` can be embedded or used for invalidation scope with our current set-up, and significant refactoring would be required to make these work.