### PR TITLE
Memory usage improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ snovault
 Change Log
 ----------
 
+11.29.0.0b1
+=======
+
+* Remove unnecessary deepcopy from indexer
+* Reduce embed cache size as it becomes polluted with unused objects over time
+
+
 11.29.0
 =======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ snovault
 Change Log
 ----------
 
-11.29.0.0b1
+11.30.0
 =======
 
 * Remove unnecessary deepcopy from indexer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.29.0.0b3"
+version = "11.29.0.0b4"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.29.0.0b2"
+version = "11.29.0.0b3"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.29.0.0b1"
+version = "11.29.0.0b2"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.29.0.0b4"
+version = "11.29.0.0b5"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.29.0.0b5"
+version = "11.29.0.0b6"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.29.0.0b6"
+version = "11.30.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.29.0"
+version = "11.29.0.0b1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/commands/es_index_data.py
+++ b/snovault/commands/es_index_data.py
@@ -1,4 +1,6 @@
 import argparse
+import ctypes
+import gc
 import logging
 import webtest
 
@@ -7,7 +9,25 @@ from dcicutils.log_utils import set_logging
 
 
 EPILOG = __doc__
-INDEXING_RUN_ITERATIONS = 100
+INDEXING_RUN_ITERATIONS = 50
+
+
+def _tune_allocator():
+    """Tune glibc so large allocations use mmap and are returned to the OS on free.
+
+    Objects above M_MMAP_THRESHOLD bypass the heap and use mmap directly; freed
+    mmap regions are immediately released to the OS without needing malloc_trim.
+    Set to 1 MB so that large embedded documents (multi-MB MetaWorkflowRun
+    objects) are mmap-backed while smaller repeated allocations still reuse the
+    heap free-list for speed.
+    """
+    try:
+        ctypes.CDLL('libc.so.6').mallopt(
+            ctypes.c_int(-3),       # M_MMAP_THRESHOLD
+            ctypes.c_int(1048576),  # 1 MB
+        )
+    except Exception:
+        pass  # non-Linux environments
 
 
 def run(app, uuids=None):
@@ -25,6 +45,7 @@ def run(app, uuids=None):
     else:
         for _ in range(INDEXING_RUN_ITERATIONS):
             testapp.post_json('/index', post_body)
+            gc.collect()
 
 
 def main():
@@ -50,6 +71,15 @@ def main():
         'indexer': 'true',
     }
     app = get_app(args.config_uri, args.app_name, options)
+
+    # Freeze all framework/app objects so GC never scans them during indexing.
+    # Only objects allocated after this point will be tracked by the collector,
+    # making each gc.collect() call between iterations much cheaper.
+    gc.freeze()
+
+    # Tune glibc mmap threshold so large embedded documents are returned to the
+    # OS automatically on free, without needing explicit malloc_trim calls.
+    _tune_allocator()
 
     # Loading app will have configured from config file. Reconfigure here:
     # Use `es_server=app.registry.settings.get('elasticsearch.server')` when ES logging is working

--- a/snovault/commands/es_index_data.py
+++ b/snovault/commands/es_index_data.py
@@ -1,5 +1,4 @@
 import argparse
-import ctypes
 import gc
 import logging
 import webtest
@@ -10,24 +9,6 @@ from dcicutils.log_utils import set_logging
 
 EPILOG = __doc__
 INDEXING_RUN_ITERATIONS = 50
-
-
-def _tune_allocator():
-    """Tune glibc so large allocations use mmap and are returned to the OS on free.
-
-    Objects above M_MMAP_THRESHOLD bypass the heap and use mmap directly; freed
-    mmap regions are immediately released to the OS without needing malloc_trim.
-    Set to 1 MB so that large embedded documents (multi-MB MetaWorkflowRun
-    objects) are mmap-backed while smaller repeated allocations still reuse the
-    heap free-list for speed.
-    """
-    try:
-        ctypes.CDLL('libc.so.6').mallopt(
-            ctypes.c_int(-3),       # M_MMAP_THRESHOLD
-            ctypes.c_int(1048576),  # 1 MB
-        )
-    except Exception:
-        pass  # non-Linux environments
 
 
 def run(app, uuids=None):
@@ -45,7 +26,6 @@ def run(app, uuids=None):
     else:
         for _ in range(INDEXING_RUN_ITERATIONS):
             testapp.post_json('/index', post_body)
-            gc.collect()
 
 
 def main():
@@ -73,13 +53,9 @@ def main():
     app = get_app(args.config_uri, args.app_name, options)
 
     # Freeze all framework/app objects so GC never scans them during indexing.
-    # Only objects allocated after this point will be tracked by the collector,
-    # making each gc.collect() call between iterations much cheaper.
+    # Objects allocated after this point are the only ones GC will track,
+    # reducing automatic collection overhead during the indexing loop.
     gc.freeze()
-
-    # Tune glibc mmap threshold so large embedded documents are returned to the
-    # OS automatically on free, without needing explicit malloc_trim calls.
-    _tune_allocator()
 
     # Loading app will have configured from config file. Reconfigure here:
     # Use `es_server=app.registry.settings.get('elasticsearch.server')` when ES logging is working

