### PR TITLE
Mods to Will's core branch to allow testing to work better

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 clean:
 	rm -rf *.egg-info
 
+clear-poetry-cache:  # clear poetry/pypi cache. for user to do explicitly, never automatic
+	poetry cache clear pypi --all
+
+macpoetry-install:
+	scripts/macpoetry-install
+
 configure:  # does any pre-requisite installs
 	@#pip install --upgrade pip==21.0.1
 	pip install --upgrade pip
@@ -8,44 +14,33 @@ configure:  # does any pre-requisite installs
 	pip install wheel
 	pip install poetry
 
-clear-poetry-cache:  # clear poetry/pypi cache. for user to do explicitly, never automatic
-	poetry cache clear pypi --all
+build-poetry:
+	make configure
+	poetry install
 
-macpoetry-install:
-	scripts/macpoetry-install
-
-lint:
-	poetry run flake8 snovault
-
-macbuild:
+macbuild-poetry:
 	make configure
 	make macpoetry-install
-	make build-after-poetry
 
 build:
-	make configure
-	make build-configured
+	make build-poetry
+	make build-after-poetry
 
-build-configured:
-	poetry install
+macbuild:
+	make macbuild-poetry
+	make build-after-poetry
+
+build-after-poetry:
+	@echo "nothing to build after poetry"
 
 build-for-ga:
 	make configure
 	poetry config --local virtualenvs.create true
-	make build-configured
+	poetry install
 
-ES_URL = search-fourfront-testing-opensearch-kqm7pliix4wgiu4druk2indorq.us-east-1.es.amazonaws.com:443
-
-LOCAL_INSTAFAIL_OPTIONS = --timeout=200 -xvv --instafail
-LOCAL_MULTIFAIL_OPTIONS = --timeout=200 -vv
-GA_CICD_TESTING_OPTIONS = --timeout=400 -xvvv --durations=100 --aws-auth --es ${ES_URL}
-STATIC_ANALYSIS_OPTIONS =  -vv
-
-TEST_NAME ?= missing_TEST_NAME
-
-test-one:
-
-	SQLALCHEMY_WARN_20=1 pytest ${LOCAL_MULTIFAIL_OPTIONS} -k ${TEST_NAME}
+kill:
+	pkill -f postgres &
+	pkill -f elasticsearch &
 
 test:
 	@git log -1 --decorate | head -1
@@ -53,6 +48,18 @@ test:
 	make test-static && make test-unit && make test-indexing
 	@git log -1 --decorate | head -1
 	@date
+
+ES_URL = search-fourfront-testing-opensearch-kqm7pliix4wgiu4druk2indorq.us-east-1.es.amazonaws.com:443
+
+LOCAL_INSTAFAIL_OPTIONS = --timeout=400 -xvv --instafail
+LOCAL_MULTIFAIL_OPTIONS = --timeout=200 -vv
+GA_CICD_TESTING_OPTIONS = --timeout=400 -xvvv --durations=100 --aws-auth --es ${ES_URL}
+STATIC_ANALYSIS_OPTIONS =  -vv
+
+TEST_NAME ?= missing_TEST_NAME
+
+test-one:
+	SQLALCHEMY_WARN_20=1 pytest ${LOCAL_MULTIFAIL_OPTIONS} -k ${TEST_NAME}
 
 test-full:
 	@git log -1 --decorate | head -1
@@ -63,27 +70,58 @@ test-full:
 	@git log -1 --decorate | head -1
 	@date
 
-test-indexing:
-	SQLALCHEMY_WARN_20=1 poetry run pytest ${LOCAL_INSTAFAIL_OPTIONS} -m "indexing"
-
 test-unit:
 	SQLALCHEMY_WARN_20=1 poetry run pytest ${LOCAL_INSTAFAIL_OPTIONS} -m "not indexing"
 
-test-indexing-full:
-	SQLALCHEMY_WARN_20=1 poetry run pytest ${LOCAL_MULTIFAIL_OPTIONS} -m "indexing"
-
 test-unit-full:
 	SQLALCHEMY_WARN_20=1 poetry run pytest ${LOCAL_MULTIFAIL_OPTIONS} -m "not indexing"
+
+test-indexing-full:
+	make test-indexing-es-full
+	make test-indexing-not-es-full
+
+test-indexing-es-full:
+	SQLALCHEMY_WARN_20=1 poetry run pytest ${LOCAL_MULTIFAIL_OPTIONS} -m "indexing and es"
+
+test-indexing-not-es-full:
+	SQLALCHEMY_WARN_20=1 poetry run pytest ${LOCAL_MULTIFAIL_OPTIONS} -m "indexing and not es"
+
+test-indexing:
+	make test-indexing-es && make test-indexing-not-es
+
+test-indexing-es:
+	SQLALCHEMY_WARN_20=1 poetry run pytest ${LOCAL_INSTAFAIL_OPTIONS} -m "indexing and es"
+
+test-indexing-not-es:
+	SQLALCHEMY_WARN_20=1 poetry run pytest ${LOCAL_INSTAFAIL_OPTIONS} -m "indexing and not es"
+
+test-performance:
+	@echo "snovault has no performance tests right now, but it could."
+
+test-integrated:
+	@echo "snovault has no integrated tests right now, but it could."
 
 test-static:
 	NO_SERVER_FIXTURES=TRUE USE_SAMPLE_ENVUTILS=TRUE poetry run python -m pytest -vv -m static
 	make lint
 
