### PR TITLE
Fewer snovault pytest and sqlalchemy warnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,21 @@ snovault
 Change Log
 ----------
 
+
+8.0.1
+=====
+
+* Fix some warnings from ``pytest``
+
+  * If a method has "test" in its name but isn't a test, it needs a prefix "_"
+
+* Fix some warnings from ``sqlalchemy``
+
+  * ``session.connection()`` doesn't need to ``.connect()``
+  * ``.join(x, y, ...)`` should be ``.join(x).join(y)...``
+  * ``session.query(Foo).get(bar)`` should be ``session.get(Foo, bar)``
+
+
 8.0.0
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "8.0.0"
+version = "8.0.1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/tests/test_attachment.py
+++ b/snovault/tests/test_attachment.py
@@ -251,7 +251,7 @@ class TestAttachmentEncrypted:
     """
     url = '/testing-downloads/'
 
-    def testing_encrypted_download(self, testapp):
+    def _testing_encrypted_download(self, testapp):  # not a test, just does some setup
         item = {
             'attachment': {
                 'download': 'red-dot.png',
@@ -270,10 +270,10 @@ class TestAttachmentEncrypted:
         blob_bucket = 'encoded-4dn-blobs'  # note that this bucket exists but is mocked out here
         conn = boto3.resource('s3', region_name='us-east-1')
         conn.create_bucket(Bucket=blob_bucket)
-        return self.testing_encrypted_download(testapp)
+        return self._testing_encrypted_download(testapp)
 
     @staticmethod
-    def get_attachment_from_s3(client, url):
+    def _get_attachment_from_s3(client, url):
         """ Uses ff_utils.parse_s3_bucket_and_key_url to parse the s3 URL in our data into it's
             bucket, key pairs and acquires/reads the content.
         """
@@ -282,12 +282,12 @@ class TestAttachmentEncrypted:
 
     def attachment_is_red_dot(self, client, url):
         """ Fails assertion if the url is not the RED_DOT """
-        content = self.get_attachment_from_s3(client, url)
+        content = self._get_attachment_from_s3(client, url)
         assert content == b64decode(RED_DOT.split(',', 1)[1])
 
     def attachment_is_blue_dot(self, client, url):
         """ Fails assertion if the url is not the BLUE_DOT """
-        content = self.get_attachment_from_s3(client, url)
+        content = self._get_attachment_from_s3(client, url)
         assert content == b64decode(BLUE_DOT.split(',', 1)[1])
 
     @mock_s3

--- a/snovault/tests/test_indexing.py
+++ b/snovault/tests/test_indexing.py
@@ -128,7 +128,7 @@ def setup_and_teardown(app):
 
     # AFTER THE TEST
     session = app.registry[DBSESSION]
-    connection = session.connection().connect()
+    connection = session.connection()  # was session.connection().connect(), rewritten for SA2.0
     # The reflect=True argument to MetaData was deprecated. Instead, one is supposed to call the .reflect()
     # method after creation. (This comment is transitional and can go away if things seem to work normally.)
     # -kmp 11-May-2020
@@ -1960,7 +1960,8 @@ def test_assert_transactions_table_is_gone(app):
     """
     session = app.registry[DBSESSION]
     conn = session.connection()
-    conn.connect()
+    # In SQLAlchemy 2.0, it is no longer necessary to explicitly connect.
+    # conn.connect()
     # The reflect=True argument to MetaData was deprecated. Instead, one is supposed to call the .reflect()
     # method after creation. (This comment is transitional and can go away if things seem to work normally.)
     # -kmp 11-May-2020

--- a/snovault/tests/test_storage.py
+++ b/snovault/tests/test_storage.py
@@ -115,10 +115,11 @@ def test_get_by_json(session):
     resource = session.query(Resource).one()
     session.flush()
     query = (session.query(CurrentPropertySheet)
-             .join(CurrentPropertySheet.propsheet, CurrentPropertySheet.resource)
+             # Rewrittent to use two separate joins per SQLAlchemy 2.0 requirements. -kmp 10-Apr-2023
+             .join(CurrentPropertySheet.propsheet)
+             .join(CurrentPropertySheet.resource)
              .filter(PropertySheet.properties['foo'].astext == 'baz')
              )
-
     data = query.one()
     assert data.propsheet.properties == props2
 


### PR DESCRIPTION
This gets rid of some warnings.

* `pytest` warnings in `test_attachments.py` where a method name has "test" in its name but it isn't a test.
* `session.connection()` doesn't need to `.connect()`
* `.join(x, y, ...)` should be `.join(x).join(y)...`
* `session.query(Foo).get(bar)` should be `session.get(Foo, bar)`.
