### PR TITLE
Broaden schema merge references

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,13 +7,21 @@ Change Log
 ----------
 
 
+11.3.1
+======
+
+* Broaden schema ``$merge`` regex to allow mixin and other references
+
+
 11.3.0
 ======
+
 * Another thug commit to add CHANGELOG for below.
 
 
 11.2.0
 ======
+
 * Thug commit to change dcictuils from 8.2.0 to ^8.2.0.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.0.1.1b0"
+version = "11.3.1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.3.0"
+version = "11.0.1.1b0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/schema_utils.py
+++ b/snovault/schema_utils.py
@@ -147,7 +147,7 @@ def fetch_field_from_schema(schema: dict, ref_identifer: str) -> dict:
     return resolved
 
 
-MERGE_PATTERN = r'^([^:]+):(.+[.]json)#/properties/(.+)$'
+MERGE_PATTERN = r'^([^:]+):(.+[.]json)#/(.+)$'
 
 
 def match_merge_syntax(merge):

--- a/snovault/tests/test_schema_utils.py
+++ b/snovault/tests/test_schema_utils.py
@@ -427,7 +427,8 @@ def test_schema_utils_validates_date_times(testapp, invalid_date_time):
     'snovault:schemas/access_key.json#/properties/access_key_id',
     'snovault:schemas/access_key2.json#/properties/access_key_id',
     'snovault:schemas/access_key.json#/properties/access_key_id2',
-    'snovault:schemas/schema_one/access_key.json#/properties/object/access_key_id'
+    'snovault:schemas/schema_one/access_key.json#/properties/object/access_key_id',
+    'snovault:schemas/mixins.json#/access_key_id',
     ]
 )
 def test_schema_utils_merge_regex_matches(ref):
@@ -442,7 +443,6 @@ def test_schema_utils_merge_regex_matches(ref):
     'snovault:schemas/schema_one',
     'missing-package.json#/properties/schema',
     'snovault:schemas/access_key.jsn#/properties/access_key_id',
-    'snovault:schemas/access_key.json#/propertie/access_key_id',
     ]
 )
 def test_schema_utils_merge_regex_no_match(ref):


### PR DESCRIPTION
Here, we broaden the regex used in schema merge references (via `$merge`) to facilitate references to mixins, and possibly other, schemas in the file system.