### PR TITLE
Submission schemas constants

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ snovault
 Change Log
 ----------
 
+11.14.1
+=======
+
+* Create constants for submission-schemas endpoint to share with downstream portals
+
+
 11.14.0
 =======
 * 2024-03-25

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.14.0"
+version = "11.14.1.0b0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.14.1.0b0"
+version = "11.14.1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/schema_views.py
+++ b/snovault/schema_views.py
@@ -216,16 +216,20 @@ def _annotate_submittable_props(schema, props):
 
     for propname, propinfo in props.items():
         if propname in required_props:
-            propinfo['is_required'] = True
+            propinfo[SubmissionSchemaConstants.IS_REQUIRED] = True
         if propname in oneof_props:
             lprops = [p for p in oneof_props if p != propname]
-            propinfo.setdefault('required_if_not_one_of', []).extend(lprops)
-            propinfo['prohibited_if_one_of'] = lprops
+            propinfo.setdefault(
+                SubmissionSchemaConstants.REQUIRED_IF_NOT_ONE_OF, []
+            ).extend(lprops)
+            propinfo[SubmissionSchemaConstants.PROHIBITED_IF_ONE_OF] = lprops
         if propname in anyof_props:
             lprops = [p for p in anyof_props if p != propname]
-            propinfo.setdefault('required_if_not_one_of', []).extend(lprops)
+            propinfo.setdefault(
+                SubmissionSchemaConstants.REQUIRED_IF_NOT_ONE_OF, []
+            ).extend(lprops)
         if propname in req_deps:
-            propinfo['also_requires'] = req_deps[propname]
+            propinfo[SubmissionSchemaConstants.ALSO_REQUIRES] = req_deps[propname]
     return props
 
 

--- a/snovault/schema_views.py
+++ b/snovault/schema_views.py
@@ -22,11 +22,23 @@ from dcicutils.schema_utils import (
 from .project_app import app_project
 
 
+class SubmissionSchemaConstants:
+
+    ENDPOINT = "/submission-schemas/"
+
+    ALSO_REQUIRES = "also_requires"
+    IS_REQUIRED = "is_required"
+    PROHIBITED_IF_ONE_OF = "prohibited_if_one_of"
+    REQUIRED_IF_NOT_ONE_OF = "required_if_not_one_of"
+
+
 def includeme(config):
     config.add_route('schemas', '/profiles/')
     config.add_route('schema', '/profiles/{type_name}.json')
-    config.add_route('submittables', '/submission-schemas/')
-    config.add_route('submittable', '/submission-schemas/{type_name}.json')
+    config.add_route('submittables', SubmissionSchemaConstants.ENDPOINT)
+    config.add_route(
+        'submittable', SubmissionSchemaConstants.ENDPOINT + '{type_name}.json'
+    )
     config.scan(__name__)
 
 


### PR DESCRIPTION
This PR refactors out some constants pertaining to the `/submission-schemas/` endpoint to import into portal modules.