### PR TITLE
Genelist upload

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,88 @@
 [flake8]
 max-line-length = 120
+ignore =
+    # ==============================================================
+    # =========  Default list of things Flake8 would ignore ========
+    # ==============================================================
+    # E121: Continuation line under-indented for hanging indent
+    #       https://www.flake8rules.com/rules/E121.html
+    E121,
+    # E123: Closing bracket does not match indentation of opening bracket's line
+    #       https://www.flake8rules.com/rules/E123.html
+    E123,
+    # E126: Continuation line over-indented for hanging indent
+    #       https://www.flake8rules.com/rules/E126.html
+    E126,
+    # E226: Missing whitespace around arithmetic operator
+    #       https://www.flake8rules.com/rules/E226.html
+    E226,
+    # E24: ??? Hard to find doc on why this undocumented code's in default list
+    # E24,
+    # E704: Multiple statements on one line (def)
+    #       https://www.flake8rules.com/rules/E704.html
+    E704,
+    # W503: Line break occurred before a binary operator
+    #       https://www.flake8rules.com/rules/W503.html
+    W503,
+    # W504: Line break occurred after a binary operator
+    #       https://www.flake8rules.com/rules/W503.html
+    W504,
+    # ==============================================================
+    # =====  Other things we think it shouldn't complain about =====
+    # ==============================================================
+    # F541: f-string is missing placeholders
+    #       https://flake8.pycqa.org/en/latest/user/error-codes.html
+    F541,
+    # ==============================================================
+    # =====  We want these complaints eventually, but not now. =====
+    # ==============================================================
+    # E111 indentation is not a multiple of 4
+    E111,
+    # E116 unexpected indentation (comment)
+    E116,
+    # E122 continuation line missing indentation or outdented
+    E122,
+    # E124 closing bracket does not match visual indentation
+    E124,
+    # E127 continuation line over-indented for visual indent
+    E127,
+    # E128 continuation line under-indented for visual indent
+    E128,
+    # E201 whitespace after '['
+    E201,
+    # E202 whitespace before '}'
+    E202,
+    # E203 whitespace before ':'
+    E203,
+    # E221 multiple spaces before operator
+    E221,
+    # E222 multiple spaces after operator
+    E222,
+    # E231 missing whitespace after ':
+    E231,
+    # E241 multiple spaces after ':'
+    E241,
+    # E251 unexpected spaces around keyword / parameter equals
+    E251,
+    # E261 at least two spaces before inline comment
+    E261,
+    # E262 inline comment should start with '# '
+    E262,
+    # E265 block comment should start with '# '
+    E265,
+    # E266 too many leading '#' for block comment
+    E266,
+    # E272 multiple spaces before keyword
+    E272,
+    # W291 trailing whitespace
+    W291,
+    # W293 blank line contains whitespace
+    W293,
+    # E302 expected 2 blank lines
+    E302,
+    # E303 too many blank lines
+    E303,
+    # W391 blank line at end of file
+    W391,
+    # E501 line too long
+    E501,

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ moto-setup: # As of 2022-01-13, this loads Jinja2-3.0.3 click-8.0.3 flask-2.0.2 
 macpoetry-install:
 	scripts/macpoetry-install
 
+lint:
+	flake8 snovault
+
 macbuild:
 	make configure
 	make macpoetry-install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "6.0.2"
+version = "6.0.2.1b0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "6.0.3.1b0"
+version = "6.0.4"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "6.0.2.1b0"
+version = "6.0.3"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "6.0.3"
+version = "6.0.3.1b0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -141,7 +141,6 @@ PyYAML = ">=5.1,<5.5"
 # Used only by moto, not explicitly by us.
 # responses = "^0.17.0"  # 0.17.0 is the last version compliant with Python 3.6
 wheel = ">=0.29.0"
-
 
 [tool.poetry.scripts]
 wipe-test-indices = "snovault.commands.wipe_test_indices:main"

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,8 @@ addopts =
     -p snovault.tests.testappfixtures
     -p snovault.tests.serverfixtures
     --instafail
+filterwarnings =
+    ignore: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working:DeprecationWarning
 markers =
     es: mark a test as an elastic search test (deselect with '-m "not es"')
     indexing: mark a test as an indexing test (deselect with '-m "not indexing"')

--- a/snovault/elasticsearch/create_mapping.py
+++ b/snovault/elasticsearch/create_mapping.py
@@ -1214,6 +1214,10 @@ def run(app, collections=None, dry_run=False, check_first=False, skip_indexing=F
     log.info('\n___ES NODES___:\n %s\n' % (str(es.cat.nodes())), cat=cat)
     log.info('\n___ES HEALTH___:\n %s\n' % (str(es.cat.health())), cat=cat)
     log.info('\n___ES INDICES (PRE-MAPPING)___:\n %s\n' % str(es.cat.indices()), cat=cat)
+
+    if check_first and strict:
+        log.warning("In create_mapping.run, check_first=True and strict=True is an unusual combination.")
+
     # keep track of uuids to be indexed after mapping is done.
     # Set of uuids for each item type; keyed by item type. Order for python < 3.6
     uuids_to_index = OrderedDict()


### PR DESCRIPTION
Instrumentation added to help debug [C4-875](https://hms-dbmi.atlassian.net/browse/C4-875).

* Improved error messages for `ValidationFailure` in `attachment.py`.

Actual proposed fix:

* In attachment.py, replaced `mimetypes.guess_type` with new function `guess_mime_type` (adjusting the receipt of return value, since I adjusted that slightly to return the mime type, not a tuple of mime type and encoding. Make sure that we have useful return values for common file extensions.

Opportunistic:

* Better `.flake8` file excluding a bunch of whitespace-related issues we don't need to care about yet.
* Add a `lint` target to the `Makefile`.
* Suppress an annoying warning from the `jose` package (included by `moto 1.3.7`) about how it's not going to work in Python 3.9.
* Do keyword-calling of `ValidationFailure` in `attachment.py` just to clarify what the weird args are.
* Add an extra warning message in `create_mapping.py` for certain unusual argument combinations. (This had come up elsewhere in a discussion I had with Will and was just waiting for a PR to ride in on.)

Available as a beta for now so that we can revise this with additional instrumentation if needed.
