### PR TITLE
Blob KMS Fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ snovault
 Change Log
 ----------
 
+6.0.6
+=====
+
+* Evaluate KMS args as truthy for blob storage to avoid errors for empty string KMS key
+
+
 6.0.5
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "6.0.5"
+version = "6.0.6"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "6.0.5b0"
+version = "6.0.5"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "6.0.4"
+version = "6.0.5b0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "5.6.2"
+version = "5.6.3b0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/storage.py
+++ b/snovault/storage.py
@@ -690,7 +690,7 @@ class S3BlobStorage(object):
             Body=data,
             ContentType=content_type
         )
-        if self.kms_key_id is not None:
+        if self.kms_key_id:
             put_kwargs.update({
                 'ServerSideEncryption': 'aws:kms',
                 'SSEKMSKeyId': self.kms_key_id


### PR DESCRIPTION
Here, we restrict the use of KMS kwargs for storing blobs to only those situations when a KMS key ID is falsy, interpreting an empty string KMS key ID as though it were `None`.

Providing an empty string, as currently occurs when running a local docker build of CGAP, results in a `KMS.ValidationException` as such key IDs are expected to be non-empty and contain ASCII characters. This change fixes the issue for local docker builds of CGAP (no KMS parameters added within devtest environment that lacks KMS encryption) and should still result in a clear `AccessDenied` if the KMS key ID is an empty string and the environment requires KMS encryption.