### PR TITLE
Add per-type track_revisions opt-out for Postgres revision history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- Add durable project-specific notes here as they are discovered through real work.
+
+## Revision-history tracking (`track_revisions` per-type flag)
+
+By default, every item type tracks full Postgres revision history: each update inserts a
+new row into the `propsheets` table keyed by `(rid, name, sid)`, so prior versions are
+preserved and the `@@revision-history` view can walk them.
+
+A type can opt out of history tracking by setting a class attribute on its `Item` subclass:
+
+```python
+class MyType(Item):
+    item_type = 'my_type'
+    track_revisions = False   # default is True
+```
+
+Behavior when `track_revisions = False`:
+- **Write path** (`snovault/storage.py`): `PickStorage.update` resolves the flag from the
+  type registry via `model.item_type` (`_track_revisions_for`) and passes it to
+  `RDBStorage.update`. After the normal write, `RDBStorage._prune_revisions` deletes the
+  prior `propsheets` rows for each written `(rid, name)`, leaving **at most one row** per
+  resource + sheet name. A fresh propsheet row is still created per write (so the `sid`
+  advances and sid-based indexing/invalidation still detects the change) — only older rows
+  are pruned. The first write (create) has no prior rows and is unaffected.
+- **Revision-history view** (`snovault/crud_views.py::item_view_revision_history`): returns
+  **HTTP 404** with a message like "Revision history is not tracked for item type ..."
+  rather than silently returning only the current version (which would falsely imply a full
+  history).
+
+The flag is declared/documented on the base `Item` class in `snovault/resources.py`.
+Tests: `snovault/tests/test_storage.py` (`test_track_revisions_*`) exercise both the
+disabled and enabled paths, asserting the propsheet row count **directly against the DB**.
+Test types `TestingRevisionHistoryDisabled` / `TestingRevisionHistoryEnabled` live in
+`snovault/tests/testing_views.py`.
+
+Test gotcha: `testapp` and the `session` fixture share one `DBSession`. Do all `testapp`
+requests first, then raw `session` queries at the end — a `session.query(...)` interleaved
+before a subsequent `testapp` request corrupts the shared transaction and makes traversal
+404 (this also leaks into later tests).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,15 @@ snovault
 Change Log
 ----------
 
