### PR TITLE
Fix in loadxl to PATCH on validate_only for items which already exist.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,10 @@ Change Log
 
 * Fix in loadxl to PATCH on validate_only for items which already exist;
   discovered during smaht-submitr testing.
-
+* Added skip_links feature to loadxl which will cause reference/link integrity
+  checking to be skipped altogether; this is (currently) only set by smaht-portal/
+  ingestion/loadxl_extensions.py for smaht-submitr, since that process already
+  does thorough reference integrity checking anyways (via structured_data).
 
 11.12.0
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Change Log
 
 * Fix in loadxl to PATCH on validate_only for items which already exist;
   discovered during smaht-submitr testing.
+* Fix in loadxl.normalize_deleted_properties which was creating/returning
+  a new (an_item) item, which was messing up determination of identifying
+  path for patch (as second_round_items comes from store but we had set uuid
+  in an_item which, without this fix, became a different object).
 * Added skip_links feature to loadxl which will cause reference/link integrity
   checking to be skipped altogether; this is (currently) only set by smaht-portal/
   ingestion/loadxl_extensions.py for smaht-submitr, since that process already

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ snovault
 Change Log
 ----------
 
+11.13.0
+=======
+
+* Fix in loadxl to PATCH on validate_only for items which already exist;
+  discovered during smaht-submitr testing.
+
+
 11.12.0
 =======
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,13 +865,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dcicutils"
-version = "8.8.0.1b25"
+version = "8.8.1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 optional = false
 python-versions = ">=3.8,<3.12"
 files = [
-    {file = "dcicutils-8.8.0.1b25-py3-none-any.whl", hash = "sha256:68d0cbbbf98dbb5b67290847b0bc1d7df35c05f02c18188446d88a6d5a8f15e2"},
-    {file = "dcicutils-8.8.0.1b25.tar.gz", hash = "sha256:1c9ea6b33f56c56f7e4b1f7c772ec554edb97c74f9ac0355cfbf6daf511cac34"},
+    {file = "dcicutils-8.8.1-py3-none-any.whl", hash = "sha256:203d5cd8161f792dea90732c6790ae01672e8c82ed7cbaa34459ee047a742dd5"},
+    {file = "dcicutils-8.8.1.tar.gz", hash = "sha256:edad472337c9929ce2f64ab379d04c4681e138d26068acaa980103c0bce0dc21"},
 ]
 
 [package.dependencies]
@@ -3286,4 +3286,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "b45f8efdadfc1efc020b4d5a63de9c6b21412e4bb4df1ab2fc8d4dcb3fbb27fe"
+content-hash = "2c7ee504d8429761be4db54bdf644193837928042a48de092fc36feff8024902"

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,13 +865,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dcicutils"
-version = "8.8.0.1b5"
+version = "8.8.0.1b6"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 optional = false
 python-versions = ">=3.8,<3.12"
 files = [
-    {file = "dcicutils-8.8.0.1b5-py3-none-any.whl", hash = "sha256:6ed7adff95b6fb870b71ac3f7cb5b4be2ba7a2c20db44dd339633652ac596367"},
-    {file = "dcicutils-8.8.0.1b5.tar.gz", hash = "sha256:5d1f6c6289ce912435a871076468421075d8a5422257d1246cdcf398ee721b67"},
+    {file = "dcicutils-8.8.0.1b6-py3-none-any.whl", hash = "sha256:3f67cf637f3f88b43816839111dd3b6452c3f0d8ef88e7ef3db1d2c4f3654ed2"},
+    {file = "dcicutils-8.8.0.1b6.tar.gz", hash = "sha256:6f724747972ae64e7932152f6843cd6ae1778449e20c718b7e3a5792d4a95231"},
 ]
 
 [package.dependencies]
@@ -3286,4 +3286,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "4efbf6818327f0fc738079a5ea5991f62a486c6ffceda24cbc82cf6b9efd1639"
+content-hash = "9b0d38a05209e73212431111bf771f18f24058031317c4a29c3580e5033a5ab7"

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,13 +865,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dcicutils"
-version = "8.8.0.1b13"
+version = "8.8.0.1b16"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 optional = false
 python-versions = ">=3.8,<3.12"
 files = [
-    {file = "dcicutils-8.8.0.1b13-py3-none-any.whl", hash = "sha256:18fbb4ce0fc889f932031f24768f0101be1750747d2b93980f4994f8caef8aa8"},
-    {file = "dcicutils-8.8.0.1b13.tar.gz", hash = "sha256:0ffd76509e4c2a448e53ed08ac255b0c9f64af921c884cf57649e8def5995dbb"},
+    {file = "dcicutils-8.8.0.1b16-py3-none-any.whl", hash = "sha256:c59830c5886763c48f8f49536c4d702ff8c597f7c57f5b04b137f1fe82042584"},
+    {file = "dcicutils-8.8.0.1b16.tar.gz", hash = "sha256:2c943643b2ee588daec102f792893008a482aec64eac0d7c71bf1ba826e0729a"},
 ]
 
 [package.dependencies]
