### PR TITLE
Re-fix parse_version 1 in snovault/updater.py (C4-988)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 * In ``upgrader.py``, default ``parse_version`` argument to ``'0'``, rather than ``'1'``
   when ``None`` or the empty string is given.
 
+* Remove the Python 3.7 classifier in ``pyproject.toml``.
+
+* Add ``make clear-poetry-cache`` in ``Makefile``.
+
 
 7.1.2
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ Change Log
 ----------
 
 
+7.1.3
+=====
+
+* In ``upgrader.py``, default ``parse_version`` argument to ``'0'``, rather than ``'1'``
+  when ``None`` or the empty string is given.
+
+
 7.1.2
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Change Log
 
 * Add ``make clear-poetry-cache`` in ``Makefile``.
 
+* Misc PEP8.
+
 
 7.1.2
 =====

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ configure:  # does any pre-requisite installs
 	pip install wheel
 	pip install poetry
 
+clear-poetry-cache:  # clear poetry/pypi cache. for user to do explicitly, never automatic
+	poetry cache clear pypi --all
+
 macpoetry-install:
 	scripts/macpoetry-install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "7.1.2b0"  # to become 7.1.3
+version = "7.1.2.1b0"  # to become 7.1.3
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "7.1.2"
+version = "7.1.2b0"  # to become 7.1.3
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -31,7 +31,6 @@ classifiers = [
     # Specify the Python versions you support here. In particular, ensure
     # that you indicate whether you support Python 2, Python 3 or both.
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "7.1.2.1b0"  # to become 7.1.3
+version = "7.1.3"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/tests/conftest.py
+++ b/snovault/tests/conftest.py
@@ -1,9 +1,9 @@
-import os
-import time
-import tempfile
+# import os
+# import time
+# import tempfile
 import pytest
 import logging
-import subprocess
+# import subprocess
 
 from ..elasticsearch.indexer_queue import QueueManager
 

--- a/snovault/tests/test_embed_utils.py
+++ b/snovault/tests/test_embed_utils.py
@@ -29,7 +29,7 @@ def test_build_default_embeds():
         'obj1.*',
         'obj1.obj3.*'
     ]
-    assert(set(final_embeds) == set(expected_embeds))
+    assert set(final_embeds) == set(expected_embeds)
 
 
 def test_find_default_embeds_and_expand_emb_list(registry):
@@ -52,7 +52,7 @@ def test_find_default_embeds_and_expand_emb_list(registry):
         "pattern_property_no_embed",
         "additional_property_no_embed",
     ]
-    assert(set(default_embeds) == set(expected_embeds))
+    assert set(default_embeds) == set(expected_embeds)
     for expected_not_embed in expected_not_embeds:
         assert expected_not_embed in schema_props
 
@@ -69,13 +69,13 @@ def test_find_default_embeds_and_expand_emb_list(registry):
         'attachment.attachment2.*',
         'attachment.principals_allowed.*'
     ]
-    assert(set(embs_to_add) == set(expected_to_add))
+    assert set(embs_to_add) == set(expected_to_add)
 
     # add default embeds for all items 'attachment'
     test_embed = ['attachment.attachment.*']
     embs_to_add2, _ = expand_embedded_list('EmbeddingTest', registry[TYPES], test_embed, schema_props, set())
     expected_to_add2 = ['attachment']
-    assert(set(embs_to_add2) == set(expected_to_add2))
+    assert set(embs_to_add2) == set(expected_to_add2)
     # lastly check the built embeds
     expected_built = [
         'attachment.display_title',

--- a/snovault/tests/test_embedding.py
+++ b/snovault/tests/test_embedding.py
@@ -1,5 +1,5 @@
 import pytest
-import time
+# import time
 
 from dcicutils.misc_utils import ignored
 from dcicutils.qa_utils import notice_pytest_fixtures, Retry, Eventually
@@ -112,9 +112,11 @@ def test_linked_uuids_object(content, dummy_request, threadlocals):
     # needed to track _linked_uuids
     dummy_request._indexing_view = True
     dummy_request.embed('/testing-link-sources-sno/', sources[0]['uuid'], '@@object')
+
     def my_assertions():
         assert dummy_request._linked_uuids == {('16157204-8c8f-4672-a1a4-14f4b8021fcd', 'TestingLinkSourceSno')}
         assert dummy_request._rev_linked_uuids_by_item == {}
+
     Eventually.call_assertion(my_assertions)
 
 
@@ -186,7 +188,8 @@ def test_linked_uuids_index_data(content, dummy_request, threadlocals):
     assert res['rev_link_names'] == {}
     assert res['rev_linked_to_me'] == [targets[0]['uuid']]
     # object view linked uuids are contained within the embedded linked uuids
-    assert set((linked['uuid'], linked['item_type']) for linked in res['linked_uuids_object']) <= dummy_request._linked_uuids
+    assert set((linked['uuid'], linked['item_type'])
+               for linked in res['linked_uuids_object']) <= dummy_request._linked_uuids
 
     # now test the target. this will reset all attributes on dummy_request
     res2 = dummy_request.embed('/testing-link-targets-sno/', targets[0]['uuid'], '@@index-data', as_user='INDEXER')

--- a/snovault/tests/test_indexing.py
+++ b/snovault/tests/test_indexing.py
@@ -22,7 +22,6 @@ from elasticsearch.exceptions import NotFoundError
 from pyramid.traversal import traverse
 from sqlalchemy import MetaData
 from unittest import mock
-from webtest.app import AppError
 from zope.sqlalchemy import mark_changed
 from ..interfaces import DBSESSION, STORAGE, COLLECTIONS, TYPES
 from .. import util  # The filename util.py, not something in __init__.py
@@ -1039,7 +1038,7 @@ def test_check_and_reindex_existing(app, testapp):
     assert doc_count == 0
     test_uuids = {TEST_TYPE: set()}
     check_and_reindex_existing(app, es, TEST_TYPE, test_uuids)
-    assert(len(test_uuids)) == 1
+    assert len(test_uuids) == 1
 
 
 @pytest.mark.flaky
@@ -1721,7 +1720,7 @@ class TestInvalidationScopeViewSno:
     ])
     def test_invalidation_scope_view_error(self, indexer_testapp, req):
         """ Test failure cases """
