### PR TITLE
Fix for circular import (from smaht ingester) WRT ACCESSION_PREFIX de…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Change Log
 =======
 
 * Changed ACCESSION_PREFIX in server_defaults.py to GET_ACCESSION_PREFIX() function;
-  called only within snovault (and only from schema_formats.py), to get around
+  called only within snovault (and only from schema_formats.py); to get around
   app_project call at file scope (came up as circular import in smaht ingester).
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ snovault
 Change Log
 ----------
 
+11.12.3
+=======
+
+* Changed ACCESSION_PREFIX in server_defaults.py to GET_ACCESSION_PREFIX() function;
+  called only within snovault (and only from schema_formats.py), to get around
+  app_project call at file scope (came up as circular import in smaht ingester).
+
+
 11.12.2
 =======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2.1b1"  # TODO: To become 11.12.3
+version = "11.12.2.3b1"  # TODO: To become 11.12.3
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.3"
+version = "11.12.2.1b1"  # TODO: To become 11.12.3
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2.3b1"  # TODO: To become 11.12.3
+version = "11.12.3"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.2"
+version = "11.12.3"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/schema_formats.py
+++ b/snovault/schema_formats.py
@@ -2,7 +2,6 @@ import re
 
 from .schema_utils import format_checker
 from .server_defaults import (
-    ACCESSION_PREFIX,
     ACCESSION_TEST_PREFIX,
 )
 
@@ -10,7 +9,7 @@ from .server_defaults import (
 # Codes we allow for testing go here.
 ACCESSION_TEST_CODES = "BS|ES|EX|FI|FS|IN|SR|WF"
 
-accession_re = re.compile(r'^%s[1-9A-Z]{9}$' % ACCESSION_PREFIX)
+accession_re = re.compile(r'^%s[1-9A-Z]{9}$' % GET_ACCESSION_PREFIX())
 
 test_accession_re = re.compile(r'^%s(%s)[0-9]{4}([0-9][0-9][0-9]|[A-Z][A-Z][A-Z])$' % (
     ACCESSION_TEST_PREFIX, ACCESSION_TEST_CODES))

--- a/snovault/schema_formats.py
+++ b/snovault/schema_formats.py
@@ -3,6 +3,7 @@ import re
 from .schema_utils import format_checker
 from .server_defaults import (
     ACCESSION_TEST_PREFIX,
+    GET_ACCESSION_PREFIX
 )
 
 

--- a/snovault/server_defaults.py
+++ b/snovault/server_defaults.py
@@ -22,8 +22,13 @@ exported(
 
 
 ACCESSION_FACTORY = __name__ + ':accession_factory'
-ACCESSION_PREFIX = app_project().ACCESSION_PREFIX
 ACCESSION_TEST_PREFIX = 'TST'
+
+# Only within snovault (only called from schema_formats.py) to get around
+# app_project call at file scope (came up as circular import in smaht ingester).
+# ACCESSION_PREFIX = app_project().ACCESSION_PREFIX
+def GET_ACCESSION_PREFIX():
+    return app_project().ACCESSION_PREFIX
 
 
 def includeme(config):
@@ -75,7 +80,7 @@ FDN_ACCESSION_FORMAT = ['ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789']*7
 
 def enc_accession(accession_type):
     random_part = ''.join(random.choice(s) for s in FDN_ACCESSION_FORMAT)
-    return ACCESSION_PREFIX + accession_type + random_part
+    return GET_ACCESSION_PREFIX() + accession_type + random_part
 
 
 TEST_ACCESSION_FORMAT = (digits, ) * 7


### PR DESCRIPTION
* Changed ACCESSION_PREFIX in server_defaults.py to GET_ACCESSION_PREFIX() function;
  called only within snovault (and only from schema_formats.py), to get around
  app_project call at file scope (came up as circular import in smaht ingester).
