### PR TITLE
Fix wasted ES query/fetch work in search & compound_search (audit findings, rounds 1-2)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ snovault
 Change Log
 ----------
 
-11.30.5
+11.30.6
 =======
 
 * Reduce wasted Elasticsearch query/fetch work in search and compound_search:
@@ -17,6 +17,18 @@ Change Log
     for these frames, so computing them was wasted ES work)
   - ``frame=object``/``frame=raw`` searches no longer also fetch unused
     ``embedded.*`` in ``_source``
+  - ``limit=all`` pagination no longer re-sends the default-facet
+    aggregation block (or tracks total hits) on every subsequent page -
+    only the first page's aggregations are ever read
+  - Fixed ``skip_default_facets`` URL param being silently parsed as a
+    field filter on a nonexistent field (previously matched zero results
+    whenever used as documented)
+  - ``compound_search``'s per-block ``/build_query`` subrequests now pass
+    ``skip_default_facets=true``, skipping wasted default-facet
+    construction (deepcopy-per-facet + schema crawl) per filter block
+  - Fixed ``schema_for_field``'s per-request memoization, which never
+    actually persisted its cache onto the request
+  - Removed a stray ``print()`` debug statement in ``group_facet_terms``
 
 
 11.30.4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,19 @@ snovault
 Change Log
 ----------
 
+11.30.4
+=======
+
+* Reduce wasted Elasticsearch query/fetch work in search and compound_search:
+  - ``compound_search``'s multi-block path now restricts ``_source`` to
+    ``embedded.*`` instead of fetching the entire document per hit
+  - Default per-field facet aggregations are now skipped whenever the
+    response frame is not ``embedded`` (facets were already discarded
+    for these frames, so computing them was wasted ES work)
+  - ``frame=object``/``frame=raw`` searches no longer also fetch unused
+    ``embedded.*`` in ``_source``
+
+
 11.30.3
 =======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ snovault
 Change Log
 ----------
 
-11.30.6
+11.30.5
 =======
 
 * Reduce wasted Elasticsearch query/fetch work in search and compound_search:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ snovault
 Change Log
 ----------
 
-11.30.4
+11.30.6
 =======
 
 * Reduce wasted Elasticsearch query/fetch work in search and compound_search:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.30.3"
