### PR TITLE
Access key status fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ snovault
 Change Log
 ----------
 
+11.12.4
+=======
+
+* Remove restricted permissions for AccessKey status to enable non-admins to delete access keys
+
+
 11.12.3
 =======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.3"
+version = "11.12.4.0b0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.12.4.0b0"
+version = "11.12.4"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/schemas/access_key.json
+++ b/snovault/schemas/access_key.json
@@ -33,8 +33,7 @@
             "enum": [
                 "current",
                 "deleted"
-            ],
-            "permission": "restricted_fields"
+            ]
         },
         "user": {
             "title": "User",


### PR DESCRIPTION
This PR reverts a schema addition in PR 270 that made `status` on AccessKey require admin permissions.

Related SMaHT PR here: https://github.com/smaht-dac/smaht-portal/pull/113