-        with pytest.raises(AppError):
+        with pytest.raises(webtest.AppError):
             indexer_testapp.post_json('/compute_invalidation_scope', req)
 
 

--- a/snovault/tests/test_key.py
+++ b/snovault/tests/test_key.py
@@ -70,8 +70,8 @@ def test_keys_conflict(testapp):
     initial = testapp.get(url).json['@graph']
     testapp.post_json(url, item, status=201)
     posted = testapp.get(url).json['@graph']
-    assert(len(initial)+1 == len(posted))
+    assert len(initial)+1 == len(posted)
     conflict = testapp.post_json(url, item, status=409)
-    assert(conflict.status_code == 409)
+    assert conflict.status_code == 409
     conflicted = testapp.get(url).json['@graph']
-    assert(len(posted) == len(conflicted))
+    assert len(posted) == len(conflicted)

--- a/snovault/tests/test_storage.py
+++ b/snovault/tests/test_storage.py
@@ -1,7 +1,7 @@
 from unittest import mock
 import pytest
 import re
-import transaction as transaction_management
+# import transaction as transaction_management
 import uuid
 import boto3
 

--- a/snovault/upgrader.py
+++ b/snovault/upgrader.py
@@ -6,14 +6,15 @@ from pyramid.interfaces import PHASE1_CONFIG
 from .interfaces import PHASE2_5_CONFIG
 
 
-DEFAULT_VERSION_STRING = '0'
+DEFAULT_VERSION_STRING = ''
+IMPOSSIBLY_LOW_VERSION_STRING = '0'
 
 
 def parse_version(version_string: str):
-    return parse_pkg_version(version_string or DEFAULT_VERSION_STRING)
-
-
-DEFAULT_VERSION = parse_version(DEFAULT_VERSION_STRING)
+    # The expectation is that version_string will represent a version equal to or greater than '1',
+    # except that if the default version string ('') is given, it will represent a version
+    # that is less than all other version strings, IMPOSSIBLY_LOW_VERSION_STRING ('0').
+    return parse_pkg_version(version_string or IMPOSSIBLY_LOW_VERSION_STRING)
 
 
 def includeme(config):
@@ -87,9 +88,9 @@ class SchemaUpgrader(object):
         if dest is None:
             dest = self.version
         if parse_version(dest) <= parse_version(source):
-            raise ValueError("dest is less than source", dest, source)
+            raise ValueError(f"In add_upgrade_step, the dest {dest!r} is not greater than source {source!r}.")
         if parse_version(source) in self.upgrade_steps:
-            raise ConfigurationError('duplicate step for source', source)
+            raise ConfigurationError(f"In add_upgrade_step, a duplicate step was given for source {source!r}.")
         self.upgrade_steps[parse_version(source)] = UpgradeStep(step, source, dest)
 
     def upgrade(self, value, current_version='1', target_version=None, **kw):

--- a/snovault/upgrader.py
+++ b/snovault/upgrader.py
@@ -17,6 +17,9 @@ def parse_version(version_string: str):
     return parse_pkg_version(version_string or IMPOSSIBLY_LOW_VERSION_STRING)
 
 
+DEFAULT_VERSION = parse_version(DEFAULT_VERSION_STRING)
+
+
 def includeme(config):
     config.include('.typeinfo')
     config.registry[UPGRADER] = Upgrader(config.registry)
@@ -107,7 +110,7 @@ class SchemaUpgrader(object):
         # If no entry exists for the current_version, fallback to DEFAULT_VERSION_STRING
         if parse_version(version) not in self.upgrade_steps:
             try:
-                step = self.upgrade_steps[DEFAULT_VERSION_STRING]
+                step = self.upgrade_steps[DEFAULT_VERSION]
             except KeyError:
                 pass
             else:

--- a/snovault/upgrader.py
+++ b/snovault/upgrader.py
@@ -6,10 +6,10 @@ from pyramid.interfaces import PHASE1_CONFIG
 from .interfaces import PHASE2_5_CONFIG
 
 
-DEFAULT_VERSION_STRING = '1'
+DEFAULT_VERSION_STRING = '0'
 
 
-def parse_version(version_string):
+def parse_version(version_string: str):
     return parse_pkg_version(version_string or DEFAULT_VERSION_STRING)
 
 

--- a/snovault/upgrader.py
+++ b/snovault/upgrader.py
@@ -6,6 +6,7 @@ from pyramid.interfaces import PHASE1_CONFIG
 from .interfaces import PHASE2_5_CONFIG
 
 
+# These are weird values for defaults, but they are backward-compatible and this code is very tricky. -kmp 6-Feb-2023
 DEFAULT_VERSION_STRING = ''
 IMPOSSIBLY_LOW_VERSION_STRING = '0'
 


### PR DESCRIPTION
This PR intends to fix C4-988. @utku-ozturk has verified that it seems to repair the observed problem.

* In `snovault/upgrader.py`, default `parse_version` argument to `'0'`, rather than `'1'`  when `None` or the empty string is given. The change to this file is really the only very material change in this PR, even though several files are changed.

* Remove the Python 3.7 classifier in `pyproject.toml`.

* Add `make clear-poetry-cache` in `Makefile` for future use.

* Misc PEP8 for a number of other files because `make lint` was failing.