-remote-test-indexing:
-	SQLALCHEMY_WARN_20=1 poetry run pytest ${GA_CICD_TESTING_OPTIONS} -m "indexing"
+remote-test:  # Actually, we don't normally use this. Instead the GA workflow sets up two parallel tests.
+	make remote-test-indexing && make remote-test-unit
 
-remote-test-unit:
+remote-test_unit:
+	make remote-test-indexing-not-es
+
+remote-test-not-indexing:
 	SQLALCHEMY_WARN_20=1 poetry run pytest ${GA_CICD_TESTING_OPTIONS} -m "not indexing"
+
+remote-test-indexing:
+	make remote-test-indexing-es && make remote-test-not-indexing
+
+remote-test-indexing-es:
+	SQLALCHEMY_WARN_20=1 poetry run pytest ${GA_CICD_TESTING_OPTIONS} -m "indexing and es"
+
+remote-test-indexing-not-es:
+	SQLALCHEMY_WARN_20=1 poetry run pytest ${GA_CICD_TESTING_OPTIONS} -m "indexing and not es"
 
 update:
 	poetry update
@@ -94,9 +132,12 @@ publish:
 publish-for-ga:
 	scripts/publish --noconfirm
 
-kill:
-	pkill -f postgres &
-	pkill -f elasticsearch &
+lint-full:
+	poetry run flake8 snovault/
+	poetry run flake8 deploy/
+
+lint:
+	poetry run flake8 snovault/ && poetry run flake8 deploy/
 
 help:
 	@make info

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ test-unit-full:
 	SQLALCHEMY_WARN_20=1 poetry run pytest ${LOCAL_MULTIFAIL_OPTIONS} -m "not indexing"
 
 test-indexing-full:
-	make test-indexing-es-full
 	make test-indexing-not-es-full
+	make test-indexing-es-full
 
 test-indexing-es-full:
 	SQLALCHEMY_WARN_20=1 poetry run pytest ${LOCAL_MULTIFAIL_OPTIONS} -m "indexing and es"
@@ -87,7 +87,7 @@ test-indexing-not-es-full:
 	SQLALCHEMY_WARN_20=1 poetry run pytest ${LOCAL_MULTIFAIL_OPTIONS} -m "indexing and not es"
 
 test-indexing:
-	make test-indexing-es && make test-indexing-not-es
+	make test-indexing-not-es && make test-indexing-es
 
 test-indexing-es:
 	SQLALCHEMY_WARN_20=1 poetry run pytest ${LOCAL_INSTAFAIL_OPTIONS} -m "indexing and es"
@@ -109,13 +109,13 @@ remote-test:  # Actually, we don't normally use this. Instead the GA workflow se
 	make remote-test-indexing && make remote-test-unit
 
 remote-test-unit:
-	make remote-test-indexing-not-es
+	make remote-test-not-indexing
 
 remote-test-not-indexing:
 	SQLALCHEMY_WARN_20=1 poetry run pytest ${GA_CICD_TESTING_OPTIONS} -m "not indexing"
 
 remote-test-indexing:
-	make remote-test-indexing-es && make remote-test-not-indexing
+	 make remote-test-indexing-not-es && make remote-test-indexing-es
 
 remote-test-indexing-es:
 	SQLALCHEMY_WARN_20=1 poetry run pytest ${GA_CICD_TESTING_OPTIONS} -m "indexing and es"

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ test-static:
 remote-test:  # Actually, we don't normally use this. Instead the GA workflow sets up two parallel tests.
 	make remote-test-indexing && make remote-test-unit
 
-remote-test_unit:
+remote-test-unit:
 	make remote-test-indexing-not-es
 
 remote-test-not-indexing:

--- a/snovault/tests/test_indexing.py
+++ b/snovault/tests/test_indexing.py
@@ -54,7 +54,7 @@ from .testing_views import TestingLinkSourceSno
 notice_pytest_fixtures(TestingLinkSourceSno)
 
 
-pytestmark = [pytest.mark.indexing]
+pytestmark = [pytest.mark.indexing, pytest.mark.es]
 
 
 TEST_COLL = '/testing-post-put-patch-sno/'
@@ -210,7 +210,7 @@ def test_indexer_namespacing(app, testapp, indexer_testapp):
         # app.registry.settings['indexer.namespace'] = indexer_namespace  # reset indexer_namespace
 
 
-@pytest.mark.es
+# @pytest.mark.es - Specified at top of file for whole file
 def test_indexer_queue_adds_telemetry_id(app):
     indexer_queue = app.registry[INDEXER_QUEUE]
     indexer_queue.clear_queue()
@@ -232,7 +232,7 @@ def test_indexer_queue_adds_telemetry_id(app):
     indexer_queue.delete_messages(received)
 
 
-@pytest.mark.es
+# @pytest.mark.es - Specified at top of file for whole file
 @pytest.mark.flaky
 def test_indexer_queue(app):
     indexer_queue_mirror = app.registry[INDEXER_QUEUE_MIRROR]


### PR DESCRIPTION
This isolates test_indexing for its own testing.
It also rearranges Makefile to better match order of targets with cgap-portal so their makefiles can be compared.
And it adds pytest.mark.es to test_indexing.py so it can be run in isolation.
