### PR TITLE
Update revision history

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,11 +50,11 @@ jobs:
         run: |
           make build-for-ga
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@main
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::643366669028:role/4dn-dcic-github-actions-deployment-role
+          role-session-name: snovault-unit-testing-session
           aws-region: us-east-1
 
       - name: QA (INDEXING)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,16 @@ snovault
 Change Log
 ----------
 
+11.29.0
+=======
+
+* Updates revision history API to make email resolution configurable,
+default is to not resolve to allow use of revision history
+in calc props without blowing up the invalidation scope
+
+
 11.28.0
-=====
+=======
 
 `PR 312: Range Aggregation Updates  <https://github.com/4dn-dcic/snovault/pull/312>`_
 
@@ -30,7 +38,7 @@ Change Log
 
 * Ports ``group_by_field`` faceting feature from Fourfront with small changes
 
-  
+
 =======
 11.25.0
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Change Log
 * Updates revision history API to make email resolution configurable,
 default is to not resolve to allow use of revision history
 in calc props without blowing up the invalidation scope
+* Configure OIDC role for builds
 
 
 11.28.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.29.0"
+version = "11.28.0.0b0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.28.0.0b0"
+version = "11.29.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.28.0"
+version = "11.29.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/crud_views.py
+++ b/snovault/crud_views.py
@@ -374,7 +374,7 @@ def validation_errors_property(context, request):
     return request.embed(path, '@@validation-errors')['validation_errors']
 
 
-def get_item_revision_history(request, uuid):
+def get_item_revision_history(request, uuid, resolve_emails=False):
     """ Computes the revision history of the given item from the DB.
         The more edits an item has undergone, the more expensive this
         operation is.
@@ -384,16 +384,22 @@ def get_item_revision_history(request, uuid):
     # NOTE: last_modified is a server_default present in our applications that
     # use snovault. This code is intended to resolve the user email of the last_modified
     # resource path (if it exists).
-    user_cache = {}
-    for revision in revisions:
-        last_modified = revision.get('last_modified', {})
-        modified_by = last_modified.get('modified_by', None)
-        if modified_by:
-            user = user_cache.get(modified_by)
-            if not user:
-                user = request.embed(modified_by, frame='raw')
-                user_cache[modified_by] = user
-            revision['last_modified']['modified_by'] = user['email']
+    # NOTE 2: This request.embed method causes an explosion of links on users
+    # if you ever want to use revision history inside of a calc prop for example.
+    # Generally, you can do this with the above fix but the embedded value cannot
+    # rely on the user email. It will now only pull this when requested via API
+    # and an extra parameter is passed.
+    if resolve_emails:
+        user_cache = {}
+        for revision in revisions:
+            last_modified = revision.get('last_modified', {})
+            modified_by = last_modified.get('modified_by', None)
+            if modified_by:
+                user = user_cache.get(modified_by)
+                if not user:
+                    user = request.embed(modified_by, frame='raw')
+                    user_cache[modified_by] = user
+                revision['last_modified']['modified_by'] = user['email']
     return revisions
 
 
@@ -405,7 +411,8 @@ def item_view_revision_history(context, request):
         For now, to view revision history the caller must have EDIT permissions.
     """
     uuid = str(context.uuid)
-    revisions = get_item_revision_history(request, uuid)
+    resolve_emails = asbool(request.GET.get('resolve_emails', False))
+    revisions = get_item_revision_history(request, uuid, resolve_emails=resolve_emails)
     return {
         'uuid': uuid,
         'revisions': revisions


### PR DESCRIPTION
- Updates revision history to no longer resolve emails (using request.embed) by default, as to eliminate explosion of user links when utilizing revision history in the data model