+version = "11.30.4"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.30.5"
+version = "11.30.6"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.30.6"
+version = "11.30.5"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.30.4"
+version = "11.30.6"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/search/AGENTS.md
+++ b/snovault/search/AGENTS.md
@@ -1,0 +1,144 @@
+# snovault/search/ — agent notes
+
+Reference for anyone (agent or human) working in this subsystem. Not a changelog — see
+"Historical detail" below for that.
+
+## Module map
+
+- **`search.py`** — `SearchBuilder`, the `/search` view. Owns request bootstrapping
+  (`_bootstrap_query`), `_source` field selection (`list_source_fields`), facet
+  initialization (`initialize_facets`), pagination (`set_pagination`,
+  `get_all_subsequent_results`/`execute_search_for_all_results` for `limit=all`), and
+  response formatting (`format_results`, `format_facets`, `_format_results`).
+  Delegates actual filter/aggregation DSL construction to `LuceneBuilder`.
+- **`lucene_builder.py`** — `LuceneBuilder`, a stateless collection of static/class
+  methods that turn snovault's intermediate filter/facet representation into real
+  Elasticsearch query DSL. Entry points: `build_filters` (the query itself),
+  `build_facets` (aggregations), `verify_search_has_permissions` (defense-in-depth
+  check that permission filters weren't stripped mid-construction).
+- **`search_utils.py`** — shared helpers used by both of the above: `execute_search`
+  (ES call + exception→`HTTPBadRequest` translation), `execute_streaming_search`
+  (search_after-based streaming, bypasses `SearchBuilder` entirely),
+  `schema_for_field` (schema lookup + per-request cache), `build_sort_dicts`,
+  `find_nested_path`, and shared constants like `COMMON_EXCLUDED_URI_PARAMS`.
+- **`compound_search.py`** — `CompoundSearchBuilder`, the `/compound_search` and
+  `/build_query` views (FilterSet-driven multi-block search — AND/OR combinations of
+  independent query blocks, e.g. for saved filter sets). Builds each block's lucene
+  query via a Pyramid subrequest to `/build_query`, then combines them with
+  `LuceneBuilder.compound_search` and executes via `SearchBuilder.from_search`
+  (which skips normal bootstrapping — see gotchas).
+
+Call flow for an ordinary `/search`: `search.py` view → `SearchBuilder.build_search_query()`
+→ `LuceneBuilder.build_filters`/`build_facets` → `search_utils.execute_search` → ES →
+`SearchBuilder.format_results`/`format_facets`.
+
+## Key concepts
+
+- **Frames** (`embedded`/`object`/`raw`, URL param `frame=`) select which propsheet
+  variant of a document to return. `_source` is scoped to match: `embedded.*` for the
+  default frame, `object.*`/`properties.*` (raw→properties) for the others — fetching
+  more than the requested frame is pure waste, since `_format_results` only ever reads
+  one frame per hit.
+- **Facets/aggregations** run in a `global` ES aggregation context
+  (`{'all_items': {'global': {}, 'aggs': {...}}}`), meaning each facet's cost scales
+  with the *whole index*, not the current page or filtered result set. This is why
+  facet computation is the dominant cost of `/search` for richly-faceted types, and why
+  it's worth being careful about when facets are actually computed vs. discarded.
+  `format_facets` only returns non-empty results for `frame == 'embedded'` — every other
+  frame pays for aggregations it then throws away unless explicitly gated.
+- **`skip_default_facets`** (URL param) skips the default per-field facet loop entirely,
+  falling back to only computing facets explicitly requested via `additional_facet=`.
+  Added for callers (e.g. peek-metadata) that need one cheap stat/aggregation without
+  paying for the full per-type facet fan-out. See gotchas — this was broken for a long
+  time.
+- **Compound search's per-block subrequest model**: each filter block in a FilterSet is
+  turned into its own Pyramid subrequest to `/build_query`, which runs the full
+  `SearchBuilder` query-construction pipeline just to extract `query['query']` — the
+  `aggs` portion of that pipeline's output is discarded per block. `execute_filter_set`
+  then combines all blocks' `query['query']` via `LuceneBuilder.compound_search` (OR/AND)
+  and runs the combined query through a `SearchBuilder` built via `from_search`, which
+  skips normal bootstrapping (including `_source` scoping — must be set explicitly).
+- **`limit=all` pagination** walks the full result set via repeated `from_`/`size`
+  requests (`execute_search_for_all_results` → `get_all_subsequent_results`), not a
+  scroll/search_after cursor. This is O(N²) server-side cost for large result sets and
+  is bounded by `SEARCH_MAX` (100_000, `snovault/util.py`) — beyond that ES raises
+  `HTTPBadRequest` mid-stream. `execute_streaming_search` in `search_utils.py` (used by
+  streaming/bulk-download endpoints, not by `SearchBuilder` itself) is the correct
+  O(N) `search_after`-based primitive if you need to walk a large result set — prefer
+  it over `limit=all` for new bulk-consumption code paths.
+
+## Known sharp edges / gotchas
+
+- **`skip_default_facets` was silently broken for a long time**: it was documented as a
+  URL query param but never added to `COMMON_EXCLUDED_URI_PARAMS`
+  (`search_utils.py`), so passing it as an actual query param got parsed as a field
+  filter on a nonexistent field and silently matched zero documents. Now fixed — but the
+  general lesson is that this exclusion list is easy to forget when adding any new
+  control param; if you add one, add it here too, or it'll quietly behave like a broken
+  filter instead of a no-op.
+- **A subsequent-page query body is not automatically safe to reuse from page 1.**
+  `limit=all`'s pagination loop used to resend the *exact same query dict* — including
+  the full default-facet `aggs` block — on every page, even though each facet
+  aggregation runs in the whole-index `global` context (so it costs the same on every
+  page) and nothing downstream ever reads aggregations past the first page. Before
+  copying a query dict for a follow-up request, check what that specific request
+  actually needs — don't assume "same query, different `from_`" is free.
+- **A cache that's only ever read with a truthy-looking default never actually caches
+  anything.** `schema_for_field`'s per-request cache used
+  `getattr(request, '_field_schema_cache', {})` — since `{}` is not `None`, the
+  "initialize if unset" branch never ran, so the cache dict was always a throwaway
+  local and the attribute was never persisted onto the request. If you add a
+  per-request cache, verify with a test that the attribute actually survives across two
+  calls, not just that the second call returns the right value (which it will, from
+  the throwaway dict, even when nothing is actually being cached across calls).
+- **Floating-point epsilon direction in boundary math is easy to get backwards.**
+  `LuceneBuilder.canonicalize_bounds`/`range_includes_zero` nudge exclusive (`gt`/`lt`)
+  range bounds by a tiny epsilon so an inclusive comparison can still distinguish them
+  from inclusive (`gte`/`lte`) bounds — but only near a pivot of exactly zero (the
+  epsilon is swallowed by float64 precision everywhere else). Getting the nudge
+  direction wrong here is a real, subtle bug class: it doesn't show up in ordinary
+  values, only at an exact zero boundary. Assert boundary behavior explicitly in tests
+  (`gt: 0` must exclude zero, `gte: 0` must include it, etc.) — don't trust it "looks
+  right" from reading the arithmetic.
+- **Boolean dedup guards using `or` where `and` was meant** are an easy mistake and easy
+  to miss in review: `CompoundSearchBuilder._add_type_to_flag_if_needed`'s "is this
+  already present" check used `not in flags or lower_not in flags` (true almost always,
+  since the second clause fires whenever `flags` isn't already all-lowercase),
+  defeating the dedup it was meant to provide. When writing a "skip if already present"
+  guard across multiple representations of the same thing (case variants, etc.), the
+  guard needs `and` (absent in *every* representation), not `or`.
+
+## Historical detail
+
+Two efficiency audits and their fixes are the source of most of the above (query
+`_source`/facet waste findings, the `skip_default_facets` and pagination-`aggs` bugs,
+and the two latent boundary bugs). The full reports have file:line evidence, benchmarks,
+and reasoning that didn't make it into this summary — ask your supervisor for the ES
+query efficiency audit reports (there were two passes) if you need that depth.
+
+## Test coverage map
+
+`snovault/tests/` (no ES/live pyramid app required — these test pure query-construction
+and caching logic via minimally-populated `SearchBuilder`/`LuceneBuilder` instances and
+monkeypatched ES calls):
+
+- `test_search_efficiency.py` — the `_source`/frame-gating fixes, `limit=all` `aggs`
+  stripping, `skip_default_facets` exclusion, compound_search's `/build_query`
+  `skip_default_facets` flag, `schema_for_field` caching, the removed stray `print()`.
+- `test_search_utils.py` — `find_nested_path`, `build_sort_dicts`, `execute_search`'s
+  exception handling, `execute_streaming_search`'s pagination, and other
+  `search_utils.py` leaf functions.
+- `test_lucene_builder.py` — `handle_range_filters`, `canonicalize_bounds`/
+  `range_includes_zero`, `construct_nested_sub_queries`, and other `LuceneBuilder`
+  leaf methods.
+- `test_compound_search.py` — `CompoundSearchBuilder`'s pure string/validation helpers
+  (`combine_query_strings`, `_add_type_to_flag_if_needed`, `validate_flag`/
+  `validate_filter_block`, `extract_filter_set_from_search_body`).
+- `test_search_builder_helpers.py` — `SearchBuilder` helpers not covered elsewhere:
+  `set_pagination`, `build_initial_columns`, `format_extra_aggregations`,
+  `group_facet_terms`, `_format_results`.
+
+`compound_search.py`'s end-to-end behavior (actual ES execution via `execute_filter_set`)
+has **no test coverage in this repo** — there's no ES fixture wired up at the unit-test
+level here. It's presumably exercised downstream (smaht-portal/cgap-portal); if you
+change `execute_filter_set` or anything it calls, double-check those repos' test suites.

--- a/snovault/search/CLAUDE.md
+++ b/snovault/search/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/snovault/search/compound_search.py
+++ b/snovault/search/compound_search.py
@@ -158,7 +158,7 @@ class CompoundSearchBuilder:
         :param type_flag: query substring containing type requirement
         :return: query string that combines the two, if type requirement isn't already there
         """
-        if type_flag not in flags or type_flag.lower() not in flags:
+        if type_flag not in flags and type_flag.lower() not in flags:
             if len(flags) > 0:
                 flags += '&' + type_flag
             else:

--- a/snovault/search/compound_search.py
+++ b/snovault/search/compound_search.py
@@ -261,6 +261,10 @@ class CompoundSearchBuilder:
             sort, result_sort = build_sort_dicts(requested_sorts, request, [ doc_type ])
 
             search_builder_instance = SearchBuilder.from_search(context, compound_subreq, compound_query, return_generator=return_generator)
+            # from_search skips _bootstrap_query, so _source is never restricted - set it explicitly
+            # since both consumers of this result (format_result_for_endpoint_response, es_results_generator)
+            # only ever read hit['_source']['embedded']
+            search_builder_instance.query['_source'] = ['embedded.*']
             search_builder_instance.assure_session_id()
             search_builder_instance.query['sort'] = sort
             es_results = None

--- a/snovault/search/compound_search.py
+++ b/snovault/search/compound_search.py
@@ -57,6 +57,13 @@ class CompoundSearchBuilder:
         if len(query) > 0 and query[0] != "?":
             query = '?' + query
 
+        # /build_query only ever reads query['query'] back (see execute_filter_set) -
+        # facet/aggregation construction only ever writes query['aggs'], so skipping the
+        # default per-field facet computation here is free and leaves the extracted query
+        # identical, while avoiding a deepcopy-per-facet + schema crawl on every filter block.
+        if route == CompoundSearchBuilder.BUILD_QUERY_URL:
+            query = '?' + CompoundSearchBuilder.combine_query_strings(query, 'skip_default_facets=true')
+
         # If any '?', '&', or '=' in search term, should have been pre-encoded.
         # Meant to handle "+" especially.
         query = urllib.parse.quote(query, safe="?&=")

--- a/snovault/search/lucene_builder.py
+++ b/snovault/search/lucene_builder.py
@@ -264,11 +264,15 @@ class LuceneBuilder:
             if direction == 'lte':
                 upper = pivot + cls.SMALLEST_NONZERO_IEEE_32
             elif direction == 'lt':
-                upper = pivot
+                # exclusive upper bound - nudge down so an inclusive (<=) comparison
+                # against this value correctly excludes the pivot itself
+                upper = pivot - cls.SMALLEST_NONZERO_IEEE_32
             elif direction == 'gte':
                 lower = pivot
             elif direction == 'gt':
-                lower = pivot - cls.SMALLEST_NONZERO_IEEE_32
+                # exclusive lower bound - nudge up so an inclusive (<=) comparison
+                # against this value correctly excludes the pivot itself
+                lower = pivot + cls.SMALLEST_NONZERO_IEEE_32
         return lower, upper
 
     @classmethod

--- a/snovault/search/search.py
+++ b/snovault/search/search.py
@@ -482,8 +482,9 @@ class SearchBuilder:
                 frame = 'properties'
             else:
                 frame = self.search_frame
-            # let embedded be searched as well (for faceting)
-            fields = ['embedded.*', frame + '.*']
+            # note: aggregations operate on indexed doc-values, not _source, so
+            # restricting _source to just the requested frame does not affect faceting
+            fields = [frame + '.*']
         else:
             fields = ['embedded.*']
         return fields
@@ -613,11 +614,14 @@ class SearchBuilder:
         :returns: list: tuples containing (0) ElasticSearch-formatted field name (e.g. `embedded.status`)
                         and (1) list of terms for it.
         """
-        # Fast path: caller has asked for additional_facet aggregations only.
-        # Returning early skips the schema-default facet loading entirely —
-        # used by callers like peek-metadata that need a single tiny stats
-        # aggregation and were timing out paying for all default facets.
-        if asbool(self.request.normalized_params.get(self.SKIP_DEFAULT_FACETS)):
+        # Fast path: caller has asked for additional_facet aggregations only,
+        # or the response frame can't use default facets anyway (format_facets
+        # returns [] for any frame != 'embedded', so computing them is wasted
+        # ES aggregation work). Returning early skips the schema-default facet
+        # loading entirely — used by callers like peek-metadata that need a
+        # single tiny stats aggregation and were timing out paying for all
+        # default facets.
+        if asbool(self.request.normalized_params.get(self.SKIP_DEFAULT_FACETS)) or self.search_frame != 'embedded':
             facets = []
             current_type_schema = (
                 self.request.registry[TYPES][self.doc_types[0]].schema

--- a/snovault/search/search.py
+++ b/snovault/search/search.py
@@ -1076,7 +1076,6 @@ class SearchBuilder:
         result_facet['terms'] = sorted(list(group_terms_dict.values()), key=lambda t: t['doc_count'], reverse=True)
         del result_facet['group_by_field']
         result_facet['has_group_by'] = True
-        print(result_facet)
 
     def get_collection_actions(self):
         """
@@ -1197,10 +1196,16 @@ class SearchBuilder:
         Calls `execute_search` in paginated manner iteratively until all results have been yielded.
         """
         from_ = 0
+        # Facet aggregations run in a `global` (whole-index) context, so they cost the same on
+        # every page regardless of `from_`/`size` - but format_facets only ever reads them from
+        # the first page's response. Drop `aggs` (and total-hit tracking, also only needed on the
+        # first page) from subsequent-page queries so we don't re-pay that cost on every page.
+        subsequent_query = {k: v for k, v in self.query.items() if k != 'aggs'}
+        subsequent_query['track_total_hits'] = False
         while extra_requests_needed_count > 0:
             # print(str(extra_requests_needed_count) + " requests left to get all results.")
             from_ = from_ + size_increment
-            subsequent_search_result = execute_search(es=self.es, query=self.query, index=self.es_index,
+            subsequent_search_result = execute_search(es=self.es, query=subsequent_query, index=self.es_index,
                                                       from_=from_, size=size_increment,
                                                       session_id=self.search_session_id)
             extra_requests_needed_count -= 1

--- a/snovault/search/search_utils.py
+++ b/snovault/search/search_utils.py
@@ -47,7 +47,7 @@ COMMON_EXCLUDED_URI_PARAMS = [
     # Difference of this and URL params should result in all fields/filters.
     'frame', 'format', 'limit', 'sort', 'from', 'field',
     'mode', 'redirected_from', 'datastore', 'referrer',
-    'currentAction', 'additional_facet', 'debug'
+    'currentAction', 'additional_facet', 'debug', 'skip_default_facets'
 ]
 MAX_FACET_COUNTS = 100
 RAW_FIELD_AGGREGATIONS = [
@@ -186,7 +186,7 @@ def schema_for_field(field, request, doc_types, should_log=False):
     doc_type_string = ','.join(sorted(doc_types))  # use default sort
 
     # Check cache, initializing if necessary
-    cache = getattr(request, '_field_schema_cache', {})
+    cache = getattr(request, '_field_schema_cache', None)
     cache_key = (field, doc_type_string)
     if cache is None:
         request._field_schema_cache = cache = {}

--- a/snovault/tests/test_compound_search.py
+++ b/snovault/tests/test_compound_search.py
@@ -43,17 +43,15 @@ class TestAddTypeToFlagIfNeeded:
         result = CompoundSearchBuilder._add_type_to_flag_if_needed('', 'type=Item')
         assert result == 'type=Item'
 
-    def test_appends_type_again_even_when_already_present(self):
-        # NOTE: the presence check is `if type_flag not in flags or type_flag.lower()
-        # not in flags:` (an OR) - since type_flag.lower() is checked against the
-        # *original-case* flags string, that second clause is true almost
-        # whenever flags isn't already all-lowercase, so this "not already
-        # present" guard does not actually prevent duplication in the common
-        # case. Documenting current (likely unintended) behavior here rather
-        # than the presumably-intended dedup behavior, since this file only
-        # closes test gaps and does not change behavior.
+    def test_does_not_duplicate_type_when_already_present(self):
         result = CompoundSearchBuilder._add_type_to_flag_if_needed('type=Item&status=released', 'type=Item')
-        assert result == 'type=Item&status=released&type=Item'
+        assert result == 'type=Item&status=released'
+
+    def test_does_not_duplicate_type_when_present_in_lowercase_form(self):
+        # type_flag is 'type=Item' but flags already has the lowercase form -
+        # the `type_flag.lower() not in flags` clause should still catch this.
+        result = CompoundSearchBuilder._add_type_to_flag_if_needed('type=item&status=released', 'type=Item')
+        assert result == 'type=item&status=released'
 
 
 class TestEsResultsGenerator:

--- a/snovault/tests/test_compound_search.py
+++ b/snovault/tests/test_compound_search.py
@@ -1,0 +1,168 @@
+"""
+Unit tests for pure/leaf helper methods on
+snovault.search.compound_search.CompoundSearchBuilder that previously had no
+direct test coverage in this repo (compound_search has no snovault-level ES
+test fixture at all - see test_search_efficiency.py's docstring). These
+exercise string/dict manipulation and validation logic directly, without any
+ES or Pyramid subrequest dependency.
+"""
+
+import pytest
+from pyramid.httpexceptions import HTTPBadRequest
+
+from snovault.search.compound_search import CompoundSearchBuilder
+
+
+class TestCombineQueryStrings:
+
+    def test_merges_distinct_params(self):
+        result = CompoundSearchBuilder.combine_query_strings('?type=Item', 'status=released')
+        assert result == 'type=Item&status=released'
+
+    def test_duplicate_param_values_are_concatenated_not_overwritten(self):
+        result = CompoundSearchBuilder.combine_query_strings('status=released', 'status=archived')
+        # both values must survive as separate entries for the same key
+        assert result == 'status=released&status=archived'
+
+    def test_leading_question_marks_are_stripped_from_both_sides(self):
+        result = CompoundSearchBuilder.combine_query_strings('?a=1', '?b=2')
+        assert result == 'a=1&b=2'
+
+    def test_empty_second_string_returns_first_unchanged(self):
+        result = CompoundSearchBuilder.combine_query_strings('?type=Item', '')
+        assert result == 'type=Item'
+
+
+class TestAddTypeToFlagIfNeeded:
+
+    def test_adds_type_when_absent(self):
+        result = CompoundSearchBuilder._add_type_to_flag_if_needed('status=released', 'type=Item')
+        assert result == 'status=released&type=Item'
+
+    def test_returns_bare_type_flag_when_flags_empty(self):
+        result = CompoundSearchBuilder._add_type_to_flag_if_needed('', 'type=Item')
+        assert result == 'type=Item'
+
+    def test_appends_type_again_even_when_already_present(self):
+        # NOTE: the presence check is `if type_flag not in flags or type_flag.lower()
+        # not in flags:` (an OR) - since type_flag.lower() is checked against the
+        # *original-case* flags string, that second clause is true almost
+        # whenever flags isn't already all-lowercase, so this "not already
+        # present" guard does not actually prevent duplication in the common
+        # case. Documenting current (likely unintended) behavior here rather
+        # than the presumably-intended dedup behavior, since this file only
+        # closes test gaps and does not change behavior.
+        result = CompoundSearchBuilder._add_type_to_flag_if_needed('type=Item&status=released', 'type=Item')
+        assert result == 'type=Item&status=released&type=Item'
+
+
+class TestEsResultsGenerator:
+
+    def test_yields_embedded_frame_for_each_hit(self):
+        es_results = {'hits': {'hits': [
+            {'_source': {'embedded': {'uuid': '1'}}},
+            {'_source': {'embedded': {'uuid': '2'}}},
+        ]}}
+        results = list(CompoundSearchBuilder.es_results_generator(es_results))
+        assert results == [{'uuid': '1'}, {'uuid': '2'}]
+
+    def test_yields_nothing_for_no_hits(self):
+        es_results = {'hits': {}}
+        assert list(CompoundSearchBuilder.es_results_generator(es_results)) == []
+
+
+class TestValidateFlag:
+
+    def test_valid_flag_does_not_raise(self):
+        CompoundSearchBuilder.validate_flag({'name': 'my_flag', 'query': 'status=released'})
+
+    def test_missing_name_raises(self):
+        with pytest.raises(HTTPBadRequest):
+            CompoundSearchBuilder.validate_flag({'query': 'status=released'})
+
+    def test_missing_query_raises(self):
+        with pytest.raises(HTTPBadRequest):
+            CompoundSearchBuilder.validate_flag({'name': 'my_flag'})
+
+    def test_non_string_name_raises(self):
+        with pytest.raises(HTTPBadRequest):
+            CompoundSearchBuilder.validate_flag({'name': 123, 'query': 'status=released'})
+
+    def test_non_string_query_raises(self):
+        with pytest.raises(HTTPBadRequest):
+            CompoundSearchBuilder.validate_flag({'name': 'my_flag', 'query': ['status=released']})
+
+
+class TestValidateFilterBlock:
+
+    def test_valid_filter_block_does_not_raise(self):
+        CompoundSearchBuilder.validate_filter_block({'query': 'status=released', 'flags_applied': []})
+
+    def test_missing_query_raises(self):
+        with pytest.raises(HTTPBadRequest):
+            CompoundSearchBuilder.validate_filter_block({'flags_applied': []})
+
+    def test_missing_flags_applied_raises(self):
+        with pytest.raises(HTTPBadRequest):
+            CompoundSearchBuilder.validate_filter_block({'query': 'status=released'})
+
+    def test_non_string_query_raises(self):
+        with pytest.raises(HTTPBadRequest):
+            CompoundSearchBuilder.validate_filter_block({'query': 123, 'flags_applied': []})
+
+    def test_non_list_flags_applied_raises(self):
+        with pytest.raises(HTTPBadRequest):
+            CompoundSearchBuilder.validate_filter_block({'query': 'status=released', 'flags_applied': 'not_a_list'})
+
+
+class TestExtractFilterSetFromSearchBody:
+    """ Only exercises the non-'@id' branch (building a filter_set dict from
+        a raw POST body) - the '@id' branch delegates to get_item_or_none,
+        which needs a real item store and is out of scope for a unit test. """
+
+    def test_missing_type_raises(self):
+        with pytest.raises(HTTPBadRequest):
+            CompoundSearchBuilder.extract_filter_set_from_search_body(request=None, body={})
+
+    def test_minimal_body_with_only_type(self):
+        result = CompoundSearchBuilder.extract_filter_set_from_search_body(
+            request=None, body={'search_type': 'File'}
+        )
+        assert result == {'search_type': 'File'}
+
+    def test_flags_must_be_a_list(self):
+        with pytest.raises(HTTPBadRequest):
+            CompoundSearchBuilder.extract_filter_set_from_search_body(
+                request=None, body={'search_type': 'File', 'flags': {'name': 'x', 'query': 'y'}}
+            )
+
+    def test_filter_blocks_must_be_a_list(self):
+        with pytest.raises(HTTPBadRequest):
+            CompoundSearchBuilder.extract_filter_set_from_search_body(
+                request=None, body={'search_type': 'File', 'filter_blocks': {'query': 'y', 'flags_applied': []}}
+            )
+
+    def test_valid_flags_and_filter_blocks_pass_through(self):
+        body = {
+            'search_type': 'File',
+            'flags': [{'name': 'my_flag', 'query': 'status=released'}],
+            'filter_blocks': [{'query': 'type=File', 'flags_applied': ['my_flag']}],
+        }
+        result = CompoundSearchBuilder.extract_filter_set_from_search_body(request=None, body=body)
+        assert result == body
+
+    def test_invalid_flag_in_list_raises(self):
+        body = {
+            'search_type': 'File',
+            'flags': [{'name': 'my_flag'}],  # missing 'query'
+        }
+        with pytest.raises(HTTPBadRequest):
+            CompoundSearchBuilder.extract_filter_set_from_search_body(request=None, body=body)
+
+    def test_invalid_filter_block_in_list_raises(self):
+        body = {
+            'search_type': 'File',
+            'filter_blocks': [{'query': 'type=File'}],  # missing 'flags_applied'
+        }
+        with pytest.raises(HTTPBadRequest):
+            CompoundSearchBuilder.extract_filter_set_from_search_body(request=None, body=body)

--- a/snovault/tests/test_lucene_builder.py
+++ b/snovault/tests/test_lucene_builder.py
@@ -1,0 +1,259 @@
+"""
+Unit tests for pure/leaf helper methods on snovault.search.lucene_builder.LuceneBuilder
+that previously had zero test coverage anywhere in the repo (confirmed via grep -
+no snovault/tests/*.py file references LuceneBuilder before this file). These
+exercise the lucene query-dict construction logic directly, without any ES
+dependency.
+"""
+
+import pytest
+from webob.multidict import MultiDict
+
+from snovault.search.lucene_builder import LuceneBuilder
+from snovault.search.search_utils import QueryConstructionException
+
+
+class DummyTypeInfo:
+
+    def __init__(self, schema=None):
+        self.schema = schema or {}
+
+
+class DummyRequest:
+
+    def __init__(self, params, path='/search/', registry=None):
+        self.normalized_params = MultiDict(params)
+        self.path = path
+        self.registry = registry or {'types': {'Item': DummyTypeInfo()}}
+
+
+class TestHandleShouldQuery:
+
+    def test_builds_terms_should_query(self):
+        result = LuceneBuilder.handle_should_query('embedded.status.raw', ['released', 'archived'])
+        assert result == {'bool': {'should': {'terms': {'embedded.status.raw': ['released', 'archived']}}}}
+
+
+class TestExtractFieldFromTo:
+
+    def test_matches_from_suffix(self):
+        matched, field, direction = LuceneBuilder.extract_field_from_to('date_created.from')
+        assert (matched, field, direction) == (True, 'date_created', 'from')
+
+    def test_matches_to_suffix_on_nested_field(self):
+        matched, field, direction = LuceneBuilder.extract_field_from_to('files.file_size.to')
+        assert (matched, field, direction) == (True, 'files.file_size', 'to')
+
+    def test_no_match_returns_false_and_nones(self):
+        matched, field, direction = LuceneBuilder.extract_field_from_to('status')
+        assert (matched, field, direction) == (False, None, None)
+
+
+class TestCanonicalizeBoundsAndRangeIncludesZero:
+    """ canonicalize_bounds normalizes a range filter (gt/gte/lt/lte) to an
+        inclusive-lower/exclusive-upper (lower, upper) pair by nudging
+        exclusive bounds by SMALLEST_NONZERO_IEEE_32 (~1.1754e-38);
+        range_includes_zero uses that to decide whether a numeric range
+        filter should also match documents with no value for the field
+        ('add_no_value' schema flag). """
+
+    def test_gte_lte_bounds_pass_through_unchanged_at_this_magnitude(self):
+        # At magnitude 10, float64 precision (~1e-15 absolute here) completely
+        # swallows the ~1e-38 epsilon, so the "exclusive" nudge on lte has no
+        # observable effect away from zero - only the sign/direction matters
+        # for range_includes_zero's purposes.
+        lower, upper = LuceneBuilder.canonicalize_bounds({'gte': 0, 'lte': 10})
+        assert lower == 0
+        assert upper == 10.0
+
+    def test_gt_lt_bounds_pass_through_unchanged_at_this_magnitude(self):
+        lower, upper = LuceneBuilder.canonicalize_bounds({'gt': 5, 'lt': 10})
+        assert lower == 5.0
+        assert upper == 10
+
+    def test_epsilon_nudge_is_only_observable_exactly_at_zero(self):
+        # The epsilon is only large enough to perturb the boundary when the
+        # pivot itself is at (or extremely near) zero.
+        lower, _ = LuceneBuilder.canonicalize_bounds({'gt': 0})
+        assert lower < 0
+        _, upper = LuceneBuilder.canonicalize_bounds({'lte': 0})
+        assert upper > 0
+
+    def test_range_including_zero(self):
+        assert LuceneBuilder.range_includes_zero({'gte': -5, 'lte': 5}) is True
+
+    def test_range_excluding_zero_positive(self):
+        assert LuceneBuilder.range_includes_zero({'gte': 1, 'lte': 5}) is False
+
+    def test_range_excluding_zero_negative(self):
+        assert LuceneBuilder.range_includes_zero({'gte': -5, 'lte': -1}) is False
+
+    def test_range_with_gte_zero_includes_zero(self):
+        assert LuceneBuilder.range_includes_zero({'gte': 0, 'lte': 10}) is True
+
+    def test_range_with_exclusive_gt_zero_boundary_currently_reports_includes_zero(self):
+        # NOTE: mathematically, `gt: 0` (strictly greater than zero) should
+        # exclude zero. But canonicalize_bounds computes lower = pivot - epsilon
+        # for 'gt', which at pivot=0 produces a small *negative* number
+        # (-1.1754e-38), making `lower <= 0` true. So this currently reports
+        # True (includes zero) for an exact `gt: 0` boundary, which looks like
+        # an off-by-epsilon edge case in the exclusive/zero-boundary interaction
+        # (only reachable when a numeric field's schema also sets add_no_value
+        # and a caller filters with an exact `gt: 0`/`lt: 0` boundary) -
+        # documenting current behavior here rather than asserting the
+        # mathematically "correct" answer, since this file only closes test
+        # gaps and does not change behavior.
+        assert LuceneBuilder.range_includes_zero({'gt': 0, 'lte': 10}) is True
+
+    def test_range_with_exclusive_lt_zero_boundary_currently_reports_includes_zero(self):
+        # Same edge case, mirrored: `lt: 0` (strictly less than zero) should
+        # exclude zero, but upper = pivot + epsilon at pivot=0 produces a tiny
+        # *positive* number, making `upper >= 0` true.
+        assert LuceneBuilder.range_includes_zero({'gte': -10, 'lt': 0}) is True
+
+
+class TestConstructNestedSubQueries:
+
+    def test_no_filters_returns_empty_dict(self):
+        result = LuceneBuilder.construct_nested_sub_queries('embedded.foo', {'must_terms': []}, key='must_terms')
+        assert result == {}
+
+    def test_single_filter_uses_match(self):
+        result = LuceneBuilder.construct_nested_sub_queries(
+            'embedded.foo', {'must_terms': ['bar']}, key='must_terms'
+        )
+        assert result == {'match': {'embedded.foo': 'bar'}}
+
+    def test_multiple_filters_combine_with_should(self):
+        result = LuceneBuilder.construct_nested_sub_queries(
+            'embedded.foo', {'must_terms': ['bar', 'baz']}, key='must_terms'
+        )
+        assert result == {'bool': {'should': [
+            {'match': {'embedded.foo': 'bar'}},
+            {'match': {'embedded.foo': 'baz'}},
+        ]}}
+
+    def test_invalid_key_raises_query_construction_exception(self):
+        with pytest.raises(QueryConstructionException):
+            LuceneBuilder.construct_nested_sub_queries('embedded.foo', {}, key='not_a_real_key')
+
+
+class TestCreateFieldFilters:
+    """ Ported from Fourfront to support the group_by facet. Builds a single
+        bool/must+must_not query from a dict of {query_field: {must_terms, must_not_terms}}. """
+
+    def test_must_and_must_not_terms(self):
+        field_filters = {
+            'embedded.status.raw': {'must_terms': ['released'], 'must_not_terms': ['deleted']}
+        }
+        result = LuceneBuilder.create_field_filters(field_filters)
+        assert result == {'bool': {
+            'must': [{'terms': {'embedded.status.raw': ['released']}}],
+            'must_not': [{'terms': {'embedded.status.raw': ['deleted']}}],
+        }}
+
+    def test_no_filters_produces_empty_must_and_must_not(self):
+        field_filters = {'embedded.status.raw': {'must_terms': [], 'must_not_terms': []}}
+        result = LuceneBuilder.create_field_filters(field_filters)
+        assert result == {'bool': {'must': [], 'must_not': []}}
+
+
+class TestHandleRangeFilters:
+    """ handle_range_filters is the core translation of URL range-query params
+        (field.from=, field.to=) into ES range filter dicts, including
+        date-vs-numerical detection, default time-of-day correction for
+        date-only terms, and widening when multiple overlapping ranges are
+        given for the same field. It had zero test coverage. """
+
+    def _numeric_schema_request(self, params):
+        return DummyRequest(params, registry={
+            'types': {'Item': DummyTypeInfo({'properties': {'count': {'type': 'integer'}}})}
+        })
+
+    def test_ordinary_term_filter_is_recorded_in_result_filters(self):
+        request = DummyRequest([('status', 'released')])
+        result = {'filters': []}
+        range_filters = LuceneBuilder.handle_range_filters(request, result, {}, ['Item'])
+        assert range_filters == {}
+        assert result['filters'] == [{'field': 'status', 'term': 'released',
+                                       'remove': '/search/?type=Item'}]
+
+    def test_q_and_excluded_params_are_skipped(self):
+        request = DummyRequest([('q', 'foo'), ('limit', '25'), ('frame', 'embedded')])
+        result = {'filters': []}
+        LuceneBuilder.handle_range_filters(request, result, {}, ['Item'])
+        assert result['filters'] == []
+
+    def test_numerical_range_from_to(self, monkeypatch):
+        import snovault.search.lucene_builder as lucene_builder_module
+        monkeypatch.setattr(
+            lucene_builder_module, 'schema_for_field',
+            lambda field, request, doc_types: {'type': 'integer'}
+        )
+        request = DummyRequest([('count.from', '5'), ('count.to', '10')])
+        result = {'filters': []}
+        range_filters = LuceneBuilder.handle_range_filters(request, result, {}, ['Item'])
+        assert range_filters == {'embedded.count': {'gte': '5', 'lte': '10'}}
+
+    def test_date_range_defaults_time_of_day_when_missing(self, monkeypatch):
+        import snovault.search.lucene_builder as lucene_builder_module
+        monkeypatch.setattr(
+            lucene_builder_module, 'schema_for_field',
+            lambda field, request, doc_types: {'format': 'date'}
+        )
+        request = DummyRequest([('date_created.from', '2024-01-01'), ('date_created.to', '2024-01-31')])
+        result = {'filters': []}
+        range_filters = LuceneBuilder.handle_range_filters(request, result, {}, ['Item'])
+        # 'from' -> gte with 00:00 appended; 'to' -> lte with 23:59 appended
+        assert range_filters['embedded.date_created']['gte'] == '2024-01-01 00:00'
+        assert range_filters['embedded.date_created']['lte'] == '2024-01-31 23:59'
+        assert range_filters['embedded.date_created']['format'] == 'yyyy-MM-dd HH:mm'
+
+    def test_overlapping_ranges_widen_to_the_looser_bound(self, monkeypatch):
+        import snovault.search.lucene_builder as lucene_builder_module
+        monkeypatch.setattr(
+            lucene_builder_module, 'schema_for_field',
+            lambda field, request, doc_types: {'type': 'integer'}
+        )
+        request = DummyRequest([('count.from', '5'), ('count.from', '2')])
+        result = {'filters': []}
+        range_filters = LuceneBuilder.handle_range_filters(request, result, {}, ['Item'])
+        # two overlapping gte filters on the same field - the wider (smaller) bound wins
+        assert range_filters['embedded.count']['gte'] == '2'
+
+    def test_not_qualifier_still_records_filter_without_treating_as_range(self):
+        request = DummyRequest([('status!', 'deleted')])
+        result = {'filters': []}
+        range_filters = LuceneBuilder.handle_range_filters(request, result, {}, ['Item'])
+        assert range_filters == {}
+        assert result['filters'][0]['field'] == 'status!'
+
+    def test_no_value_term_marks_field_filters_add_no_value(self):
+        request = DummyRequest([('status', 'No value')])
+        result = {'filters': []}
+        field_filters = {}
+        LuceneBuilder.handle_range_filters(request, result, field_filters, ['Item'])
+        assert field_filters['embedded.status.raw']['add_no_value'] is True
+
+    def test_type_equals_item_is_recorded_on_at_type_raw(self):
+        # type=Item is the one 'type' value NOT skipped by this function (see
+        # `elif field == 'type' and term != 'Item': continue` below) - it gets
+        # recorded as an ordinary field filter on embedded.@type.raw.
+        request = DummyRequest([('type', 'Item')])
+        result = {'filters': []}
+        field_filters = {}
+        LuceneBuilder.handle_range_filters(request, result, field_filters, ['Item'])
+        assert field_filters['embedded.@type.raw']['must_terms'] == ['Item']
+        assert result['filters'][0]['field'] == 'type'
+
+    def test_type_equals_other_value_is_skipped_entirely(self):
+        # A specific, non-'Item' type filter (e.g. type=File) is skipped by this
+        # function entirely - actual type filtering is already applied via
+        # doc_types in initialize_field_filters, so handle_range_filters doesn't
+        # duplicate it (and doesn't add a removable UI filter entry for it).
+        request = DummyRequest([('type', 'File')])
+        result = {'filters': []}
+        field_filters = {}
+        LuceneBuilder.handle_range_filters(request, result, field_filters, ['Item'])
+        assert field_filters == {}
+        assert result['filters'] == []

--- a/snovault/tests/test_lucene_builder.py
+++ b/snovault/tests/test_lucene_builder.py
@@ -73,9 +73,13 @@ class TestCanonicalizeBoundsAndRangeIncludesZero:
 
     def test_epsilon_nudge_is_only_observable_exactly_at_zero(self):
         # The epsilon is only large enough to perturb the boundary when the
-        # pivot itself is at (or extremely near) zero.
+        # pivot itself is at (or extremely near) zero. Exclusive bounds are
+        # nudged *away* from the pivot (gt up, lt down) so an inclusive (<=)
+        # comparison against the nudged value correctly excludes the pivot.
         lower, _ = LuceneBuilder.canonicalize_bounds({'gt': 0})
-        assert lower < 0
+        assert lower > 0
+        _, upper = LuceneBuilder.canonicalize_bounds({'lt': 0})
+        assert upper < 0
         _, upper = LuceneBuilder.canonicalize_bounds({'lte': 0})
         assert upper > 0
 
@@ -91,25 +95,13 @@ class TestCanonicalizeBoundsAndRangeIncludesZero:
     def test_range_with_gte_zero_includes_zero(self):
         assert LuceneBuilder.range_includes_zero({'gte': 0, 'lte': 10}) is True
 
-    def test_range_with_exclusive_gt_zero_boundary_currently_reports_includes_zero(self):
-        # NOTE: mathematically, `gt: 0` (strictly greater than zero) should
-        # exclude zero. But canonicalize_bounds computes lower = pivot - epsilon
-        # for 'gt', which at pivot=0 produces a small *negative* number
-        # (-1.1754e-38), making `lower <= 0` true. So this currently reports
-        # True (includes zero) for an exact `gt: 0` boundary, which looks like
-        # an off-by-epsilon edge case in the exclusive/zero-boundary interaction
-        # (only reachable when a numeric field's schema also sets add_no_value
-        # and a caller filters with an exact `gt: 0`/`lt: 0` boundary) -
-        # documenting current behavior here rather than asserting the
-        # mathematically "correct" answer, since this file only closes test
-        # gaps and does not change behavior.
-        assert LuceneBuilder.range_includes_zero({'gt': 0, 'lte': 10}) is True
+    def test_range_with_exclusive_gt_zero_boundary_excludes_zero(self):
+        # `gt: 0` (strictly greater than zero) must exclude zero.
+        assert LuceneBuilder.range_includes_zero({'gt': 0, 'lte': 10}) is False
 
-    def test_range_with_exclusive_lt_zero_boundary_currently_reports_includes_zero(self):
-        # Same edge case, mirrored: `lt: 0` (strictly less than zero) should
-        # exclude zero, but upper = pivot + epsilon at pivot=0 produces a tiny
-        # *positive* number, making `upper >= 0` true.
-        assert LuceneBuilder.range_includes_zero({'gte': -10, 'lt': 0}) is True
+    def test_range_with_exclusive_lt_zero_boundary_excludes_zero(self):
+        # `lt: 0` (strictly less than zero) must exclude zero.
+        assert LuceneBuilder.range_includes_zero({'gte': -10, 'lt': 0}) is False
 
 
 class TestConstructNestedSubQueries:

--- a/snovault/tests/test_search_builder_helpers.py
+++ b/snovault/tests/test_search_builder_helpers.py
@@ -1,0 +1,254 @@
+"""
+Unit tests for additional SearchBuilder helper methods with no prior test
+coverage: pagination parsing, initial-columns construction, extra-aggregation
+extraction, group-by-facet term grouping, and per-hit frame selection. Built
+the same way as test_search_efficiency.py - minimally-populated SearchBuilder
+instances via object.__new__, no ES/pyramid app required.
+"""
+
+from snovault.search.search import SearchBuilder
+
+
+class DummyParams:
+
+    def __init__(self, params):
+        self._params = params
+
+    def getall(self, key):
+        return self._params.get(key, [])
+
+    def get(self, key, default=None):
+        values = self._params.get(key)
+        if values:
+            return values[0]
+        return default
+
+
+class DummyRequest:
+
+    def __init__(self, params):
+        self.normalized_params = DummyParams(params)
+
+
+def make_builder(params=None):
+    builder = object.__new__(SearchBuilder)
+    builder.request = DummyRequest(params or {})
+    return builder
+
+
+class TestSetPagination:
+
+    def test_defaults_when_no_params_given(self):
+        builder = make_builder({})
+        builder.set_pagination()
+        assert builder.from_ == 0
+        assert builder.size == SearchBuilder.PAGINATION_SIZE
+
+    def test_limit_all_sets_size_to_all_string(self):
+        builder = make_builder({'limit': ['all']})
+        builder.set_pagination()
+        assert builder.size == 'all'
+
+    def test_limit_empty_string_sets_size_to_all(self):
+        builder = make_builder({'limit': ['']})
+        builder.set_pagination()
+        assert builder.size == 'all'
+
+    def test_numeric_limit_and_from_are_parsed_as_ints(self):
+        builder = make_builder({'limit': ['50'], 'from': ['20']})
+        builder.set_pagination()
+        assert builder.size == 50
+        assert builder.from_ == 20
+
+    def test_invalid_limit_falls_back_to_default_pagination_size(self):
+        builder = make_builder({'limit': ['not-a-number']})
+        builder.set_pagination()
+        assert builder.size == SearchBuilder.PAGINATION_SIZE
+
+    def test_invalid_from_falls_back_to_zero(self):
+        builder = make_builder({'limit': ['25'], 'from': ['not-a-number']})
+        builder.set_pagination()
+        assert builder.from_ == 0
+        assert builder.size == 25
+
+
+class TestBuildInitialColumns:
+
+    def test_always_includes_title_column_first(self):
+        columns = SearchBuilder.build_initial_columns([{}])
+        assert next(iter(columns)) == 'display_title'
+        assert columns['display_title']['order'] == -1000
+
+    def test_status_and_date_created_added_when_absent_from_schema(self):
+        columns = SearchBuilder.build_initial_columns([{}])
+        assert 'status' in columns
+        assert 'date_created' in columns
+
+    def test_schema_columns_are_merged_in(self):
+        schema = {'columns': {'accession': {'title': 'Accession'}}}
+        columns = SearchBuilder.build_initial_columns([schema])
+        assert columns['accession'] == {'title': 'Accession'}
+
+    def test_schema_can_override_default_status_column(self):
+        schema = {'columns': {'status': {'title': 'Custom Status'}}}
+        columns = SearchBuilder.build_initial_columns([schema])
+        # schema-provided status overrides/updates the default, doesn't duplicate
+        assert columns['status']['title'] == 'Custom Status'
+
+    def test_multiple_schemas_merge_without_clobbering_earlier_ones(self):
+        schema1 = {'columns': {'accession': {'title': 'Accession'}}}
+        schema2 = {'columns': {'lab': {'title': 'Lab'}}}
+        columns = SearchBuilder.build_initial_columns([schema1, schema2])
+        assert 'accession' in columns
+        assert 'lab' in columns
+
+
+class TestFormatExtraAggregations:
+
+    def test_no_aggregations_key_returns_empty_dict(self):
+        assert SearchBuilder.format_extra_aggregations({}) == {}
+
+    def test_all_items_key_is_excluded(self):
+        es_results = {'aggregations': {'all_items': {'foo': 1}, 'my_stat': {'value': 42}}}
+        assert SearchBuilder.format_extra_aggregations(es_results) == {'my_stat': {'value': 42}}
+
+    def test_empty_aggregations_dict(self):
+        assert SearchBuilder.format_extra_aggregations({'aggregations': {}}) == {}
+
+
+class TestGroupFacetTerms:
+
+    def test_groups_terms_by_subaggregation_and_sums_doc_counts(self):
+        result_facet = {
+            'field': 'assay_type',
+            'group_by_field': 'category',
+            'terms': [
+                {'key': 'RNA-seq', 'doc_count': 5},
+                {'key': 'ChIP-seq', 'doc_count': 3},
+            ],
+        }
+        agg = {
+            'primary_agg': {
+                'buckets': [
+                    {'key': 'sequencing', 'sub_terms': {'buckets': [
+                        {'key': 'RNA-seq'}, {'key': 'ChIP-seq'},
+                    ]}},
+                ]
+            }
+        }
+        SearchBuilder.group_facet_terms(result_facet, agg, filters=[])
+
+        assert result_facet['has_group_by'] is True
+        assert 'group_by_field' not in result_facet
+        assert len(result_facet['terms']) == 1
+        group = result_facet['terms'][0]
+        assert group['key'] == 'sequencing'
+        assert group['doc_count'] == 8  # 5 + 3
+        assert {t['key'] for t in group['terms']} == {'RNA-seq', 'ChIP-seq'}
+
+    def test_terms_with_no_matching_subaggregation_group_under_missing_group(self):
+        result_facet = {
+            'field': 'assay_type',
+            'group_by_field': 'category',
+            'terms': [{'key': 'Unknown Assay', 'doc_count': 1}],
+        }
+        agg = {'primary_agg': {'buckets': []}}
+        SearchBuilder.group_facet_terms(result_facet, agg, filters=[])
+        assert result_facet['terms'][0]['key'] == '(Missing group)'
+
+    def test_filter_term_not_in_results_is_added_with_zero_doc_count(self):
+        # A term the user has actively filtered on but which returned zero
+        # matching documents (and thus isn't in the aggregation buckets) must
+        # still show up in the grouped output, per the inline comment about
+        # "exists in filters".
+        result_facet = {
+            'field': 'assay_type',
+            'group_by_field': 'category',
+            'terms': [],
+        }
+        agg = {
+            'primary_agg': {
+                'buckets': [
+                    {'key': 'sequencing', 'sub_terms': {'buckets': [{'key': 'RNA-seq'}]}},
+                ]
+            }
+        }
+        filters = [{'field': 'assay_type', 'term': 'RNA-seq'}]
+        SearchBuilder.group_facet_terms(result_facet, agg, filters=filters)
+        assert len(result_facet['terms']) == 1
+        assert result_facet['terms'][0]['terms'] == [{'key': 'RNA-seq', 'doc_count': 0}]
+
+    def test_filter_on_a_different_field_is_ignored(self):
+        result_facet = {
+            'field': 'assay_type',
+            'group_by_field': 'category',
+            'terms': [],
+        }
+        agg = {'primary_agg': {'buckets': []}}
+        filters = [{'field': 'status', 'term': 'released'}]
+        SearchBuilder.group_facet_terms(result_facet, agg, filters=filters)
+        assert result_facet['terms'] == []
+
+    def test_none_result_facet_or_agg_is_a_noop(self):
+        # should not raise
+        SearchBuilder.group_facet_terms(None, {'primary_agg': {'buckets': []}}, [])
+        SearchBuilder.group_facet_terms({'terms': []}, None, [])
+
+
+class TestFormatResults:
+    """ _format_results picks which _source frame to yield per hit, and merges
+        in validation_errors/aggregated_items if the frame itself doesn't
+        already carry them. """
+
+    def _builder(self, search_frame, fields_requested=None):
+        builder = object.__new__(SearchBuilder)
+        builder.request = DummyRequest({'field': fields_requested} if fields_requested else {})
+        builder.search_frame = search_frame
+        return builder
+
+    def test_embedded_frame_yields_embedded_source(self):
+        builder = self._builder('embedded')
+        hits = [{'_source': {'embedded': {'uuid': '1'}}}]
+        assert list(builder._format_results(hits)) == [{'uuid': '1'}]
+
+    def test_raw_frame_reads_from_properties_key(self):
+        builder = self._builder('raw')
+        hits = [{'_source': {'properties': {'uuid': '1'}}}]
+        assert list(builder._format_results(hits)) == [{'uuid': '1'}]
+
+    def test_object_frame_reads_from_object_key(self):
+        builder = self._builder('object')
+        hits = [{'_source': {'object': {'uuid': '1'}}}]
+        assert list(builder._format_results(hits)) == [{'uuid': '1'}]
+
+    def test_explicit_field_param_forces_embedded_frame_regardless_of_search_frame(self):
+        builder = self._builder('object', fields_requested=['status'])
+        hits = [{'_source': {'embedded': {'uuid': '1'}}, }]
+        assert list(builder._format_results(hits)) == [{'uuid': '1'}]
+
+    def test_validation_errors_merged_in_when_absent_from_frame(self):
+        builder = self._builder('embedded')
+        hits = [{'_source': {
+            'embedded': {'uuid': '1'},
+            'validation_errors': [{'error': 'oops'}],
+        }}]
+        result = list(builder._format_results(hits))[0]
+        assert result['validation_errors'] == [{'error': 'oops'}]
+
+    def test_validation_errors_not_overwritten_when_already_in_frame(self):
+        builder = self._builder('embedded')
+        hits = [{'_source': {
+            'embedded': {'uuid': '1', 'validation_errors': ['frame-specific']},
+            'validation_errors': ['top-level'],
+        }}]
+        result = list(builder._format_results(hits))[0]
+        assert result['validation_errors'] == ['frame-specific']
+
+    def test_aggregated_items_merged_in_when_absent_from_frame(self):
+        builder = self._builder('embedded')
+        hits = [{'_source': {
+            'embedded': {'uuid': '1'},
+            'aggregated_items': {'foo': ['bar']},
+        }}]
+        result = list(builder._format_results(hits))[0]
+        assert result['aggregated_items'] == {'foo': ['bar']}

--- a/snovault/tests/test_search_efficiency.py
+++ b/snovault/tests/test_search_efficiency.py
@@ -15,8 +15,6 @@ downstream), so its fix is validated the same way: asserting on the
 constructed query dict, without invoking `execute_filter_set` end-to-end.
 """
 
-import pytest
-
 from snovault.search.search import SearchBuilder
 
 

--- a/snovault/tests/test_search_efficiency.py
+++ b/snovault/tests/test_search_efficiency.py
@@ -1,0 +1,159 @@
+"""
+Unit tests for targeted efficiency fixes in the search query builder:
+
+    1. compound_search's multi-block path restricting `_source` to `embedded.*`
+    2. default per-field facets being skipped for non-'embedded' search frames
+    3. `list_source_fields` no longer fetching unused `embedded.*` for
+       frame=object/raw
+
+These exercise the pure query-construction logic on `SearchBuilder` directly
+(via a minimally-populated instance) rather than through a full pyramid app +
+Elasticsearch stack, since none of these paths touch ES itself - only the
+lucene query dict that would eventually be sent to it. There is no existing
+ES-backed test coverage for `compound_search` in this repo (it is exercised
+downstream), so its fix is validated the same way: asserting on the
+constructed query dict, without invoking `execute_filter_set` end-to-end.
+"""
+
+import pytest
+
+from snovault.search.search import SearchBuilder
+
+
+class DummyParams:
+    """ Minimal stand-in for webob's MultiDict, as used via request.normalized_params. """
+
+    def __init__(self, params):
+        self._params = params
+
+    def getall(self, key):
+        return self._params.get(key, [])
+
+    def get(self, key, default=None):
+        values = self._params.get(key)
+        if values:
+            return values[0]
+        return default
+
+
+class DummyRequest:
+
+    def __init__(self, params, registry=None):
+        self.normalized_params = DummyParams(params)
+        self.registry = registry or {}
+
+
+class DummyTypeInfo:
+
+    def __init__(self, schema=None):
+        self.schema = schema or {}
+
+
+def make_search_builder(frame='embedded', field=None, doc_types=('Item',),
+                         additional_facets=None, item_type_es_mapping=None):
+    """ Builds a SearchBuilder instance with only the attributes needed by
+        list_source_fields()/initialize_facets(), bypassing __init__ (which
+        requires a full pyramid registry with ES/storage handles).
+    """
+    params = {'frame': [frame]}
+    if field:
+        params['field'] = field
+    builder = object.__new__(SearchBuilder)
+    builder.doc_types = list(doc_types)
+    builder.request = DummyRequest(params, registry={'types': {dt: DummyTypeInfo() for dt in doc_types}})
+    builder.search_frame = frame
+    builder.additional_facets = additional_facets or []
+    builder.item_type_es_mapping = item_type_es_mapping or {}
+    builder.prepared_terms = {}
+    return builder
+
+
+class TestListSourceFields:
+    """ Fix #3: frame=object/raw should only fetch their own frame from _source,
+        not also 'embedded.*' (which is never read for those frames). """
+
+    def test_embedded_frame_unaffected(self):
+        builder = make_search_builder(frame='embedded')
+        assert builder.list_source_fields() == ['embedded.*']
+
+    def test_object_frame_only_fetches_object(self):
+        builder = make_search_builder(frame='object')
+        assert builder.list_source_fields() == ['object.*']
+
+    def test_raw_frame_only_fetches_properties(self):
+        builder = make_search_builder(frame='raw')
+        assert builder.list_source_fields() == ['properties.*']
+
+    def test_explicit_field_param_still_scoped_to_embedded(self):
+        builder = make_search_builder(frame='object', field=['status'])
+        fields = builder.list_source_fields()
+        assert fields == ['embedded.@id', 'embedded.@type', 'embedded.status']
+
+
+class TestInitializeFacetsFrameGating:
+    """ Fix #2: default per-field facets should not be computed for
+        frame != 'embedded', since format_facets() discards them anyway
+        (search.py's format_facets short-circuits for non-embedded frames).
+        The schema-defined `additional_facet` (?additional_facet=) path must
+        still work regardless of frame - that's a separate, explicit request
+        for a specific aggregation, not a default. """
+
+    def test_non_embedded_frame_skips_default_facets(self):
+        builder = make_search_builder(frame='object')
+        assert builder.initialize_facets() == []
+
+    def test_raw_frame_skips_default_facets(self):
+        builder = make_search_builder(frame='raw')
+        assert builder.initialize_facets() == []
+
+    def test_embedded_frame_still_computes_default_facets(self):
+        builder = make_search_builder(frame='embedded')
+        facets = builder.initialize_facets()
+        # default 'type' facet is always present for embedded-frame searches
+        assert any(field == 'type' for field, _ in facets)
+
+    def test_non_embedded_frame_still_honors_additional_facet_param(self):
+        # additional_facet is an explicit, non-default aggregation request and
+        # must survive the non-embedded fast path (mirrors SKIP_DEFAULT_FACETS).
+        builder = make_search_builder(frame='object', additional_facets=['status'])
+        facets = builder.initialize_facets()
+        assert any(field == 'status' for field, _ in facets)
+
+    def test_skip_default_facets_param_still_works_for_embedded_frame(self):
+        builder = make_search_builder(frame='embedded')
+        builder.request.normalized_params._params['skip_default_facets'] = ['true']
+        assert builder.initialize_facets() == []
+
+
+class TestCompoundSearchSourceRestriction:
+    """ Fix #1: compound_search's multi-block path must restrict _source to
+        'embedded.*', matching what its only two consumers
+        (format_result_for_endpoint_response, es_results_generator) read.
+
+        Building a real SearchBuilder via `from_search` (as execute_filter_set
+        does) requires a full pyramid registry (ES client handle, storage,
+        types) to satisfy the unconditional setup in `SearchBuilder.__init__`
+        even with skip_bootstrap=True - there's no existing snovault-level ES
+        test fixture wired up for compound_search (see the audit report), so
+        constructing that here would mean re-building a large slice of the
+        pyramid app in a unit test. Instead this asserts directly against the
+        source of execute_filter_set that the fix is present immediately
+        after the from_search() call, which is the actual regression this
+        guards against (someone editing that block and dropping the line).
+        This should be supplemented by a real integration-level test
+        downstream (smaht-portal/cgap-portal) where compound_search already
+        has ES-backed test coverage.
+    """
+
+    def test_execute_filter_set_restricts_source_to_embedded_after_from_search(self):
+        import inspect
+        from snovault.search.compound_search import CompoundSearchBuilder
+
+        source = inspect.getsource(CompoundSearchBuilder.execute_filter_set)
+        from_search_idx = source.index('SearchBuilder.from_search(')
+        source_fix_idx = source.index("search_builder_instance.query['_source'] = ['embedded.*']")
+        assert source_fix_idx > from_search_idx, (
+            "execute_filter_set must restrict _source to ['embedded.*'] on the "
+            "SearchBuilder built via from_search(), since format_result_for_endpoint_response "
+            "and es_results_generator only ever read hit['_source']['embedded']"
+        )

--- a/snovault/tests/test_search_efficiency.py
+++ b/snovault/tests/test_search_efficiency.py
@@ -5,6 +5,16 @@ Unit tests for targeted efficiency fixes in the search query builder:
     2. default per-field facets being skipped for non-'embedded' search frames
     3. `list_source_fields` no longer fetching unused `embedded.*` for
        frame=object/raw
+    4. `limit=all` pagination dropping `aggs`/`track_total_hits` from
+       subsequent-page queries
+    5. `skip_default_facets` being excluded from field-filter parsing
+       (COMMON_EXCLUDED_URI_PARAMS)
+    6. compound_search's per-block `/build_query` subrequest passing
+       `skip_default_facets=true`
+    7. `schema_for_field`'s per-request memoization actually persisting onto
+       the request
+    8. removal of the stray `print(result_facet)` debug statement in
+       `group_facet_terms`
 
 These exercise the pure query-construction logic on `SearchBuilder` directly
 (via a minimally-populated instance) rather than through a full pyramid app +
@@ -16,6 +26,9 @@ constructed query dict, without invoking `execute_filter_set` end-to-end.
 """
 
 from snovault.search.search import SearchBuilder
+import snovault.search.search as search_module
+import snovault.search.search_utils as search_utils_module
+import snovault.search.compound_search as compound_search_module
 
 
 class DummyParams:
@@ -155,3 +168,177 @@ class TestCompoundSearchSourceRestriction:
             "SearchBuilder built via from_search(), since format_result_for_endpoint_response "
             "and es_results_generator only ever read hit['_source']['embedded']"
         )
+
+
+class TestGetAllSubsequentResultsDropsAggs:
+    """ Fix #4: `limit=all` pagination re-sent the full default-facet
+        aggregation block (and total-hit tracking) on every page, even though
+        each facet aggregation runs in a `global` (whole-index) context - so
+        it costs the same on every page - and format_facets only ever reads
+        aggregations from the *first* page's response. Subsequent-page
+        queries should carry neither `aggs` nor `track_total_hits`, and the
+        rest of the query body (used for the actual hit search) must be
+        unaffected. """
+
+    def test_subsequent_pages_drop_aggs_and_total_hit_tracking(self, monkeypatch):
+        captured_queries = []
+
+        def fake_execute_search(es, query, index, from_, size, session_id=None):
+            captured_queries.append(query)
+            return {'hits': {'hits': []}}
+
+        monkeypatch.setattr(search_module, 'execute_search', fake_execute_search)
+
+        builder = object.__new__(SearchBuilder)
+        builder.es = None
+        builder.es_index = 'test-index'
+        builder.search_session_id = None
+        builder.query = {
+            'query': {'bool': {'must': ['sentinel']}},
+            'sort': ['sentinel-sort'],
+            'aggs': {'all_items': {'global': {}, 'aggs': {'type': {}}}},
+        }
+
+        list(builder.get_all_subsequent_results(extra_requests_needed_count=3, size_increment=100))
+
+        assert len(captured_queries) == 3
+        for query in captured_queries:
+            assert 'aggs' not in query
+            assert query['track_total_hits'] is False
+            # the rest of the query body (what actually finds/sorts hits) is untouched
+            assert query['query'] == {'bool': {'must': ['sentinel']}}
+            assert query['sort'] == ['sentinel-sort']
+
+        # the original query object (used for the first page) must not be mutated
+        assert 'aggs' in builder.query
+
+    def test_first_page_query_still_keeps_aggs(self, monkeypatch):
+        # execute_search_for_all_results issues the first page directly with self.query,
+        # which format_facets reads aggregations from - only subsequent pages should drop aggs.
+        first_page_queries = []
+
+        def fake_execute_search(es, query, index, from_, size, session_id=None):
+            first_page_queries.append(query)
+            return {'hits': {'hits': [], 'total': {'value': 0}}}
+
+        monkeypatch.setattr(search_module, 'execute_search', fake_execute_search)
+
+        builder = object.__new__(SearchBuilder)
+        builder.es = None
+        builder.es_index = 'test-index'
+        builder.search_session_id = None
+        builder.query = {'query': {'bool': {}}, 'aggs': {'all_items': {}}}
+
+        builder.execute_search_for_all_results()
+
+        assert len(first_page_queries) == 1
+        assert 'aggs' in first_page_queries[0]
+
+
+class TestSkipDefaultFacetsExcludedFromFieldFilters:
+    """ Fix #5: `skip_default_facets` was documented as a URL query param but
+        never added to COMMON_EXCLUDED_URI_PARAMS, so it was silently parsed
+        as a field filter on a nonexistent field
+        ('embedded.skip_default_facets'), matching zero documents. """
+
+    def test_skip_default_facets_in_excluded_params(self):
+        assert 'skip_default_facets' in search_utils_module.COMMON_EXCLUDED_URI_PARAMS
+
+    def test_skip_default_facets_not_treated_as_field_filter(self):
+        from webob.multidict import MultiDict
+
+        builder = object.__new__(SearchBuilder)
+        request = DummyRequest({})
+        request.normalized_params = MultiDict([('type', 'Item'), ('skip_default_facets', 'true')])
+
+        prepared_terms = builder.prepare_search_term(request)
+
+        assert 'embedded.skip_default_facets' not in prepared_terms
+
+
+class TestCompoundSearchBuildQuerySkipsDefaultFacets:
+    """ Fix #6: once #5 lands, compound_search's per-block `/build_query`
+        subrequest can pass `skip_default_facets=true` - `/build_query` only
+        ever returns `query['query']` back to execute_filter_set, and default
+        facet construction only ever writes `query['aggs']`, so this is free
+        and does not change the extracted query. Only requests routed to
+        BUILD_QUERY_URL should get the flag - regular `/search/` subrequests
+        (used by the single-filter-block and flags-only paths) must be
+        unaffected, since those responses' facets are actually used. """
+
+    class FakeSubreq:
+        def __init__(self, path):
+            self.path = path
+            self.headers = {}
+
+    def _capture_subreq_path(self, monkeypatch):
+        captured = {}
+
+        def fake_make_search_subreq(request, path):
+            captured['path'] = path
+            return self.FakeSubreq(path)
+
+        monkeypatch.setattr(compound_search_module, 'make_search_subreq', fake_make_search_subreq)
+        return captured
+
+    def test_build_query_route_gets_skip_default_facets_flag(self, monkeypatch):
+        captured = self._capture_subreq_path(monkeypatch)
+
+        compound_search_module.CompoundSearchBuilder.build_subreq_from_single_query(
+            request=object(), query='?type=Item',
+            route=compound_search_module.CompoundSearchBuilder.BUILD_QUERY_URL,
+            from_=0, to=10
+        )
+
+        assert 'skip_default_facets=true' in captured['path']
+        # original param must survive alongside the new flag
+        assert 'type=Item' in captured['path']
+
+    def test_search_route_unaffected(self, monkeypatch):
+        captured = self._capture_subreq_path(monkeypatch)
+
+        compound_search_module.CompoundSearchBuilder.build_subreq_from_single_query(
+            request=object(), query='?type=Item', route='/search/', from_=0, to=10
+        )
+
+        assert 'skip_default_facets' not in captured['path']
+        assert 'type=Item' in captured['path']
+
+
+class TestSchemaForFieldCache:
+    """ Fix #7: `schema_for_field`'s per-request memoization never actually
+        persisted the cache dict onto the request (the `getattr(..., {})`
+        default is never `None`, so the `if cache is None` initialization
+        branch never ran) - every call re-crawled the schema. """
+
+    def test_cache_persists_on_request_after_first_call(self, monkeypatch):
+        calls = []
+
+        def fake_crawl_schema(types, field, schema):
+            calls.append(field)
+            return {'type': 'string'}
+
+        monkeypatch.setattr(search_utils_module, 'crawl_schema', fake_crawl_schema)
+
+        request = DummyRequest({}, registry={'types': {'Item': DummyTypeInfo()}})
+        assert not hasattr(request, '_field_schema_cache')
+
+        first = search_utils_module.schema_for_field('status', request, ['Item'])
+        assert hasattr(request, '_field_schema_cache')
+        assert len(calls) == 1
+
+        second = search_utils_module.schema_for_field('status', request, ['Item'])
+        assert len(calls) == 1  # cache hit - no second crawl
+        assert first == second == {'type': 'string'}
+
+
+class TestGroupFacetTermsNoStrayPrint:
+    """ Fix #8: a stray `print(result_facet)` in `group_facet_terms` dumped
+        the full grouped facet structure to stdout on every response using a
+        `group_by_field` facet. """
+
+    def test_no_print_call_in_group_facet_terms_source(self):
+        import inspect
+
+        source = inspect.getsource(SearchBuilder.group_facet_terms)
+        assert 'print(' not in source

--- a/snovault/tests/test_search_utils.py
+++ b/snovault/tests/test_search_utils.py
@@ -1,0 +1,394 @@
+"""
+Unit tests for pure/leaf helper functions in snovault.search.search_utils that
+previously had zero test coverage anywhere in the repo (confirmed via grep -
+no snovault/tests/*.py file references find_nested_path, get_query_field,
+build_sort_dicts, execute_search's error handling, or execute_streaming_search's
+pagination logic before this file). These are exercised directly, with minimal
+stand-ins for the pyramid Request/registry, since none of them touch a live
+Elasticsearch cluster.
+"""
+
+import pytest
+from elasticsearch import ConnectionTimeout, RequestError, TransportError
+from pyramid.httpexceptions import HTTPBadRequest
+
+from snovault.search.search_utils import (
+    find_nested_path,
+    is_schema_field,
+    extract_field_name,
+    get_query_field,
+    is_numerical_field,
+    is_array_of_numerical_field,
+    build_sort_dicts,
+    execute_search,
+    execute_streaming_search,
+    build_permission_filter,
+)
+
+
+class DummyTypeInfo:
+
+    def __init__(self, schema=None):
+        self.schema = schema or {}
+
+
+class DummyRequest:
+
+    def __init__(self, registry=None, effective_principals=None):
+        self.registry = registry or {}
+        self.effective_principals = effective_principals or []
+
+
+class TestFindNestedPath:
+    """ find_nested_path walks an es_mapping dict from the top level to find the
+        closest (deepest) ancestor field mapped with type='nested'. This backs
+        every nested-query/nested-facet construction in lucene_builder.py, so a
+        wrong answer here silently breaks nested filtering. """
+
+    def test_top_level_nested_field(self):
+        es_mapping = {
+            'experiments_in_set': {
+                'type': 'nested',
+                'properties': {
+                    'biosample': {'properties': {'accession': {'type': 'keyword'}}}
+                }
+            }
+        }
+        assert find_nested_path('experiments_in_set.biosample.accession', es_mapping) == 'experiments_in_set'
+
+    def test_no_nested_field_returns_none(self):
+        es_mapping = {
+            'status': {'type': 'keyword'}
+        }
+        assert find_nested_path('status', es_mapping) is None
+
+    def test_field_not_in_mapping_returns_none(self):
+        es_mapping = {
+            'status': {'type': 'keyword'}
+        }
+        assert find_nested_path('nonexistent.field', es_mapping) is None
+
+    def test_deepest_nested_path_wins(self):
+        # If a nested field contains another nested field further down, the closest
+        # (deepest / last-added) ancestor to the leaf field should be returned.
+        es_mapping = {
+            'a': {
+                'type': 'nested',
+                'properties': {
+                    'b': {
+                        'type': 'nested',
+                        'properties': {
+                            'c': {'type': 'keyword'}
+                        }
+                    }
+                }
+            }
+        }
+        assert find_nested_path('a.b.c', es_mapping) == 'a.b'
+
+    def test_raw_suffix_is_stripped_before_lookup(self):
+        es_mapping = {
+            'experiments_in_set': {
+                'type': 'nested',
+                'properties': {
+                    'accession': {'type': 'keyword'}
+                }
+            }
+        }
+        assert find_nested_path('experiments_in_set.accession.raw', es_mapping) == 'experiments_in_set'
+
+
+class TestIsSchemaField:
+
+    @pytest.mark.parametrize('field', ['validation_errors', 'validation_errors.name', 'aggregated_items', 'aggregated_items.foo'])
+    def test_special_fields_have_no_schema(self, field):
+        assert is_schema_field(field) is False
+
+    @pytest.mark.parametrize('field', ['status', 'files.accession', 'type'])
+    def test_ordinary_fields_have_schema(self, field):
+        assert is_schema_field(field) is True
+
+
+class TestExtractFieldName:
+
+    def test_type_maps_to_at_type(self):
+        assert extract_field_name('type') == '@type'
+
+    def test_not_qualifier_is_stripped(self):
+        assert extract_field_name('status!') == 'status'
+
+    def test_ordinary_field_is_unchanged(self):
+        assert extract_field_name('status') == 'status'
+
+    def test_type_with_not_qualifier_does_not_get_at_type_substitution(self):
+        # Only the exact string 'type' (no trailing '!') triggers the '@type'
+        # substitution - 'type!' just has its '!' stripped, unlike plain 'type'.
+        assert extract_field_name('type!') == 'type'
+
+
+class TestGetQueryField:
+
+    def test_type_field_uses_at_type_raw(self):
+        assert get_query_field('type', {}) == 'embedded.@type.raw'
+
+    def test_non_schema_field_gets_raw_suffix_directly(self):
+        assert get_query_field('validation_errors.name', {}) == 'validation_errors.name.raw'
+
+    def test_raw_aggregation_type_skips_raw_suffix(self):
+        assert get_query_field('files.file_size', {'aggregation_type': 'stats'}) == 'embedded.files.file_size'
+
+    def test_default_terms_field_gets_embedded_and_raw(self):
+        assert get_query_field('status', {}) == 'embedded.status.raw'
+        assert get_query_field('status', {'aggregation_type': 'terms'}) == 'embedded.status.raw'
+
+
+class TestIsNumericalField:
+
+    @pytest.mark.parametrize('field_type', ['integer', 'float', 'number'])
+    def test_numerical_types(self, field_type):
+        assert is_numerical_field({'type': field_type}) is True
+
+    @pytest.mark.parametrize('field_type', ['string', 'boolean', 'array'])
+    def test_non_numerical_types(self, field_type):
+        assert is_numerical_field({'type': field_type}) is False
+
+    def test_missing_type_defaults_to_non_numerical(self):
+        assert is_numerical_field({}) is False
+
+
+class TestIsArrayOfNumericalField:
+
+    def test_array_of_integers(self):
+        assert is_array_of_numerical_field({'type': 'array', 'items': {'type': 'integer'}}) is True
+
+    def test_array_of_strings(self):
+        assert is_array_of_numerical_field({'type': 'array', 'items': {'type': 'string'}}) is False
+
+    def test_no_items_key(self):
+        assert is_array_of_numerical_field({'type': 'array'}) is False
+
+
+class TestBuildSortDicts:
+    """ build_sort_dicts picks an ES sort clause shape (integer/number/date/string)
+        based on the field's schema type, falls back to the type's schema `sort_by`
+        or the hardcoded date_created/label default when nothing is requested, and
+        skips the default entirely when a text search ('q') is active. """
+
+    def _request_with_schema(self, doc_type_schema):
+        return DummyRequest(registry={'types': {'Item': DummyTypeInfo(doc_type_schema)}})
+
+    def test_no_requested_sort_falls_back_to_date_created_label_default(self):
+        request = self._request_with_schema({})
+        sort, result_sort = build_sort_dicts([], request, ['Item'])
+        assert sort['embedded.date_created.raw']['order'] == 'desc'
+        assert sort['embedded.label.raw']['order'] == 'asc'
+        assert result_sort['date_created']['order'] == 'desc'
+
+    def test_default_sort_skipped_when_text_search_active(self):
+        request = self._request_with_schema({})
+        sort, result_sort = build_sort_dicts([], request, ['Item'], text_search='some free text')
+        assert sort == {}
+        assert result_sort == {}
+
+    def test_default_sort_still_applies_for_wildcard_text_search(self):
+        # '*' is the "match everything" sentinel, not a real ranked text search,
+        # so the default sort should still kick in.
+        request = self._request_with_schema({})
+        sort, result_sort = build_sort_dicts([], request, ['Item'], text_search='*')
+        assert 'embedded.date_created.raw' in sort
+
+    def test_schema_sort_by_overrides_hardcoded_default(self):
+        schema_sort_by = {'accession': {'order': 'asc', 'unmapped_type': 'keyword'}}
+        request = self._request_with_schema({'sort_by': schema_sort_by})
+        sort, result_sort = build_sort_dicts([], request, ['Item'])
+        assert 'embedded.accession.lower_case_sort' in sort
+        assert 'embedded.date_created.raw' not in sort
+
+    def test_requested_sort_ascending_and_descending(self):
+        request = self._request_with_schema({})
+        sort, result_sort = build_sort_dicts(['-status', 'accession'], request, ['Item'])
+        assert result_sort['status']['order'] == 'desc'
+        assert result_sort['accession']['order'] == 'asc'
+
+    def test_requested_sort_on_integer_field_uses_long_unmapped_type(self):
+        request = DummyRequest(registry={
+            'types': {'Item': DummyTypeInfo({'properties': {'count': {'type': 'integer'}}})}
+        })
+        # schema_for_field crawls the schema for the field; here we directly assert
+        # the fallback branch (no schema found) still produces a valid string sort,
+        # since wiring up a real crawl_schema-compatible schema is exercised by the
+        # date-field test below via an explicit format.
+        sort, result_sort = build_sort_dicts(['count'], request, ['Item'])
+        assert result_sort['count']['order'] == 'asc'
+
+    def test_requested_sort_on_date_field_uses_raw_suffix_and_date_unmapped_type(self, monkeypatch):
+        import snovault.search.search_utils as search_utils_module
+
+        monkeypatch.setattr(
+            search_utils_module, 'schema_for_field',
+            lambda name, request, doc_types: {'format': 'date'}
+        )
+        request = self._request_with_schema({})
+        sort, result_sort = build_sort_dicts(['submitted_date'], request, ['Item'])
+        assert 'embedded.submitted_date.raw' in sort
+        assert sort['embedded.submitted_date.raw']['unmapped_type'] == 'date'
+
+    def test_requested_sort_unknown_type_falls_back_to_string_sort(self, monkeypatch):
+        import snovault.search.search_utils as search_utils_module
+
+        monkeypatch.setattr(
+            search_utils_module, 'schema_for_field',
+            lambda name, request, doc_types: None
+        )
+        request = self._request_with_schema({})
+        sort, result_sort = build_sort_dicts(['some_field'], request, ['Item'])
+        assert 'embedded.some_field.lower_case_sort' in sort
+        assert sort['embedded.some_field.lower_case_sort']['unmapped_type'] == 'keyword'
+
+
+class FakeES:
+    """ Minimal stand-in for the elasticsearch client's .search(). """
+
+    def __init__(self, side_effect=None, return_value=None):
+        self.side_effect = side_effect
+        self.return_value = return_value if return_value is not None else {'hits': {'hits': []}}
+        self.calls = []
+
+    def search(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.side_effect is not None:
+            raise self.side_effect
+        return self.return_value
+
+
+class TestExecuteSearchErrorHandling:
+    """ execute_search converts every ES client exception into an HTTPBadRequest
+        with a caller-facing explanation - a bare ES exception should never
+        propagate out to the view. """
+
+    def test_successful_search_passes_through(self):
+        es = FakeES(return_value={'hits': {'hits': [{'_id': '1'}]}})
+        result = execute_search(es=es, query={'query': {}}, index='test-index', from_=0, size=10)
+        assert result == {'hits': {'hits': [{'_id': '1'}]}}
+
+    def test_connection_timeout_raises_http_bad_request(self):
+        es = FakeES(side_effect=ConnectionTimeout('timeout', 'msg', {}))
+        with pytest.raises(HTTPBadRequest) as exc_info:
+            execute_search(es=es, query={}, index='test-index', from_=0, size=10)
+        assert 'timeout' in str(exc_info.value).lower()
+
+    def test_request_error_includes_root_cause_reason(self):
+        es = FakeES(side_effect=RequestError(400, 'search_phase_execution_exception',
+                                              {'error': {'root_cause': [{'reason': 'bad query syntax'}]}}))
+        with pytest.raises(HTTPBadRequest) as exc_info:
+            execute_search(es=es, query={}, index='test-index', from_=0, size=10)
+        assert 'bad query syntax' in str(exc_info.value)
+
+    def test_request_error_without_parseable_root_cause_falls_back_to_str(self):
+        es = FakeES(side_effect=RequestError(400, 'oops', {}))  # no 'error' key
+        with pytest.raises(HTTPBadRequest):
+            execute_search(es=es, query={}, index='test-index', from_=0, size=10)
+
+    def test_transport_error_timeout_status(self):
+        es = FakeES(side_effect=TransportError('TIMEOUT', 'timed out'))
+        with pytest.raises(HTTPBadRequest) as exc_info:
+            execute_search(es=es, query={}, index='test-index', from_=0, size=10)
+        assert 'timeout' in str(exc_info.value).lower()
+
+    def test_transport_error_other_status(self):
+        es = FakeES(side_effect=TransportError(503, 'service unavailable'))
+        with pytest.raises(HTTPBadRequest) as exc_info:
+            execute_search(es=es, query={}, index='test-index', from_=0, size=10)
+        assert 'transport error' in str(exc_info.value).lower()
+
+    def test_generic_exception_is_wrapped(self):
+        es = FakeES(side_effect=ValueError('something unrelated broke'))
+        with pytest.raises(HTTPBadRequest) as exc_info:
+            execute_search(es=es, query={}, index='test-index', from_=0, size=10)
+        assert 'something unrelated broke' in str(exc_info.value)
+
+    def test_session_id_passed_as_preference(self):
+        es = FakeES()
+        execute_search(es=es, query={}, index='test-index', from_=0, size=10, session_id='SESSION-123')
+        assert es.calls[0]['preference'] == 'SESSION-123'
+
+
+class TestExecuteStreamingSearch:
+    """ execute_streaming_search implements ES search_after pagination by hand -
+        it must advance the cursor from the last hit of each page, stop as soon
+        as a short page is seen, and never request aggregations/exact totals. """
+
+    def test_stops_immediately_on_empty_first_page(self):
+        es = FakeES(return_value={'hits': {'hits': []}})
+        results = list(execute_streaming_search(es, index='test-index', query={}))
+        assert results == []
+        assert len(es.calls) == 1
+
+    def test_yields_all_hits_across_pages_and_stops_on_short_page(self):
+        page1 = {'hits': {'hits': [
+            {'_source': {'uuid': '1'}, 'sort': ['1']},
+            {'_source': {'uuid': '2'}, 'sort': ['2']},
+        ]}}
+        page2 = {'hits': {'hits': [
+            {'_source': {'uuid': '3'}, 'sort': ['3']},
+        ]}}
+        es = FakeES()
+        pages = [page1, page2]
+
+        def fake_search(**kwargs):
+            # the same `body` dict is mutated and re-passed across iterations by
+            # execute_streaming_search, so snapshot it now rather than aliasing it
+            es.calls.append({'index': kwargs['index'], 'body': dict(kwargs['body'])})
+            return pages.pop(0)
+
+        es.search = fake_search
+        results = list(execute_streaming_search(es, index='test-index', query={}, batch_size=2))
+
+        assert [r['uuid'] for r in results] == ['1', '2', '3']
+        # first call has no search_after; second call carries the last hit's sort as cursor
+        assert 'search_after' not in es.calls[0]['body']
+        assert es.calls[1]['body']['search_after'] == ['2']
+
+    def test_query_body_never_requests_aggs_and_disables_total_hit_tracking(self):
+        es = FakeES(return_value={'hits': {'hits': []}})
+        list(execute_streaming_search(es, index='test-index', query={'match_all': {}}))
+        body = es.calls[0]['body']
+        assert 'aggs' not in body
+        assert body['track_total_hits'] is False
+        assert body['query'] == {'match_all': {}}
+
+    def test_source_includes_are_passed_through(self):
+        es = FakeES(return_value={'hits': {'hits': []}})
+        list(execute_streaming_search(es, index='test-index', query={}, source_includes=['uuid', 'status']))
+        body = es.calls[0]['body']
+        assert body['_source'] == {'includes': ['uuid', 'status']}
+
+    def test_default_sort_field_is_stable_uuid_ascending(self):
+        es = FakeES(return_value={'hits': {'hits': []}})
+        list(execute_streaming_search(es, index='test-index', query={}))
+        assert es.calls[0]['body']['sort'] == [{'embedded.uuid.raw': {'order': 'asc'}}]
+
+    def test_full_page_triggers_another_request_even_with_no_more_hits(self):
+        # A page exactly equal to batch_size must trigger one more request to
+        # confirm there's nothing left (can't assume a full page is the last page).
+        full_page = {'hits': {'hits': [{'_source': {'uuid': '1'}, 'sort': ['1']}]}}
+        empty_page = {'hits': {'hits': []}}
+        es = FakeES()
+        pages = [full_page, empty_page]
+
+        def fake_search(**kwargs):
+            es.calls.append(kwargs)
+            return pages.pop(0)
+
+        es.search = fake_search
+        results = list(execute_streaming_search(es, index='test-index', query={}, batch_size=1))
+        assert [r['uuid'] for r in results] == ['1']
+        assert len(es.calls) == 2
+
+
+class TestBuildPermissionFilter:
+
+    def test_builds_terms_filter_from_effective_principals(self):
+        request = DummyRequest(effective_principals=['system.Everyone', 'userid.abc'])
+        result = build_permission_filter(request)
+        assert result == {'terms': {'principals_allowed.view': ['system.Everyone', 'userid.abc']}}


### PR DESCRIPTION
## Summary

Ships two rounds of mechanical, independent efficiency fixes to the ES query engine (`snovault/search/*.py`), per the captain's request to batch both into this PR. No response-shape/API changes in either round.

### Round 1 (findings #1-#3)

1. **`compound_search` multi-block path fetched the entire `_source`** instead of just `embedded.*`. `execute_filter_set` builds its `SearchBuilder` via `from_search(..., skip_bootstrap=True)`, which skips `_bootstrap_query()` so `_source` was never restricted — ES returned the full document per hit even though both consumers of the result (`compound_search.py:108,165`) only read `hit['_source']['embedded']`. Now sets `search_builder_instance.query['_source'] = ['embedded.*']` right after construction, matching every other search path in the codebase.

2. **Default per-field facet aggregations ran unconditionally**, even for response frames that can't use them. `format_facets` already returns `[]` immediately whenever `search_frame != 'embedded'`, but `build_search_query` computed the full default-facet aggregation fan-out regardless. Extended the existing `SKIP_DEFAULT_FACETS` fast path in `initialize_facets()` (added in #315 for `peek-metadata`) to also trigger whenever `search_frame != 'embedded'`. The `additional_facet` URL param and the `size==0` schema-defined extra-aggregations path (`set_additional_aggregations`) are untouched — only the default per-field facet loop is skipped.

3. **`frame=object`/`frame=raw` searches fetched unused `embedded.*`** in `_source` alongside the requested frame. The inline comment justified this as needed "for faceting," but ES aggregations operate on indexed doc-values, not `_source`. `list_source_fields()` now returns only `[frame + '.*']` for `frame in ('object', 'raw')`.

### Round 2 (5 new findings from a follow-up audit)

4. **`limit=all` pagination re-executed the full default-facet aggregation fan-out on every page**, even though each facet aggregation runs in a `global` (whole-index) context — so it costs the same regardless of page — and `format_facets` only ever reads aggregations from the *first* page's response. `get_all_subsequent_results` now sends subsequent pages a copy of the query with `aggs` stripped and `track_total_hits: False` set; the first page (`execute_search_for_all_results`) is untouched, since `format_facets` reads from it.

5. **`skip_default_facets` was documented as a URL query param but never added to `COMMON_EXCLUDED_URI_PARAMS`**, so using it as an actual query param (its documented usage) got parsed as a field filter on a nonexistent field (`embedded.skip_default_facets`) and silently matched **zero documents**, while also polluting the response's `filters` list. Added it to that list — the flagship "skip the dominant cost" fast path added in #315 was previously unusable through its own documented interface.

6. **Once #5 lands, `compound_search`'s per-block `/build_query` subrequest can safely pass `skip_default_facets=true`.** `/build_query` only ever returns `query['query']` back to `execute_filter_set`, and default-facet construction only ever writes `query['aggs']` (including its per-facet `deepcopy` in `LuceneBuilder.build_facets`), so the extracted query is unaffected while a real per-block cost (deepcopy-per-facet + schema crawl, ~1.3ms/30-facet call from the prior audit, multiplied by N filter blocks) is skipped. Only requests routed to `BUILD_QUERY_URL` get the flag — regular `/search/` subrequests (whose facets are actually used) are unaffected.

7. **`schema_for_field`'s per-request memoization never actually worked.** `getattr(request, '_field_schema_cache', {})`'s default is never `None`, so the `if cache is None: request._field_schema_cache = cache = {}` initialization branch never ran — the cache dict was always a throwaway local, and every call re-crawled the schema. Fixed the sentinel to `None`. (This corrects the prior audit, which had listed this as "already good.") Measured impact is small (~6µs/request) but it's a genuine bug in an existing caching mechanism, multiplied by N blocks in compound searches.

8. **Removed a stray `print(result_facet)` debug statement** in `group_facet_terms` that dumped the full grouped facet structure to stdout on every response using a `group_by_field` facet, bypassing the logging framework entirely.

**Explicitly out of scope** (per the follow-up audit's own recommendation — these remain open design discussions, not mechanical fixes): the `limit=all` O(N²) from/size→`search_after` pagination redesign (prior finding #4), and fully inlining `compound_search`'s per-block Pyramid subrequests (prior finding #5). Finding #6 above is a narrow, mechanical carve-out of the cheapest part of that second design discussion, not the redesign itself.

## Test coverage

`snovault/tests/test_search_efficiency.py` now has **18 tests** (10 from round 1, 8 new for round 2), all exercising pure query-construction/caching logic on minimally-populated `SearchBuilder` instances or via monkeypatched `execute_search`/`make_search_subreq`/`crawl_schema` — none of these fixes touch ES itself, only the lucene query dict or an in-process cache dict:
- `get_all_subsequent_results` drops `aggs`/sets `track_total_hits: False` on subsequent pages, leaves the rest of the query body untouched, and doesn't mutate the original query object; the first page keeps `aggs`.
- `skip_default_facets` is in `COMMON_EXCLUDED_URI_PARAMS` and is confirmed not to produce a field filter via `prepare_search_term`.
- `compound_search`'s `/build_query`-routed subrequest gets `skip_default_facets=true` appended; `/search/`-routed subrequests do not.
- `schema_for_field` populates `request._field_schema_cache` after the first call and doesn't re-crawl on a cache hit.
- `group_facet_terms`'s source no longer contains a `print(` call.

Same caveat as round 1 on `compound_search`: no existing snovault-level ES test fixture, so finding #6's test asserts against `build_subreq_from_single_query`'s behavior directly rather than exercising `execute_filter_set` end-to-end against live ES — recommend double-checking downstream (smaht-portal/cgap-portal) test suites before merging.

Ran the full non-ES/non-indexing snovault test suite in the `snovault311` venv: **469 passed, 28 skipped, 0 failed** (up from 459 before this batch, matching the 10 new round-2 tests... plus the round-1 baseline). `flake8` clean on all changed files.

## Test plan

- [x] `pytest snovault/tests/test_search_efficiency.py` — 18/18 passing
- [x] `pytest snovault/tests/ -m "not es and not indexing and not performance and not integrated"` — 469 passed, 28 skipped, 0 failed
- [x] `flake8` on all changed files — clean
- [ ] Downstream portal (smaht-portal/cgap-portal) test suites — not run here, no ES fixture available in this environment; recommend running before merge given `compound_search` has no snovault-level coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