@@ -3286,4 +3286,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "4d44415fb47dd28b4e48433a8396b1e2cf1694ce9430ccca230222e35ad36364"
+content-hash = "fefa82dbdf21d4554aa5a8f41456a06e51ae0dae850e74d030ebd50e1b31cbd4"

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,13 +865,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dcicutils"
-version = "8.8.0.1b2"
+version = "8.8.0.1b3"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 optional = false
 python-versions = ">=3.8,<3.12"
 files = [
-    {file = "dcicutils-8.8.0.1b2-py3-none-any.whl", hash = "sha256:b15e4f6e6c87c711f2f4a010b48a852a2c523409be957fc68b112252d254b9df"},
-    {file = "dcicutils-8.8.0.1b2.tar.gz", hash = "sha256:e6db43f5621ccdfccb1fe1b88618ab168e808fa1da7684960fd32698d5fc4d13"},
+    {file = "dcicutils-8.8.0.1b3-py3-none-any.whl", hash = "sha256:98b69691c5cec6f2a93e96d20c2449a6cfcba59ea8bbb48871b07cff754a8b19"},
+    {file = "dcicutils-8.8.0.1b3.tar.gz", hash = "sha256:e01e37dfe142427e13a8509132317a3e249d9a9815eff670e7d6ddab601f0c0d"},
 ]
 
 [package.dependencies]
@@ -3286,4 +3286,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "32851c84f6c26c8b15737fd3bdedd02cb0773520933034ce79ab2587fa40615f"
+content-hash = "0ce54f2cff94bace9a1728cbe81dbb8beddf6fd5d4e8d08c3d997f80caf10788"

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,13 +865,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dcicutils"
-version = "8.8.0.1b4"
+version = "8.8.0.1b5"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 optional = false
 python-versions = ">=3.8,<3.12"
 files = [
-    {file = "dcicutils-8.8.0.1b4-py3-none-any.whl", hash = "sha256:c752d5e6613069f2f9d21a42f478a4b7710582d8fbab2383dd568e00812632a5"},
-    {file = "dcicutils-8.8.0.1b4.tar.gz", hash = "sha256:260f12d95015ddf01007997aafc0308907db2192528c98b914962530d7e7618c"},
+    {file = "dcicutils-8.8.0.1b5-py3-none-any.whl", hash = "sha256:6ed7adff95b6fb870b71ac3f7cb5b4be2ba7a2c20db44dd339633652ac596367"},
+    {file = "dcicutils-8.8.0.1b5.tar.gz", hash = "sha256:5d1f6c6289ce912435a871076468421075d8a5422257d1246cdcf398ee721b67"},
 ]
 
 [package.dependencies]
@@ -3286,4 +3286,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "98e24dcecabf6f5b8f14baaef145817451686d0444c892c395d55e5115793460"
+content-hash = "4efbf6818327f0fc738079a5ea5991f62a486c6ffceda24cbc82cf6b9efd1639"

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,13 +865,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dcicutils"
-version = "8.8.0.1b3"
+version = "8.8.0.1b4"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 optional = false
 python-versions = ">=3.8,<3.12"
 files = [
-    {file = "dcicutils-8.8.0.1b3-py3-none-any.whl", hash = "sha256:98b69691c5cec6f2a93e96d20c2449a6cfcba59ea8bbb48871b07cff754a8b19"},
-    {file = "dcicutils-8.8.0.1b3.tar.gz", hash = "sha256:e01e37dfe142427e13a8509132317a3e249d9a9815eff670e7d6ddab601f0c0d"},
+    {file = "dcicutils-8.8.0.1b4-py3-none-any.whl", hash = "sha256:c752d5e6613069f2f9d21a42f478a4b7710582d8fbab2383dd568e00812632a5"},
+    {file = "dcicutils-8.8.0.1b4.tar.gz", hash = "sha256:260f12d95015ddf01007997aafc0308907db2192528c98b914962530d7e7618c"},
 ]
 
 [package.dependencies]
@@ -3286,4 +3286,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "0ce54f2cff94bace9a1728cbe81dbb8beddf6fd5d4e8d08c3d997f80caf10788"
+content-hash = "98e24dcecabf6f5b8f14baaef145817451686d0444c892c395d55e5115793460"

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,13 +865,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dcicutils"
-version = "8.8.0.1b6"
+version = "8.8.0.1b8"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 optional = false
 python-versions = ">=3.8,<3.12"
 files = [
-    {file = "dcicutils-8.8.0.1b6-py3-none-any.whl", hash = "sha256:3f67cf637f3f88b43816839111dd3b6452c3f0d8ef88e7ef3db1d2c4f3654ed2"},
-    {file = "dcicutils-8.8.0.1b6.tar.gz", hash = "sha256:6f724747972ae64e7932152f6843cd6ae1778449e20c718b7e3a5792d4a95231"},
+    {file = "dcicutils-8.8.0.1b8-py3-none-any.whl", hash = "sha256:0ca5ca54ddfbb84203d44b190e84fab35d6ef53e647a2b0c1b587e9028f4c0f8"},
+    {file = "dcicutils-8.8.0.1b8.tar.gz", hash = "sha256:15e0b230b632124a987701755830f0c54acf3d8ce0cb9aec89a55f8adb55f94b"},
 ]
 
 [package.dependencies]
@@ -3286,4 +3286,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "9b0d38a05209e73212431111bf771f18f24058031317c4a29c3580e5033a5ab7"
+content-hash = "60fdec63fa5cbf0df296968b488cae7213de35e6199def7b2baae9862330ca90"

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,13 +865,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dcicutils"
-version = "8.8.0.1b16"
+version = "8.8.0.1b18"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 optional = false
 python-versions = ">=3.8,<3.12"
 files = [
-    {file = "dcicutils-8.8.0.1b16-py3-none-any.whl", hash = "sha256:c59830c5886763c48f8f49536c4d702ff8c597f7c57f5b04b137f1fe82042584"},
-    {file = "dcicutils-8.8.0.1b16.tar.gz", hash = "sha256:2c943643b2ee588daec102f792893008a482aec64eac0d7c71bf1ba826e0729a"},
+    {file = "dcicutils-8.8.0.1b18-py3-none-any.whl", hash = "sha256:93fac82236b2ea08edd679b6c22e7b588a854479ccebfa975542a1b57d3dfd60"},
+    {file = "dcicutils-8.8.0.1b18.tar.gz", hash = "sha256:e555865f0b222bcbe87bf85f365a4193496ac5de703db01660663fc49c832e54"},
 ]
 
 [package.dependencies]
