### PR TITLE
Fix revision history

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ snovault
 Change Log
 ----------
 
+11.19.0
+=======
+
+* Fix for revision history - deepcopy history as to not modify props in place
+
+
 11.18.0
 =======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.18.0"
+version = "11.19.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/crud_views.py
+++ b/snovault/crud_views.py
@@ -3,7 +3,7 @@ from uuid import (
     UUID,
     uuid4,
 )
-
+from copy import deepcopy
 import transaction
 from pyramid.exceptions import HTTPForbidden
 from pyramid.settings import asbool
@@ -379,7 +379,7 @@ def get_item_revision_history(request, uuid):
         The more edits an item has undergone, the more expensive this
         operation is.
     """
-    revisions = request.registry[STORAGE].revision_history(uuid=uuid)
+    revisions = deepcopy(request.registry[STORAGE].revision_history(uuid=uuid))
     # Resolve last_modified
     # NOTE: last_modified is a server_default present in our applications that
     # use snovault. This code is intended to resolve the user email of the last_modified
@@ -393,7 +393,7 @@ def get_item_revision_history(request, uuid):
             if not user:
                 user = request.embed(modified_by, frame='raw')
                 user_cache[modified_by] = user
-            revision['last_modified']['modified_by'] = user.get('email', 'No email specified!')
+            revision['last_modified']['modified_by'] = user['email']
     return revisions
 
 


### PR DESCRIPTION
- Use `deepcopy` on revisions, as it appears doing any modifications to them persist in the database and cause odd timing issues in indexing. This fix, combined with another in smaht-portal restore intended functionality (transforming user uuids to emails)