+11.31.0
+=======
+
+* Add a per-type ``track_revisions`` flag (default ``True``) letting an item type opt out
+  of Postgres revision-history tracking. When ``False``, updates overwrite the existing
+  ``propsheets`` row (at most one row per resource + sheet name survives) and the
+  ``@@revision-history`` view returns a 404 instead of an implied-complete partial history.
+
+
 11.30.3
 =======
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.30.3"
+version = "11.31.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/crud_views.py
+++ b/snovault/crud_views.py
@@ -6,6 +6,7 @@ from uuid import (
 from copy import deepcopy
 import transaction
 from pyramid.exceptions import HTTPForbidden
+from pyramid.httpexceptions import HTTPNotFound
 from pyramid.settings import asbool
 from pyramid.view import view_config
 from structlog import get_logger
@@ -409,7 +410,17 @@ def get_item_revision_history(request, uuid, resolve_emails=False):
 def item_view_revision_history(context, request):
     """ View config for viewing an item's revision history.
         For now, to view revision history the caller must have EDIT permissions.
+
+        Types that opt out of revision-history tracking (track_revisions = False)
+        do not retain prior propsheet rows, so there is no honest history to
+        return. Rather than silently returning only the current version (which
+        would imply a full history), fail explicitly with a 404.
     """
+    if not getattr(context, 'track_revisions', True):
+        raise HTTPNotFound(
+            f'Revision history is not tracked for item type '
+            f'{context.type_info.name!r} (track_revisions = False).'
+        )
     uuid = str(context.uuid)
     resolve_emails = asbool(request.GET.get('resolve_emails', False))
     revisions = get_item_revision_history(request, uuid, resolve_emails=resolve_emails)

--- a/snovault/resources.py
+++ b/snovault/resources.py
@@ -367,6 +367,14 @@ class Item(Resource):
     item_type = None
     base_types = ['Item']
     name_key = None
+    # Whether Postgres revision history is tracked for this type. When True (the
+    # default), each update inserts a new `propsheets` row keyed by (rid, name,
+    # sid), preserving prior versions so the revision-history view can walk them.
+    # A type may opt out by setting `track_revisions = False`, in which case an
+    # update overwrites the existing propsheet row (at most one row per rid+name
+    # survives) and the revision-history view returns a 404. See snovault.storage
+    # (RDBStorage._prune_revisions) and crud_views.item_view_revision_history.
+    track_revisions = True
     rev = {}
     aggregated_items = {}
     embedded_list = []

--- a/snovault/storage.py
+++ b/snovault/storage.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext import baked
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import backref, collections
 from sqlalchemy.orm.exc import FlushError, MultipleResultsFound, NoResultFound
-from .interfaces import BLOBS, DBSESSION, STORAGE
+from .interfaces import BLOBS, DBSESSION, STORAGE, TYPES
 
 
 log = structlog.getLogger(__name__)
@@ -264,13 +264,34 @@ class PickStorage(object):
         then this will both update DB tables and the item properties in ES
         """
         storage = self.storage(datastore)
+        # Per-type opt-out: types with `track_revisions = False` overwrite their
+        # existing propsheet row on update instead of accumulating history rows.
+        track_revisions = self._track_revisions_for(model)
         if storage is self.read:
             # must update links and such in write RDS. However, don't update
             # properties and sheets, as those are exclusively stored in ES.
             # Still call `storage.update` below to update contents of ES doc
-            self.write.update(model, {}, None, unique_keys, links)
+            self.write.update(model, {}, None, unique_keys, links,
+                              track_revisions=track_revisions)
+            return storage.update(model, properties, sheets, unique_keys, links)
 
-        return storage.update(model, properties, sheets, unique_keys, links)
+        return storage.update(model, properties, sheets, unique_keys, links,
+                              track_revisions=track_revisions)
+
+    def _track_revisions_for(self, model):
+        """
+        Resolve the per-type `track_revisions` flag for the given resource model
+        using the type registry. Defaults to True (track history) so existing
+        types are unaffected. A type opts out of revision-history tracking by
+        setting the class attribute `track_revisions = False` on its factory.
+        """
+        try:
+            type_info = self.registry[TYPES].by_item_type.get(model.item_type)
+        except (KeyError, AttributeError, TypeError):
+            return True
+        if type_info is None:
+            return True
+        return getattr(type_info.factory, 'track_revisions', True)
 
     def get_sids_by_uuids(self, uuids):
         """
@@ -455,7 +476,8 @@ class RDBStorage(object):
     def create(self, item_type, rid):
         return Resource(item_type, rid=rid)
 
-    def update(self, model, properties=None, sheets=None, unique_keys=None, links=None):
+    def update(self, model, properties=None, sheets=None, unique_keys=None, links=None,
+               track_revisions=True):
         session = self.DBSession()
         sp = session.begin_nested()
         try:
@@ -465,6 +487,8 @@ class RDBStorage(object):
                 self._update_rels(model, links)
             if unique_keys is not None:
                 keys_add, keys_remove = self._update_keys(model, unique_keys)
+            if not track_revisions:
+                self._prune_revisions(model, properties, sheets)
             sp.commit()
             return
         except (IntegrityError, FlushError):
@@ -514,6 +538,43 @@ class RDBStorage(object):
         if sheets is not None:
             for key, value in sheets.items():
                 model.propsheets[key] = value
+
+    def _prune_revisions(self, model, properties, sheets=None):
+        """
+        For types that opt out of revision-history tracking (track_revisions =
+        False), delete stale propsheet rows so that at most one row remains per
+        (rid, name) after this write.
+
+        A brand-new propsheet row is still created for each write (by
+        `_update_properties`), which advances the sid so that downstream sid-based
+        indexing/invalidation still detects the change. This method then removes
+        any *prior* propsheet rows for the same resource + sheet name, leaving
+        only the current one. The first write of a resource has no prior rows and
+        is therefore unaffected.
+        """
+        names = []
+        if properties is not None:
+            names.append('')
+        if sheets is not None:
+            names.extend(sheets.keys())
+        if not names:
+            return
+        session = self.DBSession()
+        # Flush so the freshly-created propsheet rows are assigned their sids and
+        # the current_propsheet rows point at them before we prune older rows.
+        session.flush()
+        for name in names:
+            current = model.data.get(name)
+            if current is None:
+                continue
+            current_sid = current.sid
+            stale = session.query(PropertySheet).filter(
+                PropertySheet.rid == model.rid,
+                PropertySheet.name == name,
+                PropertySheet.sid != current_sid,
+            ).all()
+            for propsheet in stale:
+                session.delete(propsheet)
 
     def _update_keys(self, model, unique_keys):
         keys_set = {(k, v) for k, values in unique_keys.items() for v in values}

--- a/snovault/tests/test_storage.py
+++ b/snovault/tests/test_storage.py
@@ -8,7 +8,7 @@ from dcicutils.misc_utils import filtered_warnings
 from pyramid.threadlocal import manager
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
-from ..interfaces import DBSESSION, STORAGE
+from ..interfaces import DBSESSION, STORAGE, TYPES
 from ..storage import (
     POSTGRES_COMPATIBLE_MAJOR_VERSIONS,
     Blob,
@@ -312,6 +312,143 @@ def _test_S3BlobStorage_get_blob_url_for_non_s3_file():
     download_meta = {'blob_id': 'blob_id'}
     url = storage.get_blob_url(download_meta)
     assert url
+
+
+def _count_propsheet_rows(session, rid, name=''):
+    """ Direct-DB count of propsheet rows for a given resource + sheet name. """
+    return (
+        session.query(PropertySheet)
+        .filter(PropertySheet.rid == rid, PropertySheet.name == name)
+        .count()
+    )
+
+
+def test_track_revisions_flag_resolution(registry, storage):
+    """ The per-type track_revisions flag defaults to True and can be opted out. """
+    types = registry[TYPES]
+    enabled_ti = types.by_item_type['testing_revision_history_enabled']
+    disabled_ti = types.by_item_type['testing_revision_history_disabled']
+    assert enabled_ti.factory.track_revisions is True
+    assert disabled_ti.factory.track_revisions is False
+
+    # PickStorage resolves the flag from the resource model's item_type
+    enabled_model = Resource('testing_revision_history_enabled', {'': {}})
+    disabled_model = Resource('testing_revision_history_disabled', {'': {}})
+    unknown_model = Resource('some_unregistered_type', {'': {}})
+    assert storage._track_revisions_for(enabled_model) is True
+    assert storage._track_revisions_for(disabled_model) is False
+    # unknown/unregistered types default to tracking history (True)
+    assert storage._track_revisions_for(unknown_model) is True
+
+
+def test_track_revisions_disabled_first_write(testapp, session):
+    """ The initial create of a history-disabled type produces exactly one row. """
+    res = testapp.post_json('/testing-revision-history-disabled',
+                            {'title': 'v1', 'description': 'first'}, status=201)
+    item_uuid = res.json['@graph'][0]['uuid']
+    # NOTE: all direct `session` queries happen AFTER every testapp request; the
+    # testapp and the `session` fixture share a DBSession, so a raw session query
+    # interleaved before a subsequent testapp request corrupts the shared txn.
+    assert _count_propsheet_rows(session, item_uuid) == 1
+
+
+def test_track_revisions_disabled_overwrites_single_row(testapp, session):
+    """ For a history-disabled type, N updates leave AT MOST ONE propsheet row
+        for the resource + default sheet name. Verified directly against the DB.
+    """
+    res = testapp.post_json('/testing-revision-history-disabled',
+                            {'title': 'v1', 'description': 'first'}, status=201)
+    item = res.json['@graph'][0]
+    item_uuid = item['uuid']
+    item_id = item['@id']
+
+    # Perform several updates (5 of them)
+    for i in range(2, 7):
+        testapp.patch_json(item_id,
+                           {'title': f'v{i}', 'description': f'update {i}'},
+                           status=200)
+
+    # The API reflects the latest version (do all testapp requests first)
+    latest = testapp.get(item_id + '?frame=object').json
+    assert latest['title'] == 'v6'
+
+    # Direct-DB assertion: exactly one propsheet row for this resource+sheet name,
+    # holding the latest properties, after create + 5 updates.
+    assert _count_propsheet_rows(session, item_uuid) == 1
+    surviving = (session.query(PropertySheet)
+                 .filter(PropertySheet.rid == item_uuid, PropertySheet.name == '')
+                 .one())
+    assert surviving.properties['title'] == 'v6'
+
+
+def test_track_revisions_disabled_history_view_404(testapp):
+    """ The revision-history view fails honestly (404) for a history-disabled
+        type rather than returning an empty or partial history.
+    """
+    res = testapp.post_json('/testing-revision-history-disabled',
+                            {'title': 'v1', 'description': 'first'}, status=201)
+    item_id = res.json['@graph'][0]['@id']
+    testapp.patch_json(item_id, {'title': 'v2'}, status=200)
+
+    # revision-history should 404 with an honest message (history not tracked)
+    err = testapp.get(item_id + '@@revision-history', status=404)
+    assert 'not tracked' in err.json['detail'].lower()
+
+
+def test_track_revisions_enabled_accumulates_rows(testapp, session):
+    """ Inverse case: a history-enabled type still accumulates one propsheet row
+        per update, and its revision-history view returns them all. No regression.
+    """
+    res = testapp.post_json('/testing-revision-history-enabled',
+                            {'title': 'v1', 'description': 'first'}, status=201)
+    item = res.json['@graph'][0]
+    item_uuid = item['uuid']
+    item_id = item['@id']
+
+    for i in range(2, 7):  # 5 updates -> 6 total writes
+        testapp.patch_json(item_id,
+                           {'title': f'v{i}', 'description': f'update {i}'},
+                           status=200)
+
+    # revision-history view returns the full ordered history (all testapp first)
+    revisions = testapp.get(item_id + '@@revision-history').json['revisions']
+    assert len(revisions) == 6
+    assert [r['title'] for r in revisions] == ['v1', 'v2', 'v3', 'v4', 'v5', 'v6']
+
+    # Direct-DB assertion: one row per write (create + 5 updates == 6)
+    assert _count_propsheet_rows(session, item_uuid) == 6
+
+
+def test_track_revisions_disabled_mixed_sheets(testapp, session, storage, connection):
+    """ Edge case: a history-disabled type with more than one sheet name keeps at
+        most one row PER (rid, name). Exercises the storage `sheets` write path
+        directly (the API only writes the default '' sheet).
+    """
+    res = testapp.post_json('/testing-revision-history-disabled',
+                            {'title': 'v1', 'description': 'first'}, status=201)
+    item_uuid = res.json['@graph'][0]['uuid']
+    model = storage.write.get_by_uuid(item_uuid)
+
+    extra_sheet = 'downloads'
+    # Multiple updates writing BOTH the default sheet and an extra named sheet
+    for i in range(2, 6):  # 4 updates
+        connection.update(
+            model,
+            {'title': f'v{i}', 'description': f'update {i}'},
+            sheets={extra_sheet: {'blob_id': f'blob-{i}'}},
+        )
+
+    # Each (rid, name) retains at most one row, holding the latest content
+    assert _count_propsheet_rows(session, item_uuid, name='') == 1
+    assert _count_propsheet_rows(session, item_uuid, name=extra_sheet) == 1
+    default_row = (session.query(PropertySheet)
+                   .filter(PropertySheet.rid == item_uuid, PropertySheet.name == '')
+                   .one())
+    extra_row = (session.query(PropertySheet)
+                 .filter(PropertySheet.rid == item_uuid, PropertySheet.name == extra_sheet)
+                 .one())
+    assert default_row.properties['title'] == 'v5'
+    assert extra_row.properties['blob_id'] == 'blob-5'
 
 
 def test_pick_storage(registry, dummy_request):

--- a/snovault/tests/testing_views.py
+++ b/snovault/tests/testing_views.py
@@ -898,6 +898,52 @@ class TestingEmbeddedLinkedSchemaField(Item):
 
 
 
+@collection(
+    'testing-revision-history-enabled',
+    properties={
+        'title': 'Testing Revision History Enabled',
+        'description': 'Item type that tracks revision history (the default).',
+    },
+)
+class TestingRevisionHistoryEnabled(Item):
+    """ Item type that tracks Postgres revision history (the default behavior).
+        Sibling of TestingRevisionHistoryDisabled, used to verify that the opt-out
+        flag does not regress the default (history-tracking) behavior.
+    """
+    item_type = 'testing_revision_history_enabled'
+    schema = {
+        'type': 'object',
+        'properties': {
+            'title': {'type': 'string'},
+            'description': {'type': 'string'},
+        }
+    }
+
+
+@collection(
+    'testing-revision-history-disabled',
+    properties={
+        'title': 'Testing Revision History Disabled',
+        'description': 'Item type that opts out of revision-history tracking.',
+    },
+)
+class TestingRevisionHistoryDisabled(Item):
+    """ Item type that opts out of Postgres revision-history tracking by setting
+        `track_revisions = False`. Updates overwrite the existing propsheet row
+        instead of inserting a new one, so at most one propsheet row per
+        (rid, name) survives, and the revision-history view returns a 404.
+    """
+    item_type = 'testing_revision_history_disabled'
+    track_revisions = False
+    schema = {
+        'type': 'object',
+        'properties': {
+            'title': {'type': 'string'},
+            'description': {'type': 'string'},
+        }
+    }
+
+
 @collection('testing-hidden-facets')
 class TestingHiddenFacets(Item):
     """ Collection designed to test searching with hidden facets. Yes this is large, but this is a complex feature


### PR DESCRIPTION
## Summary

Makes Postgres revision-history tracking a per-type, opt-out flag instead of always-on.

snovault persists each resource's property sheets in the `propsheets` table, where every write inserts a **new** row keyed by `(rid, name, sid)` — this is what makes revision history possible (the `@@revision-history` view walks all prior rows for a resource). This PR lets an item type declare it does not want that history retained.

## Design choices (please review)

- **Flag: `track_revisions` class attribute on `Item`, default `True`.**
  Set `track_revisions = False` on an `Item` subclass to opt out. Chose a class attribute (over a schema property or registry setting) to match how other per-type behavior flags work in this codebase (`name_key`, `rev`, `filtered_rev_statuses`, etc.). Named it `track_revisions` rather than `rev_history` to avoid confusion with the existing `rev` reverse-links attribute. Documented on the base `Item` class in `resources.py`.

- **Write path — resolve in `PickStorage`, prune in `RDBStorage`.**
  `PickStorage.update` is the single funnel for writes and holds the registry, so it resolves the flag from `model.item_type` (`_track_revisions_for`, defaults `True` for unknown types) and passes it to `RDBStorage.update`. When disabled, `RDBStorage._prune_revisions` runs after the normal write and deletes prior `propsheets` rows for each written `(rid, name)`, leaving **at most one row** per resource + sheet name.
  Note: a fresh propsheet row is still created per write (only *older* rows are pruned), so the `sid` keeps advancing — this preserves sid-based indexing/invalidation, which would otherwise stop detecting updates to history-disabled types. Create (first write) has no prior rows and is unaffected.

- **Revision-history API — `HTTP 404` when disabled.**
  `item_view_revision_history` raises `HTTPNotFound` with a clear message ("Revision history is not tracked for item type ...") rather than silently returning only the current row and implying it's a full history. 404 fits: the history sub-resource genuinely doesn't exist for these types, and it's consistent with the codebase's httpexceptions usage.

## No regression for history-enabled types

Default `True` types keep exactly current behavior: multiple propsheet rows across updates and a working history API. Verified by an inverse test and by the existing suite.

## Tests (with direct-DB verification)

New tests in `snovault/tests/test_storage.py` (test types `TestingRevisionHistoryEnabled` / `TestingRevisionHistoryDisabled` in `testing_views.py`):

- Disabled type, create + 5 updates → **exactly one** `propsheets` row for `(rid, '')`, asserted via `session.query(PropertySheet).count()` (raw DB, not just the API), holding the latest properties.
- Disabled type → `@@revision-history` returns 404 with an honest message.
- **Inverse:** enabled type, create + 5 updates → **6** propsheet rows in the DB and the history view returns all 6 in order.
- First-write (create) of a disabled type → exactly one row (create path unaffected).
- Mixed sheet names (default `''` + a named sheet) on a disabled type → at most one row **per** `(rid, name)`.
- Flag-resolution unit test (default True, opt-out False, unknown type defaults True).

Green locally: `test_storage.py`, `test_views.py`, `test_link.py`, `test_post_put_patch.py`, `test_attachment.py`, `test_schemas.py`, `test_key.py`, `test_misc.py` (version/changelog check). Lint clean.

Bumps version to `11.31.0` and adds a CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