@@ -3286,4 +3286,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "fefa82dbdf21d4554aa5a8f41456a06e51ae0dae850e74d030ebd50e1b31cbd4"
+content-hash = "05f0b6d5a5525ca7d58b8ace2a4d795777a55b996aa10519f0d7ecad6c473970"

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,13 +865,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dcicutils"
-version = "8.8.0.1b10"
+version = "8.8.0.1b11"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 optional = false
 python-versions = ">=3.8,<3.12"
 files = [
-    {file = "dcicutils-8.8.0.1b10-py3-none-any.whl", hash = "sha256:602d8ec295a903d99ed40ddfaf30c0192acda8b1ab587383f35e3e9b8442c141"},
-    {file = "dcicutils-8.8.0.1b10.tar.gz", hash = "sha256:a028be88c4adfb859081c1b80d70fa8cd107987a9bf2cc78969492cb48e63d2e"},
+    {file = "dcicutils-8.8.0.1b11-py3-none-any.whl", hash = "sha256:98f1891510f6a9f8406ba52528caaa48164356c2248cc4f5f81cdf8581e81955"},
+    {file = "dcicutils-8.8.0.1b11.tar.gz", hash = "sha256:28323c61e724846a271d6d6f11d593ae650dfc316a7e86de653c65c3b0fa2af5"},
 ]
 
 [package.dependencies]
@@ -3286,4 +3286,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "75151b707538de2ba167685f79c9e5094e8268ca1dfa8b7fcf2e21391efda643"
+content-hash = "c42babac8b34419631881457eb7ef672168fe2f72108a6156083826c1b438680"

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,13 +865,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dcicutils"
-version = "8.8.0.1b18"
+version = "8.8.0.1b20"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 optional = false
 python-versions = ">=3.8,<3.12"
 files = [
-    {file = "dcicutils-8.8.0.1b18-py3-none-any.whl", hash = "sha256:93fac82236b2ea08edd679b6c22e7b588a854479ccebfa975542a1b57d3dfd60"},
-    {file = "dcicutils-8.8.0.1b18.tar.gz", hash = "sha256:e555865f0b222bcbe87bf85f365a4193496ac5de703db01660663fc49c832e54"},
+    {file = "dcicutils-8.8.0.1b20-py3-none-any.whl", hash = "sha256:97364bb84ac87be281568dbc36075ac9ba11691fa2aff2e3ce7de3042d15c7fd"},
+    {file = "dcicutils-8.8.0.1b20.tar.gz", hash = "sha256:bd2b35330476a0c2a83230ba0d3d91ece46bf5b9f4af852267bce8896546aabc"},
 ]
 
 [package.dependencies]
@@ -3286,4 +3286,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "05f0b6d5a5525ca7d58b8ace2a4d795777a55b996aa10519f0d7ecad6c473970"
+content-hash = "14483a20ceb62dde8bdaf907d7aed859dd638760cbc6feb858a934f1b21877a7"

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,13 +865,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dcicutils"
-version = "8.8.0.1b11"
+version = "8.8.0.1b13"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 optional = false
 python-versions = ">=3.8,<3.12"
 files = [
-    {file = "dcicutils-8.8.0.1b11-py3-none-any.whl", hash = "sha256:98f1891510f6a9f8406ba52528caaa48164356c2248cc4f5f81cdf8581e81955"},
-    {file = "dcicutils-8.8.0.1b11.tar.gz", hash = "sha256:28323c61e724846a271d6d6f11d593ae650dfc316a7e86de653c65c3b0fa2af5"},
+    {file = "dcicutils-8.8.0.1b13-py3-none-any.whl", hash = "sha256:18fbb4ce0fc889f932031f24768f0101be1750747d2b93980f4994f8caef8aa8"},
+    {file = "dcicutils-8.8.0.1b13.tar.gz", hash = "sha256:0ffd76509e4c2a448e53ed08ac255b0c9f64af921c884cf57649e8def5995dbb"},
 ]
 
 [package.dependencies]
@@ -3286,4 +3286,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "c42babac8b34419631881457eb7ef672168fe2f72108a6156083826c1b438680"
+content-hash = "4d44415fb47dd28b4e48433a8396b1e2cf1694ce9430ccca230222e35ad36364"

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,13 +865,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dcicutils"
-version = "8.8.0.1b1"
+version = "8.8.0.1b2"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 optional = false
 python-versions = ">=3.8,<3.12"
 files = [
-    {file = "dcicutils-8.8.0.1b1-py3-none-any.whl", hash = "sha256:e67e7f3650868bc24e4846435aaf0f2f791b3f98ab7d78943074c66d34ce8ebb"},
-    {file = "dcicutils-8.8.0.1b1.tar.gz", hash = "sha256:1ba35bdb5417d0c4f4450e4eaade19e0d0a04ba5e2bd6a198a7ced7808afef16"},
+    {file = "dcicutils-8.8.0.1b2-py3-none-any.whl", hash = "sha256:b15e4f6e6c87c711f2f4a010b48a852a2c523409be957fc68b112252d254b9df"},
+    {file = "dcicutils-8.8.0.1b2.tar.gz", hash = "sha256:e6db43f5621ccdfccb1fe1b88618ab168e808fa1da7684960fd32698d5fc4d13"},
 ]
 
 [package.dependencies]