--- a/snovault/commands/es_index_data.py
+++ b/snovault/commands/es_index_data.py
@@ -46,7 +46,7 @@ def main():
     # of indexing many objects that are not used frequently or enough to
     # justify keeping around - Will 22 May 2026
     options = {
-        'embed_cache.capacity': '2000',
+        'embed_cache.capacity': '200',
         'indexer': 'true',
     }
     app = get_app(args.config_uri, args.app_name, options)

--- a/snovault/commands/es_index_data.py
+++ b/snovault/commands/es_index_data.py
@@ -42,8 +42,11 @@ def main():
     args = parser.parse_args()
 
     logging.basicConfig()
+    # NOTE: the embed cache capacity can in fact be too large in the case
+    # of indexing many objects that are not used frequently or enough to
+    # justify keeping around - Will 22 May 2026
     options = {
-        'embed_cache.capacity': '5000',
+        'embed_cache.capacity': '2000',
         'indexer': 'true',
     }
     app = get_app(args.config_uri, args.app_name, options)

--- a/snovault/commands/es_index_data.py
+++ b/snovault/commands/es_index_data.py
@@ -1,5 +1,4 @@
 import argparse
-import gc
 import logging
 import webtest
 
@@ -8,7 +7,7 @@ from dcicutils.log_utils import set_logging
 
 
 EPILOG = __doc__
-INDEXING_RUN_ITERATIONS = 50
+INDEXING_RUN_ITERATIONS = 100
 
 
 def run(app, uuids=None):
@@ -51,11 +50,6 @@ def main():
         'indexer': 'true',
     }
     app = get_app(args.config_uri, args.app_name, options)
-
-    # Freeze all framework/app objects so GC never scans them during indexing.
-    # Objects allocated after this point are the only ones GC will track,
-    # reducing automatic collection overhead during the indexing loop.
-    gc.freeze()
 
     # Loading app will have configured from config file. Reconfigure here:
     # Use `es_server=app.registry.settings.get('elasticsearch.server')` when ES logging is working

--- a/snovault/commands/es_index_data.py
+++ b/snovault/commands/es_index_data.py
@@ -46,7 +46,7 @@ def main():
     # of indexing many objects that are not used frequently or enough to
     # justify keeping around - Will 22 May 2026
     options = {
-        'embed_cache.capacity': '200',
+        'embed_cache.capacity': '2000',
         'indexer': 'true',
     }
     app = get_app(args.config_uri, args.app_name, options)

--- a/snovault/embed.py
+++ b/snovault/embed.py
@@ -125,7 +125,10 @@ def embed(request, *elements, **kw):
 
     # NOTE: if result was retrieved from ES, the following cached attrs will be
     # empty: _aggregated_items, _linked_uuids, _rev_linked_by_item
-    result = deepcopy(cached['result'])
+    # deepcopy is not necessary in an indexing view - this causes explosion
+    # of memory usage when indexing very large objects, slows indexing speed
+    # - Will 22 May 26
+    result = cached['result'] if request._indexing_view else deepcopy(cached['result'])
 
     # aggregated_items may be cached; if so, add them to the request
     # these conditions only fulfilled when using @@embedded and aggregated

--- a/snovault/embed.py
+++ b/snovault/embed.py
@@ -121,7 +121,9 @@ def embed(request, *elements, **kw):
             # handle common cases of as_user, otherwise use what's given
             subreq_user = 'EMBED' if as_user is None else as_user
             cached = _embed(request, path, as_user=subreq_user)
-            embed_cache[path] = cached
+            # Do not cache revision history, quickly pollutes memory
+            if not (request._indexing_view and '@@revision-history' in path):
+                embed_cache[path] = cached
 
     # NOTE: if result was retrieved from ES, the following cached attrs will be
     # empty: _aggregated_items, _linked_uuids, _rev_linked_by_item

--- a/snovault/indexing_views.py
+++ b/snovault/indexing_views.py
@@ -144,6 +144,11 @@ def item_index_data(context, request):
     # setting _indexing_view enables the embed_cache and cause population of
     # request._linked_uuids and request._rev_linked_uuids_by_item
     request._indexing_view = True
+    # Set aggregate_for before @@object (not just @@embedded) so that calculated
+    # properties during @@object can identify the primary indexed item and its type.
+    # item_type is snake_case (e.g. 'file_set', 'meta_workflow_run').
+    request._aggregate_for['uuid'] = uuid
+    request._aggregate_for['item_type'] = context.type_info.item_type
 
     # run the object view first
     request._linked_uuids = set()
@@ -155,7 +160,7 @@ def item_index_data(context, request):
     # reset these properties, then run embedded view
     request._linked_uuids = set()
     request._rev_linked_uuids_by_item = {}
-    request._aggregate_for['uuid'] = uuid
+    # _aggregate_for uuid/item_type already set above
     request._aggregated_items = {
         agg: {'_fields': context.aggregated_items[agg], 'items': []} for agg in context.aggregated_items
     }


### PR DESCRIPTION
- Eliminate use of `deepcopy` in indexing, as it is not necessary as the indexing process does not modify the base documents retrieved, use a guard to ensure this only happens in indexing views
- Reduce embed cache size to reduce memory footprint, at the expense of more DB requests - DB appears to tolerate load well so will monitor this for future updates - requires benchmarking