### PR TITLE
Propagate subrequest stats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "8.0.1"
+version = "8.0.2b0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Here, we make a small update to functions involved in `request.embed()` to propagate the parent requests stats to the subrequest and do some minor refactoring.

Hit this bug when refactoring spreadsheet download code in cgap-portal previously written by Alex B. (see his comments [here](https://github.com/dbmi-bgm/cgap-portal/blob/master/src/encoded/batch_download.py#L142-L145)).

Note: wrapped propagation of the new attribute in a try/except clause to be conservative here given how central the function involved is.