@@ -3286,4 +3286,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "b1ebd28985b8edf540d5a70f8fa44ae61040dd13c9cb1ca60fb0937aea8b49ce"
+content-hash = "32851c84f6c26c8b15737fd3bdedd02cb0773520933034ce79ab2587fa40615f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,13 +865,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dcicutils"
-version = "8.8.0.1b8"
+version = "8.8.0.1b9"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 optional = false
 python-versions = ">=3.8,<3.12"
 files = [
-    {file = "dcicutils-8.8.0.1b8-py3-none-any.whl", hash = "sha256:0ca5ca54ddfbb84203d44b190e84fab35d6ef53e647a2b0c1b587e9028f4c0f8"},
-    {file = "dcicutils-8.8.0.1b8.tar.gz", hash = "sha256:15e0b230b632124a987701755830f0c54acf3d8ce0cb9aec89a55f8adb55f94b"},
+    {file = "dcicutils-8.8.0.1b9-py3-none-any.whl", hash = "sha256:4a26445e4924e40bec6baf2d64ffbaaf0674d20bed2099b14d93eae64b58d18d"},
+    {file = "dcicutils-8.8.0.1b9.tar.gz", hash = "sha256:df93b3a4d076c188a72401e90c69bca50a8473215e34f2201a5a3f0037a7be71"},
 ]
 
 [package.dependencies]
@@ -3286,4 +3286,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "60fdec63fa5cbf0df296968b488cae7213de35e6199def7b2baae9862330ca90"
+content-hash = "a42255f5e4d5b44bb8d068d6c78e804f59cd2b5053781cd214e4cc9b6a8cebf4"

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,13 +865,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dcicutils"
-version = "8.8.0.1b20"
+version = "8.8.0.1b25"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 optional = false
 python-versions = ">=3.8,<3.12"
 files = [
-    {file = "dcicutils-8.8.0.1b20-py3-none-any.whl", hash = "sha256:97364bb84ac87be281568dbc36075ac9ba11691fa2aff2e3ce7de3042d15c7fd"},
-    {file = "dcicutils-8.8.0.1b20.tar.gz", hash = "sha256:bd2b35330476a0c2a83230ba0d3d91ece46bf5b9f4af852267bce8896546aabc"},
+    {file = "dcicutils-8.8.0.1b25-py3-none-any.whl", hash = "sha256:68d0cbbbf98dbb5b67290847b0bc1d7df35c05f02c18188446d88a6d5a8f15e2"},
+    {file = "dcicutils-8.8.0.1b25.tar.gz", hash = "sha256:1c9ea6b33f56c56f7e4b1f7c772ec554edb97c74f9ac0355cfbf6daf511cac34"},
 ]
 
 [package.dependencies]
@@ -3286,4 +3286,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "14483a20ceb62dde8bdaf907d7aed859dd638760cbc6feb858a934f1b21877a7"
+content-hash = "b45f8efdadfc1efc020b4d5a63de9c6b21412e4bb4df1ab2fc8d4dcb3fbb27fe"

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,13 +865,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dcicutils"
-version = "8.8.0"
+version = "8.8.0.1b1"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 optional = false
 python-versions = ">=3.8,<3.12"
 files = [
-    {file = "dcicutils-8.8.0-py3-none-any.whl", hash = "sha256:1817910ed91026353b882ba4659d16cd7e49ca4b2db85548f8e43f6f70ee65d1"},
-    {file = "dcicutils-8.8.0.tar.gz", hash = "sha256:afa63f7cf0c0ffd39d4e0ac172240b5074ba352edca9813db1a97f1808631a31"},
+    {file = "dcicutils-8.8.0.1b1-py3-none-any.whl", hash = "sha256:e67e7f3650868bc24e4846435aaf0f2f791b3f98ab7d78943074c66d34ce8ebb"},
+    {file = "dcicutils-8.8.0.1b1.tar.gz", hash = "sha256:1ba35bdb5417d0c4f4450e4eaade19e0d0a04ba5e2bd6a198a7ced7808afef16"},
 ]
 
 [package.dependencies]
@@ -3286,4 +3286,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "3dc8b2d63c44201930bcb91763e5f172ee8133b37d339188b04a11d893b4a5e4"
+content-hash = "b1ebd28985b8edf540d5a70f8fa44ae61040dd13c9cb1ca60fb0937aea8b49ce"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.0.1b2"  # TODO: To become 11.13.0
+version = "11.12.0.1b3"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2.1b6"  # TODO: To become 11.13.0
+version = "11.12.2.1b7"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -44,7 +44,7 @@ botocore = ">=1.31.62"  # no particular version required, but this speeds up sea
 elasticsearch = "7.13.4"  # versions >= 7.14.0 lock out AWS ES
 elasticsearch_dsl = "^7.4.0"
 #dcicutils = "^8.8.0"
-dcicutils = "8.8.0.1b4"
+dcicutils = "8.8.0.1b5"
 future = ">=0.15.2,<1"
 html5lib = ">=1.1"  # experimental, should be OK now that we're not using moto server
 humanfriendly = "^1.44.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2.1b9"  # TODO: To become 11.13.0
+version = "11.12.2.1b10"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -44,7 +44,7 @@ botocore = ">=1.31.62"  # no particular version required, but this speeds up sea
 elasticsearch = "7.13.4"  # versions >= 7.14.0 lock out AWS ES
 elasticsearch_dsl = "^7.4.0"
 #dcicutils = "^8.8.0"
