### PR TITLE
ES Total

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ snovault
 Change Log
 ----------
 
+11.12.1
+=======
+
+* Gets total results from ES, then try to get exact count if total hits ES_MAX_HIT_TOTAL limitation
+
+
 11.12.0
 =======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.0"
+version = "11.12.1.0b1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
After `ES7` upgrade, `total` does not return the exact count if it is >10000. To get a more precise result, this workaround loops through the facet terms. (currently, type=Item's doc_count is calculated correctly) Note that this workaround does not work unless facets are included.

Release (beta): https://pypi.org/project/dcicsnovault/11.12.1.0b1/ 

<img width="787" alt="Screen Shot 2024-02-29 at 13 37 20" src="https://github.com/4dn-dcic/snovault/assets/49978017/dd87422e-1613-4de8-9e24-d76b999e5455">