-dcicutils = "8.8.0.1b6"
+dcicutils = "8.8.0.1b8"
 future = ">=0.15.2,<1"
 html5lib = ">=1.1"  # experimental, should be OK now that we're not using moto server
 humanfriendly = "^1.44.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.0"
+version = "11.12.0.1b1"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2.1b3"  # TODO: To become 11.13.0
+version = "11.12.2.1b4"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -44,7 +44,7 @@ botocore = ">=1.31.62"  # no particular version required, but this speeds up sea
 elasticsearch = "7.13.4"  # versions >= 7.14.0 lock out AWS ES
 elasticsearch_dsl = "^7.4.0"
 #dcicutils = "^8.8.0"
-dcicutils = "8.8.0.1b1"
+dcicutils = "8.8.0.1b2"
 future = ">=0.15.2,<1"
 html5lib = ">=1.1"  # experimental, should be OK now that we're not using moto server
 humanfriendly = "^1.44.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2.1b7"  # TODO: To become 11.13.0
+version = "11.12.2.1b8"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -44,7 +44,7 @@ botocore = ">=1.31.62"  # no particular version required, but this speeds up sea
 elasticsearch = "7.13.4"  # versions >= 7.14.0 lock out AWS ES
 elasticsearch_dsl = "^7.4.0"
 #dcicutils = "^8.8.0"
-dcicutils = "8.8.0.1b5"
+dcicutils = "8.8.0.1b6"
 future = ">=0.15.2,<1"
 html5lib = ">=1.1"  # experimental, should be OK now that we're not using moto server
 humanfriendly = "^1.44.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2.2b3"  # TODO: To become 11.13.0
+version = "11.12.2.2b4"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -44,7 +44,7 @@ botocore = ">=1.31.62"  # no particular version required, but this speeds up sea
 elasticsearch = "7.13.4"  # versions >= 7.14.0 lock out AWS ES
 elasticsearch_dsl = "^7.4.0"
 #dcicutils = "^8.8.0"
-dcicutils = "8.8.0.1b13"
+dcicutils = "8.8.0.1b16"
 future = ">=0.15.2,<1"
 html5lib = ">=1.1"  # experimental, should be OK now that we're not using moto server
 humanfriendly = "^1.44.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.0.1b5"  # TODO: To become 11.13.0
+version = "11.12.0.1b6"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2.2b4"  # TODO: To become 11.13.0
+version = "11.12.2.2b5"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -44,7 +44,7 @@ botocore = ">=1.31.62"  # no particular version required, but this speeds up sea
 elasticsearch = "7.13.4"  # versions >= 7.14.0 lock out AWS ES
 elasticsearch_dsl = "^7.4.0"
 #dcicutils = "^8.8.0"
-dcicutils = "8.8.0.1b16"
+dcicutils = "8.8.0.1b18"
 future = ">=0.15.2,<1"
 html5lib = ">=1.1"  # experimental, should be OK now that we're not using moto server
 humanfriendly = "^1.44.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2.2b1"  # TODO: To become 11.13.0
+version = "11.12.2.2b2"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -44,7 +44,7 @@ botocore = ">=1.31.62"  # no particular version required, but this speeds up sea
 elasticsearch = "7.13.4"  # versions >= 7.14.0 lock out AWS ES
 elasticsearch_dsl = "^7.4.0"
 #dcicutils = "^8.8.0"
-dcicutils = "8.8.0.1b10"
+dcicutils = "8.8.0.1b11"
 future = ">=0.15.2,<1"
 html5lib = ">=1.1"  # experimental, should be OK now that we're not using moto server
 humanfriendly = "^1.44.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2.1b10"  # TODO: To become 11.13.0
+version = "11.12.2.1b11"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -44,7 +44,7 @@ botocore = ">=1.31.62"  # no particular version required, but this speeds up sea
 elasticsearch = "7.13.4"  # versions >= 7.14.0 lock out AWS ES
 elasticsearch_dsl = "^7.4.0"
 #dcicutils = "^8.8.0"
-dcicutils = "8.8.0.1b8"
+dcicutils = "8.8.0.1b9"
 future = ">=0.15.2,<1"
 html5lib = ">=1.1"  # experimental, should be OK now that we're not using moto server
 humanfriendly = "^1.44.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.5.1b2"
+version = "11.13.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -43,7 +43,6 @@ boto3 = ">=1.28.62"  # no particular version required, but this speeds up search
 botocore = ">=1.31.62"  # no particular version required, but this speeds up search
 elasticsearch = "7.13.4"  # versions >= 7.14.0 lock out AWS ES
 elasticsearch_dsl = "^7.4.0"
-#dcicutils = "^8.8.0"
 dcicutils = "^8.8.1"
 future = ">=0.15.2,<1"
 html5lib = ">=1.1"  # experimental, should be OK now that we're not using moto server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2.1b1"  # TODO: To become 11.13.0
+version = "11.12.2.1b2"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2.1b4"  # TODO: To become 11.13.0
+version = "11.12.2.1b5"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -44,7 +44,7 @@ botocore = ">=1.31.62"  # no particular version required, but this speeds up sea
 elasticsearch = "7.13.4"  # versions >= 7.14.0 lock out AWS ES
 elasticsearch_dsl = "^7.4.0"
 #dcicutils = "^8.8.0"
-dcicutils = "8.8.0.1b2"
+dcicutils = "8.8.0.1b3"
 future = ">=0.15.2,<1"
 html5lib = ">=1.1"  # experimental, should be OK now that we're not using moto server
 humanfriendly = "^1.44.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2.1b2"  # TODO: To become 11.13.0
+version = "11.12.2.1b3"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -43,7 +43,8 @@ boto3 = ">=1.28.62"  # no particular version required, but this speeds up search
 botocore = ">=1.31.62"  # no particular version required, but this speeds up search
 elasticsearch = "7.13.4"  # versions >= 7.14.0 lock out AWS ES
 elasticsearch_dsl = "^7.4.0"
-dcicutils = "^8.8.0"
+#dcicutils = "^8.8.0"
+dcicutils = "8.8.0.1b1"
 future = ">=0.15.2,<1"
 html5lib = ">=1.1"  # experimental, should be OK now that we're not using moto server
 humanfriendly = "^1.44.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2.2b2"  # TODO: To become 11.13.0
+version = "11.12.2.2b3"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -44,7 +44,7 @@ botocore = ">=1.31.62"  # no particular version required, but this speeds up sea
 elasticsearch = "7.13.4"  # versions >= 7.14.0 lock out AWS ES
 elasticsearch_dsl = "^7.4.0"
 #dcicutils = "^8.8.0"
-dcicutils = "8.8.0.1b11"
+dcicutils = "8.8.0.1b13"
 future = ">=0.15.2,<1"
 html5lib = ">=1.1"  # experimental, should be OK now that we're not using moto server
 humanfriendly = "^1.44.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2.1b5"  # TODO: To become 11.13.0
+version = "11.12.2.1b6"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -44,7 +44,7 @@ botocore = ">=1.31.62"  # no particular version required, but this speeds up sea
 elasticsearch = "7.13.4"  # versions >= 7.14.0 lock out AWS ES
 elasticsearch_dsl = "^7.4.0"
 #dcicutils = "^8.8.0"
-dcicutils = "8.8.0.1b3"
+dcicutils = "8.8.0.1b4"
 future = ">=0.15.2,<1"
 html5lib = ">=1.1"  # experimental, should be OK now that we're not using moto server
 humanfriendly = "^1.44.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.3.1b1"  # TODO: To become 11.13.0
+version = "11.12.5.1b1"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.0.1b4"  # TODO: To become 11.13.0
+version = "11.12.0.1b5"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.0.1b6"  # TODO: To become 11.13.0
+version = "11.12.2.1b1"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.0.1b1"  # TODO: To become 11.13.0
+version = "11.12.0.1b2"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2.1b1"  # TODO: To become 11.13.0
+version = "11.12.2.2b1"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ botocore = ">=1.31.62"  # no particular version required, but this speeds up sea
 elasticsearch = "7.13.4"  # versions >= 7.14.0 lock out AWS ES
 elasticsearch_dsl = "^7.4.0"
 #dcicutils = "^8.8.0"
-dcicutils = "^8.8.0.1b20"
+dcicutils = "^8.8.0.1b25"
 future = ">=0.15.2,<1"
 html5lib = ">=1.1"  # experimental, should be OK now that we're not using moto server
 humanfriendly = "^1.44.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2.2b6"  # TODO: To become 11.13.0
+version = "11.12.2.2b7"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -44,7 +44,7 @@ botocore = ">=1.31.62"  # no particular version required, but this speeds up sea
 elasticsearch = "7.13.4"  # versions >= 7.14.0 lock out AWS ES
 elasticsearch_dsl = "^7.4.0"
 #dcicutils = "^8.8.0"
-dcicutils = "8.8.0.1b18"
+dcicutils = "^8.8.0.1b20"
 future = ">=0.15.2,<1"
 html5lib = ">=1.1"  # experimental, should be OK now that we're not using moto server
 humanfriendly = "^1.44.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2.1b8"  # TODO: To become 11.13.0
+version = "11.12.2.1b9"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.0.1b3"  # TODO: To become 11.13.0
+version = "11.12.0.1b4"  # TODO: To become 11.13.0
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/loadxl.py
+++ b/snovault/loadxl.py
@@ -684,7 +684,12 @@ def load_all_gen(testapp, inserts, docsdir, overwrite=True, itype=None, from_jso
                     raise Exception("Item has no uuid nor any other identifying property; cannot PATCH.")
                 normalized_item, deleted_properties = normalize_deleted_properties(an_item)
                 if deleted_properties:
-                    identifying_path += f"?delete_fields={','.join(deleted_properties)}"
+                    if validate_only and skip_links:
+                        identifying_path += f"?delete_fields={','.join(deleted_properties)}&skip_links=true"
+                    else:
+                        identifying_path += f"?delete_fields={','.join(deleted_properties)}"
+                elif validate_only and skip_links:
+                    identifying_path += f"?skip_links=true"
                 res = testapp.patch_json(identifying_path, normalized_item)
                 assert res.status_code == 200
                 patched += 1

--- a/snovault/loadxl.py
+++ b/snovault/loadxl.py
@@ -391,15 +391,14 @@ def get_response_uuid(response: TestAppResponse) -> Optional[str]:
 
 
 def normalize_deleted_properties(data: dict) -> Tuple[dict, List[str]]:
-    normalized_data = {}
-    deleted_properties = []
-    # TODO: This is not doing it recursively ...
+    deleted_property_names = []
+    # TODO: This is not doing it recursively; probably not needed.
     for property_name, property_value in data.items():
         if property_value == RowReader.CELL_DELETION_SENTINEL:
-            deleted_properties.append(property_name)
-        else:
-            normalized_data[property_name] = property_value
-    return normalized_data, deleted_properties
+            deleted_property_names.append(property_name)
+    for deleted_property_name in deleted_property_names:
+        del data[deleted_property_name]
+    return data, deleted_property_names
 
 
 def load_all_gen(testapp, inserts, docsdir, overwrite=True, itype=None, from_json=False,

--- a/snovault/loadxl.py
+++ b/snovault/loadxl.py
@@ -404,7 +404,7 @@ def normalize_deleted_properties(data: dict) -> Tuple[dict, List[str]]:
 
 def load_all_gen(testapp, inserts, docsdir, overwrite=True, itype=None, from_json=False,
                  patch_only=False, post_only=False, skip_types=None, validate_only=False,
-                 continue_on_exception: bool = False, verbose=False):
+                 skip_links=False, continue_on_exception: bool = False, verbose=False):
     """
     Generator function that yields bytes information about each item POSTed/PATCHed.
     Is the base functionality of load_all function.
@@ -591,6 +591,8 @@ def load_all_gen(testapp, inserts, docsdir, overwrite=True, itype=None, from_jso
                         # would not have made it into second_round_items because validate_only.
                         if validate_patch_path := get_identifying_path(an_item, a_type, identifying_properties):
                             validate_patch_path += "?check_only=true"
+                            if skip_links:
+                                validate_patch_path += "&skip_links=true"
                             try:
                                 testapp.patch_json(validate_patch_path, an_item)
                             except Exception as e:
@@ -608,6 +610,8 @@ def load_all_gen(testapp, inserts, docsdir, overwrite=True, itype=None, from_jso
                     post_request = f'/{a_type}?skip_indexing=true'
                     if validate_only:
                         post_request += '&check_only=true'
+                        if skip_links:
+                            post_request += "&skip_links=true"
                     to_post = format_for_attachment(to_post, docsdir)
                     try:
                         # This creates the (as yet non-existent) item to the

--- a/snovault/loadxl.py
+++ b/snovault/loadxl.py
@@ -591,8 +591,10 @@ def load_all_gen(testapp, inserts, docsdir, overwrite=True, itype=None, from_jso
                         # would not have made it into second_round_items because validate_only.
                         if validate_patch_path := get_identifying_path(an_item, a_type, identifying_properties):
                             validate_patch_path += "?check_only=true"
-                            if skip_links:
-                                validate_patch_path += "&skip_links=true"
+                            # To be safe we will unconditionally do skip_links in this case;
+                            # to get away with not doing this would require more analysis.
+                            # See: https://github.com/4dn-dcic/snovault/pull/283
+                            validate_patch_path += "&skip_links=true"
                             try:
                                 testapp.patch_json(validate_patch_path, an_item)
                             except Exception as e:

--- a/snovault/schema_utils.py
+++ b/snovault/schema_utils.py
@@ -275,11 +275,8 @@ def mixinSchemas(schema, resolver, key_name='properties'):
 
 
 def linkTo(validator, linkTo, instance, schema):
-    # 2024-02-21/dmichaels: EXPERIMENTAL ...
-    # MAYBE for check_only we should just skip this altogether;
-    # AND/OR maybe better to only do this skip for check_only
-    # if it is on behalf of smaht-submitr (i.e. e.g. create special/new
-    # ignore_refs=true flag to control this, and used only by smaht-submitr).
+    # 2024-02-21/dmichaels:
+    # New skip_links functionality for smaht-submitr since it does link integrity checking.
     skip_links = (request := get_current_request()) and asbool(request.params.get('skip_links', False))
     if skip_links:
         return
@@ -299,20 +296,6 @@ def linkTo(validator, linkTo, instance, schema):
     try:
         item = find_resource(base, instance.replace(':', '%3A'))
     except KeyError:
-        # 2024-02-21/dmichaels: EXPERIMENTAL ...
-        # If check_only mode then ignore reference/linkTo errors (?).
-        # But the downside of this, is that we do not actually check that this
-        # reference, which was not found in the database, is actually in the
-        # submitted data; to do that we need this exception and processing in
-        # smaht-portal//ingestion/loadxl_extensions._get_ref_error_info_from_exception_string.
-        # But that SHOULD be OK because submitr is doing its own reference integrity checking.
-        # See also: schema_validation.normalize_links
-        # No ...
-        # Decided instead of this to add skip_links feature to loadxl which is only
-        # set by smaht-portal/.../ingestion/loadxl_extensions.py; and which
-        # will skip reference/link integrity checking altogether here/above,
-        # since smaht-submitr (structured_data) does reference integrity checking anyways.
-        # TODO: Remove all this 2024-02-21 stuff including these comments once tested ...
         check_only = (request := get_current_request()) and asbool(request.params.get('check_only', False))
         if not check_only:
             error = "%r not found" % instance

--- a/snovault/schema_utils.py
+++ b/snovault/schema_utils.py
@@ -280,6 +280,9 @@ def linkTo(validator, linkTo, instance, schema):
     # AND/OR maybe better to only do this skip for check_only
     # if it is on behalf of smaht-submitr (i.e. e.g. create special/new
     # ignore_refs=true flag to control this, and used only by smaht-submitr).
+    skip_links = (request := get_current_request()) and asbool(request.params.get('skip_links', False))
+    if skip_links:
+        return
     if not validator.is_type(instance, "string"):
         return
 
@@ -304,6 +307,12 @@ def linkTo(validator, linkTo, instance, schema):
         # smaht-portal//ingestion/loadxl_extensions._get_ref_error_info_from_exception_string.
         # But that SHOULD be OK because submitr is doing its own reference integrity checking.
         # See also: schema_validation.normalize_links
+        # No ...
+        # Decided instead of this to add skip_links feature to loadxl which is only
+        # set by smaht-portal/.../ingestion/loadxl_extensions.py; and which
+        # will skip reference/link integrity checking altogether here/above,
+        # since smaht-submitr (structured_data) does reference integrity checking anyways.
+        # TODO: Remove all this 2024-02-21 stuff including these comments once tested ...
         check_only = (request := get_current_request()) and asbool(request.params.get('check_only', False))
         if not check_only:
             error = "%r not found" % instance

--- a/snovault/schema_validation.py
+++ b/snovault/schema_validation.py
@@ -42,9 +42,17 @@ def normalize_links(validator, links, linkTo):
         except KeyError:
             # 2024-02-13: To help out smaht-submitr refererential integrity checking,
             # include the schema type name (linkTo) as well as the idenitifying value (link).
-            errors.append(
-                ValidationError(f"Unable to resolve link: /{linkTo}/{link}")
-            )
+            #
+            # 2024-02-21/dmichaels: EXPERIMENTAL/TEMPORARY ...
+            # If check_only=true then ignore reference/linkTo errors (?);
+            # and obviously cleanup up the "check_only=true" in ... stuff.
+            skip_unresolved_link_error = False
+            if (request := get_current_request()) and request.url and "check_only=true" in request.url:
+                skip_unresolved_link_error = True
+            if not skip_unresolved_link_error:
+                errors.append(
+                    ValidationError(f"Unable to resolve link: /{linkTo}/{link}")
+                )
             normalized_links.append(
                 link
             )

--- a/snovault/schema_validation.py
+++ b/snovault/schema_validation.py
@@ -2,7 +2,6 @@ from copy import deepcopy
 from jsonschema import Draft202012Validator
 from jsonschema import validators
 from jsonschema.exceptions import ValidationError
-from pyramid.settings import asbool
 from pyramid.threadlocal import get_current_request
 from pyramid.traversal import find_resource
 
@@ -52,11 +51,22 @@ def normalize_links(validator, links, linkTo):
             # smaht-portal//ingestion/loadxl_extensions._get_ref_error_info_from_exception_string.
             # But that SHOULD be OK because submitr is doing its own reference integrity checking.
             # See also: schema_utils.linkTo
+            # No ...
+            # Decided instead of this to add skip_links feature to loadxl which is only
+            # set by smaht-portal/.../ingestion/loadxl_extensions.py; and which will
+            # skip reference/link integrity checking altogether (in schema_utils.linkTo),
+            # since smaht-submitr (structured_data) does reference integrity checking anyways.
+            # TODO: Remove all this 2024-02-21 stuff including these comments once tested ...
+            """
             check_only = (request := get_current_request()) and asbool(request.params.get('check_only', False))
             if not check_only:
                 errors.append(
                     ValidationError(f"Unable to resolve link: /{linkTo}/{link}")
                 )
+            """
+            errors.append(
+                ValidationError(f"Unable to resolve link: /{linkTo}/{link}")
+            )
             normalized_links.append(
                 link
             )

--- a/snovault/schema_validation.py
+++ b/snovault/schema_validation.py
@@ -43,9 +43,15 @@ def normalize_links(validator, links, linkTo):
         except KeyError:
             # 2024-02-13: To help out smaht-submitr refererential integrity checking,
             # include the schema type name (linkTo) as well as the idenitifying value (link).
-            #
+
             # 2024-02-21/dmichaels: EXPERIMENTAL ...
             # If check_only mode then ignore reference/linkTo errors (?).
+            # But the downside of this, is that we do not actually check that this
+            # reference, which was not found in the database, is actually in the
+            # submitted data; to do that we need this exception and processing in
+            # smaht-portal//ingestion/loadxl_extensions._get_ref_error_info_from_exception_string.
+            # But that SHOULD be OK because submitr is doing its own reference integrity checking.
+            # See also: schema_utils.linkTo
             check_only = (request := get_current_request()) and asbool(request.params.get('check_only', False))
             if not check_only:
                 errors.append(

--- a/snovault/schema_validation.py
+++ b/snovault/schema_validation.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from jsonschema import Draft202012Validator
 from jsonschema import validators
 from jsonschema.exceptions import ValidationError
+from pyramid.settings import asbool
 from pyramid.threadlocal import get_current_request
 from pyramid.traversal import find_resource
 
@@ -43,13 +44,10 @@ def normalize_links(validator, links, linkTo):
             # 2024-02-13: To help out smaht-submitr refererential integrity checking,
             # include the schema type name (linkTo) as well as the idenitifying value (link).
             #
-            # 2024-02-21/dmichaels: EXPERIMENTAL/TEMPORARY ...
-            # If check_only=true then ignore reference/linkTo errors (?);
-            # and obviously cleanup up the "check_only=true" in ... stuff.
-            skip_unresolved_link_error = False
-            if (request := get_current_request()) and request.url and "check_only=true" in request.url:
-                skip_unresolved_link_error = True
-            if not skip_unresolved_link_error:
+            # 2024-02-21/dmichaels: EXPERIMENTAL ...
+            # If check_only mode then ignore reference/linkTo errors (?).
+            check_only = (request := get_current_request()) and asbool(request.params.get('check_only', False))
+            if not check_only:
                 errors.append(
                     ValidationError(f"Unable to resolve link: /{linkTo}/{link}")
                 )


### PR DESCRIPTION
* Fix in loadxl to PATCH on validate_only for items which already exist;
  discovered during smaht-submitr testing.
* Added skip_links feature to loadxl which will cause reference/link integrity
  checking to be skipped altogether; this is (currently) only set by smaht-portal/
  ingestion/loadxl_extensions.py for smaht-submitr, since that process already
  does thorough reference integrity checking anyways (via structured_data).
