### PR TITLE
Add unit tests closing coverage gaps in pure-logic modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,24 @@ Test gotcha: `testapp` and the `session` fixture share one `DBSession`. Do all `
 requests first, then raw `session` queries at the end — a `session.query(...)` interleaved
 before a subsequent `testapp` request corrupts the shared transaction and makes traversal
 404 (this also leaks into later tests).
+
+## SQS/ES-polling tests in `test_indexing.py` need the flaky rerun decorator
+
+Tests in `snovault/tests/test_indexing.py` that poll SQS and/or ES for eventual
+consistency intermittently fail on CI purely from timing (this also hits `master`; the
+INDEXING CI job is known-flaky). The established mitigation is
+`@pytest.mark.flaky(max_runs=N, rerun_filter=delay_rerun)` (`delay_rerun` from
+`snovault/tools.py` sleeps 10s between reruns). When adding a test to this file that
+follows the queue-then-poll pattern, include that decorator — several timing failures
+traced back to tests that used the pattern but were missing it
+(`test_aggregated_items`, `test_indexer_namespacing`, `test_indexer_queue_adds_telemetry_id`).
+
+## `ItemNamespace.__getattr__` sharp edge (calculated.py)
+
+`ItemNamespace.__getattr__` resolves unknown names via `self.registry` / `self._properties`
+(both pyramid `reify` properties). If the namespace was built with `request=None` (or a
+request lacking `.registry`), the reify body raises `AttributeError`, which re-enters
+`__getattr__` and recurses to `RecursionError` instead of a clean `AttributeError`. Not
+reachable in production (`calculate_properties` always passes a real request), but when
+unit-testing the namespace directly, inject `registry`/`_properties` via the `ns` dict —
+see `snovault/tests/test_calculated_registry.py`.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ snovault
 Change Log
 ----------
 
+11.30.4
+=======
+
+* Add unit tests closing coverage gaps in pure-logic modules (typedsheets,
+  authorization, etag, schema_formats, server_defaults_misc, predicates,
+  typeinfo, and util helpers); no production code changes
+
+
 11.30.3
 =======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ snovault
 Change Log
 ----------
 
-11.30.4
+11.30.7
 =======
 
 * Add unit tests closing coverage gaps in pure-logic modules (typedsheets,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,13 +6,26 @@ snovault
 Change Log
 ----------
 
-11.31.1
+11.31.8
+=======
+
+* Add unit tests closing further coverage gaps flagged as follow-ups in the
+  initial audit: local_roles (local principal expansion / authorization policy),
+  the calculated-property registry classes, json_renderer adapters,
+  ManagerLRUCache, and the untested EDWHash branches (verify round-trip,
+  password-too-long guard); no production code changes
+* Re-enable the ``flaky`` rerun decorator on ``test_aggregated_items`` and add it
+  to ``test_indexer_namespacing`` / ``test_indexer_queue_adds_telemetry_id``,
+  which use the same SQS/ES polling pattern as their already-protected neighbors
+  (known CI flakiness mitigation)
+
+11.31.7
 =======
 
 * Add unit tests closing coverage gaps in pure-logic modules (typedsheets,
   authorization, etag, schema_formats, server_defaults_misc, predicates,
   typeinfo, and util helpers); no production code changes
-  
+
 
 11.31.0
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ snovault
 Change Log
 ----------
 
-11.31.8
+11.31.1
 =======
 
 * Add unit tests closing further coverage gaps flagged as follow-ups in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.31.8"
+version = "11.31.1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.30.3"
+version = "11.30.4"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.31.7"
+version = "11.31.8"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.30.4"
+version = "11.30.7"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/tests/test_authorization.py
+++ b/snovault/tests/test_authorization.py
@@ -1,0 +1,153 @@
+"""
+Unit tests for snovault.authorization -- the groupfinder permission resolution
+used on every authenticated request. This is security-critical code that only had
+indirect coverage. Lightweight fakes stand in for the request/collections, and
+app_project() is patched for the full-user path.
+"""
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+from pyramid.security import Authenticated
+
+from .. import authorization as authz
+from ..authorization import groupfinder, _create_principals, is_admin_request
+from snovault import COLLECTIONS
+
+
+pytestmark = [pytest.mark.unit]
+
+
+class FakeUser:
+    def __init__(self, uuid, properties):
+        self.uuid = uuid
+        self.properties = properties
+
+
+class FakeItemTypeMap:
+    """ Mimics collections.by_item_type[item_type] dict-of-items access. """
+    def __init__(self, mapping):
+        self._mapping = mapping
+
+    def __getitem__(self, key):
+        return self._mapping[key]
+
+
+class FakeCollections:
+    def __init__(self, by_item_type):
+        self.by_item_type = by_item_type
+
+
+def make_request(collections=None, effective_principals=None):
+    registry = {COLLECTIONS: collections}
+    return SimpleNamespace(
+        registry=registry,
+        effective_principals=effective_principals or [],
+    )
+
+
+class TestGroupfinderSyntheticResults:
+
+    def test_login_without_dot_returns_none(self):
+        # Short circuits before the registry is even consulted.
+        assert groupfinder('nodothere', make_request()) is None
+
+    @pytest.mark.parametrize('localname', ['EMBED', 'INDEXER'])
+    def test_embed_indexer_get_empty_principals(self, localname):
+        request = make_request(collections=FakeCollections({}))
+        assert groupfinder('remoteuser.%s' % localname, request) == []
+
+    @pytest.mark.parametrize('localname', ['TEST', 'IMPORT', 'UPGRADE', 'INGESTION'])
+    def test_admin_synthetic_results(self, localname):
+        request = make_request(collections=FakeCollections({}))
+        assert groupfinder('remoteuser.%s' % localname, request) == ['group.admin']
+
+    def test_submitter_synthetic_result(self):
+        request = make_request(collections=FakeCollections({}))
+        assert groupfinder('remoteuser.TEST_SUBMITTER', request) == ['group.submitter']
+
+    def test_authenticated_synthetic_result(self):
+        request = make_request(collections=FakeCollections({}))
+        assert groupfinder('remoteuser.TEST_AUTHENTICATED', request) == [Authenticated]
+
+
+class TestGroupfinderUserLookup:
+
+    def test_missing_user_returns_none(self):
+        collections = FakeCollections({'user': FakeItemTypeMap({})})
+        request = make_request(collections=collections)
+        assert groupfinder('mailto.unknown@example.com', request) is None
+
+    def test_deleted_user_returns_none(self):
+        user = FakeUser('uuid-1', {'status': 'deleted', 'groups': ['admin']})
+        collections = FakeCollections({'user': FakeItemTypeMap({'uuid-1': user})})
+        request = make_request(collections=collections)
+        assert groupfinder('remoteuser.uuid-1', request) is None
+
+    def test_active_user_delegates_to_project_create_principals(self):
+        user = FakeUser('uuid-1', {'status': 'current', 'groups': ['admin']})
+        collections = FakeCollections({'user': FakeItemTypeMap({'uuid-1': user})})
+        request = make_request(collections=collections)
+        fake_project = SimpleNamespace(
+            authorization_create_principals=lambda login, u, c: ['userid.uuid-1', 'group.admin'])
+        with mock.patch.object(authz, 'app_project', return_value=fake_project):
+            result = groupfinder('remoteuser.uuid-1', request)
+        assert result == ['userid.uuid-1', 'group.admin']
+
+
+class TestGroupfinderAccessKey:
+
+    def _collections_with(self, access_key_props, user=None):
+        access_key = SimpleNamespace(properties=access_key_props)
+        user_map = {}
+        if user is not None:
+            user_map[user.uuid] = user
+        return FakeCollections({
+            'access_key': FakeItemTypeMap({'key-1': access_key}),
+            'user': FakeItemTypeMap(user_map),
+        })
+
+    def test_missing_access_key_returns_none(self):
+        collections = FakeCollections({'access_key': FakeItemTypeMap({})})
+        request = make_request(collections=collections)
+        assert groupfinder('accesskey.missing', request) is None
+
+    @pytest.mark.parametrize('status', ['deleted', 'revoked'])
+    def test_deleted_or_revoked_access_key_returns_none(self, status):
+        collections = self._collections_with({'status': status, 'user': 'uuid-1'})
+        request = make_request(collections=collections)
+        assert groupfinder('accesskey.key-1', request) is None
+
+    def test_valid_access_key_resolves_user(self):
+        user = FakeUser('uuid-1', {'status': 'current', 'groups': []})
+        collections = self._collections_with({'status': 'current', 'user': 'uuid-1'}, user=user)
+        request = make_request(collections=collections)
+        fake_project = SimpleNamespace(
+            authorization_create_principals=lambda login, u, c: ['userid.uuid-1'])
+        with mock.patch.object(authz, 'app_project', return_value=fake_project):
+            result = groupfinder('accesskey.key-1', request)
+        assert result == ['userid.uuid-1']
+
+
+class TestCreatePrincipals:
+
+    def test_userid_and_groups(self):
+        user = FakeUser('uuid-abc', {'groups': ['admin', 'submitter']})
+        assert _create_principals('login', user, collections=None) == [
+            'userid.uuid-abc', 'group.admin', 'group.submitter'
+        ]
+
+    def test_no_groups(self):
+        user = FakeUser('uuid-abc', {})
+        assert _create_principals('login', user, collections=None) == ['userid.uuid-abc']
+
+
+class TestIsAdminRequest:
+
+    def test_admin_present(self):
+        request = make_request(effective_principals=['group.admin', 'userid.x'])
+        assert is_admin_request(request) is True
+
+    def test_admin_absent(self):
+        request = make_request(effective_principals=['group.submitter', 'userid.x'])
+        assert is_admin_request(request) is False

--- a/snovault/tests/test_calculated_registry.py
+++ b/snovault/tests/test_calculated_registry.py
@@ -1,0 +1,143 @@
+"""
+Unit tests for the snovault.calculated registry classes -- CalculatedProperty
+(schema guard/marking, condition/attr dispatch) and CalculatedProperties
+(per-category registration, MRO-ordered props_for). These drive every calculated
+property in the system but were only covered indirectly through a single
+integration test (test_calculated.py). No services required.
+
+Complements (does not replace) test_calculated.py's end-to-end check.
+"""
+import pytest
+
+from ..calculated import CalculatedProperty, CalculatedProperties, ItemNamespace
+from ..interfaces import CONNECTION
+
+
+pytestmark = [pytest.mark.unit]
+
+
+class TestCalculatedProperty:
+
+    def test_schema_with_default_is_rejected(self):
+        with pytest.raises(ValueError) as excinfo:
+            CalculatedProperty(fn=lambda: 1, name='x',
+                               schema={'type': 'string', 'default': 'nope'})
+        assert 'default' in str(excinfo.value)
+
+    def test_schema_is_copied_and_marked_calculated(self):
+        original = {'type': 'string'}
+        prop = CalculatedProperty(fn=lambda: 1, name='x', schema=original)
+        assert prop.schema == {'type': 'string', 'calculatedProperty': True}
+        # the caller's schema dict must not be mutated
+        assert original == {'type': 'string'}
+
+    def test_no_schema_stays_none(self):
+        prop = CalculatedProperty(fn=lambda: 1, name='x')
+        assert prop.schema is None
+
+    def test_call_invokes_fn_through_namespace(self):
+        prop = CalculatedProperty(fn=lambda: 'computed', name='x')
+        namespace = ItemNamespace(context=None, request=None)
+        assert prop(namespace) == 'computed'
+
+    def test_call_returns_none_when_condition_fails(self):
+        prop = CalculatedProperty(fn=lambda: 'computed', name='x',
+                                  condition=lambda: False)
+        namespace = ItemNamespace(context=None, request=None)
+        assert prop(namespace) is None
+
+    def test_call_computes_when_condition_passes(self):
+        prop = CalculatedProperty(fn=lambda: 'computed', name='x',
+                                  condition=lambda: True)
+        namespace = ItemNamespace(context=None, request=None)
+        assert prop(namespace) == 'computed'
+
+    def test_fn_args_are_resolved_from_namespace(self):
+        # fn parameters are looked up by name on the namespace; ns entries
+        # populate the namespace's __dict__.
+        prop = CalculatedProperty(fn=lambda first, last: first + ' ' + last, name='x')
+        namespace = ItemNamespace(context=None, request=None,
+                                  ns={'first': 'Ada', 'last': 'Lovelace'})
+        assert prop(namespace) == 'Ada Lovelace'
+
+    def test_attr_dispatches_to_context_method(self):
+        class Ctx:
+            def display_title(self):
+                return 'from attr'
+
+        prop = CalculatedProperty(fn=None, name='display_title', attr='display_title')
+        namespace = ItemNamespace(context=Ctx(), request=None)
+        assert prop(namespace) == 'from attr'
+
+
+class TestItemNamespaceCall:
+
+    def test_results_are_memoized_per_fn(self):
+        calls = []
+
+        def fn():
+            calls.append(1)
+            return 'value'
+
+        namespace = ItemNamespace(context=None, request=None)
+        assert namespace(fn) == 'value'
+        assert namespace(fn) == 'value'
+        assert len(calls) == 1
+
+    def test_string_fn_resolves_attribute_or_none(self):
+        # For the unknown-name branch the namespace must be able to walk
+        # __getattr__ to its terminal AttributeError, which touches the
+        # connection registry, item properties, and rev links along the way.
+        class FakeContext:
+            rev = {}
+
+        namespace = ItemNamespace(
+            context=FakeContext(), request=None,
+            ns={'known': 42, 'registry': {CONNECTION: None}, '_properties': {}})
+        assert namespace('known') == 42
+        assert namespace('unknown') is None
+
+
+class TestCalculatedPropertiesRegistry:
+
+    @pytest.fixture
+    def hierarchy(self):
+        class Base:
+            pass
+
+        class Sub(Base):
+            pass
+
+        return Base, Sub
+
+    def test_props_for_inherits_from_base(self, hierarchy):
+        Base, Sub = hierarchy
+        registry = CalculatedProperties()
+        registry.register_prop(lambda: 'baseonly', 'base_only', Base)
+        props = registry.props_for(Sub)
+        assert set(props) == {'base_only'}
+        assert props['base_only'].fn() == 'baseonly'
+
+    def test_subclass_registration_overrides_base(self, hierarchy):
+        Base, Sub = hierarchy
+        registry = CalculatedProperties()
+        registry.register_prop(lambda: 'base', 'shared', Base)
+        registry.register_prop(lambda: 'sub', 'shared', Sub)
+        assert registry.props_for(Sub)['shared'].fn() == 'sub'
+        # base class itself still sees its own registration
+        assert registry.props_for(Base)['shared'].fn() == 'base'
+
+    def test_props_for_accepts_instance_or_class(self, hierarchy):
+        Base, Sub = hierarchy
+        registry = CalculatedProperties()
+        registry.register_prop(lambda: 'v', 'prop', Base)
+        assert set(registry.props_for(Sub())) == set(registry.props_for(Sub)) == {'prop'}
+
+    def test_categories_are_isolated(self, hierarchy):
+        Base, Sub = hierarchy
+        registry = CalculatedProperties()
+        registry.register_prop(lambda: 'obj', 'objprop', Base, category='object')
+        registry.register_prop(lambda: 'page', 'pageprop', Base, category='page')
+        assert set(registry.props_for(Sub, category='object')) == {'objprop'}
+        assert set(registry.props_for(Sub, category='page')) == {'pageprop'}
+        assert registry.props_for(Sub, category='missing') == {}

--- a/snovault/tests/test_edw_hash.py
+++ b/snovault/tests/test_edw_hash.py
@@ -16,3 +16,24 @@ TEST_HASHES = {
 @pytest.mark.parametrize(('password', 'pwhash'), TEST_HASHES.items())
 def test_edw_hash(password, pwhash):
     assert EDWHash.hash(password) == pwhash
+
+
+def test_edw_hash_verify_roundtrip():
+    assert EDWHash.verify('test', EDWHash.hash('test')) is True
+    assert EDWHash.verify('wrong', EDWHash.hash('test')) is False
+
+
+def test_edw_hash_bytes_and_str_secrets_agree():
+    assert EDWHash.hash(b'test') == EDWHash.hash('test')
+
+
+def test_edw_hash_password_too_long():
+    # salted = salt_before + secret + salt_after + NUL must fit in salt_base
+    max_secret_len = (len(EDWHash.salt_base)
+                      - len(EDWHash.salt_before)
+                      - len(EDWHash.salt_after)
+                      - 1)
+    assert max_secret_len == 454
+    EDWHash.hash('x' * max_secret_len)  # exactly at the limit is fine
+    with pytest.raises(ValueError, match='Password too long'):
+        EDWHash.hash('x' * (max_secret_len + 1))

--- a/snovault/tests/test_etag.py
+++ b/snovault/tests/test_etag.py
@@ -1,0 +1,94 @@
+"""
+Unit tests for snovault.etag -- the view decorators that attach ETags and drive
+conditional-GET (HTTP 304) handling. This is caching-correctness code and had no
+direct test. Lightweight fakes stand in for the pyramid request/response.
+"""
+from types import SimpleNamespace
+
+import pytest
+from pyramid.httpexceptions import HTTPNotModified
+
+from ..etag import etag_app_version, etag_app_version_effective_principals
+
+
+pytestmark = [pytest.mark.unit]
+
+
+APP_VERSION = 'v1.2.3'
+
+
+class FakeCacheControl:
+    def __init__(self):
+        self.private = None
+        self.max_age = None
+        self.must_revalidate = None
+
+
+def make_request(if_none_match=(), effective_principals=None):
+    response = SimpleNamespace(etag=None, cache_control=FakeCacheControl())
+    registry = SimpleNamespace(settings={'snovault.app_version': APP_VERSION})
+    return SimpleNamespace(
+        registry=registry,
+        if_none_match=if_none_match,
+        effective_principals=effective_principals or [],
+        response=response,
+    )
+
+
+class TestEtagAppVersion:
+
+    def test_sets_etag_and_returns_result(self):
+        request = make_request()
+        wrapped = etag_app_version(lambda context, req: 'the-result')
+        result = wrapped(context=None, request=request)
+        assert result == 'the-result'
+        assert request.response.etag == APP_VERSION
+
+    def test_raises_not_modified_when_etag_matches(self):
+        request = make_request(if_none_match=[APP_VERSION])
+        called = []
+        wrapped = etag_app_version(lambda context, req: called.append(1))
+        with pytest.raises(HTTPNotModified):
+            wrapped(context=None, request=request)
+        # The underlying view must NOT run when we short-circuit with 304.
+        assert called == []
+
+
+class TestEtagAppVersionEffectivePrincipals:
+
+    def test_etag_includes_sorted_principals(self):
+        request = make_request(effective_principals=['b', 'a', 'c'])
+        wrapped = etag_app_version_effective_principals(lambda context, req: 'ok')
+        result = wrapped(context=None, request=request)
+        assert result == 'ok'
+        assert request.response.etag == APP_VERSION + ' ' + 'a b c'
+
+    def test_sets_private_no_cache_headers(self):
+        request = make_request(effective_principals=['x'])
+        wrapped = etag_app_version_effective_principals(lambda context, req: 'ok')
+        wrapped(context=None, request=request)
+        cc = request.response.cache_control
+        assert cc.private is True
+        assert cc.max_age == 0
+        assert cc.must_revalidate is True
+
+    def test_raises_not_modified_on_matching_principal_etag(self):
+        principals = ['a', 'b']
+        etag = APP_VERSION + ' ' + 'a b'
+        request = make_request(if_none_match=[etag], effective_principals=principals)
+        called = []
+        wrapped = etag_app_version_effective_principals(
+            lambda context, req: called.append(1))
+        with pytest.raises(HTTPNotModified):
+            wrapped(context=None, request=request)
+        assert called == []
+
+    def test_different_principals_produce_different_etag(self):
+        # Guards against cache poisoning across principal sets: distinct principals
+        # must never collide on the same ETag.
+        wrapped = etag_app_version_effective_principals(lambda context, req: 'ok')
+        r1 = make_request(effective_principals=['a'])
+        r2 = make_request(effective_principals=['a', 'admin'])
+        wrapped(None, r1)
+        wrapped(None, r2)
+        assert r1.response.etag != r2.response.etag

--- a/snovault/tests/test_indexing.py
+++ b/snovault/tests/test_indexing.py
@@ -192,6 +192,7 @@ def test_indexing_post_then_get_immediately(testapp, indexer_testapp):
     assert index_settings.settings['index']['number_of_replicas'] == 2  # should match value in testing_views.py
 
 
+@pytest.mark.flaky(max_runs=3, rerun_filter=delay_rerun)
 def test_indexer_namespacing(app, testapp, indexer_testapp):
     """
     Tests that namespacing indexes works as expected. This test has no real
@@ -215,6 +216,7 @@ def test_indexer_namespacing(app, testapp, indexer_testapp):
 
 
 # @pytest.mark.es - Specified at top of file for whole file
+@pytest.mark.flaky(max_runs=3, rerun_filter=delay_rerun)
 def test_indexer_queue_adds_telemetry_id(app):
     indexer_queue = app.registry[INDEXER_QUEUE]
     indexer_queue.clear_queue()
@@ -1448,7 +1450,7 @@ def test_indexing_rdbstorage_can_purge_without_es(app, testapp, indexer_testapp)
     print("All done.")
 
 
-# @pytest.mark.flaky(max_runs=3, rerun_filter=delay_rerun)
+@pytest.mark.flaky(max_runs=3, rerun_filter=delay_rerun)
 def test_aggregated_items(app, testapp, indexer_testapp):
     """
     Test that the item aggregation works, which only occurs when indexing

--- a/snovault/tests/test_json_renderer.py
+++ b/snovault/tests/test_json_renderer.py
@@ -1,0 +1,72 @@
+"""
+Unit tests for snovault.json_renderer -- the default JSON renderer's type
+adapters (UUID/set/frozenset/datetime), the BinaryFromJSON wrapper, and
+JSONResult.serializer. Every response body in the system flows through this
+module; it previously had no direct test. No services required.
+"""
+import datetime
+import json
+import uuid
+
+import pytest
+
+from ..json_renderer import (
+    json_renderer,
+    uuid_adapter,
+    listy_adapter,
+    datetime_adapter,
+    BinaryFromJSON,
+    JSONResult,
+)
+
+
+pytestmark = [pytest.mark.unit]
+
+
+class TestAdapters:
+
+    def test_uuid_adapter_stringifies(self):
+        value = uuid.UUID('12345678-1234-5678-1234-567812345678')
+        assert uuid_adapter(value, None) == '12345678-1234-5678-1234-567812345678'
+
+    def test_listy_adapter_converts_sets(self):
+        assert listy_adapter({'a'}, None) == ['a']
+        assert listy_adapter(frozenset(['b']), None) == ['b']
+
+    def test_datetime_adapter_isoformats(self):
+        value = datetime.datetime(2026, 7, 6, 12, 30, 15)
+        assert datetime_adapter(value, None) == '2026-07-06T12:30:15'
+
+
+class TestJsonRendererDumps:
+
+    def test_dumps_handles_registered_types_without_a_request(self):
+        # dumps() resolves adapters via get_current_request(); it must work
+        # outside any request (returns None) since indexers call it that way.
+        value = {
+            'id': uuid.UUID('12345678-1234-5678-1234-567812345678'),
+            'when': datetime.datetime(2026, 7, 6, 12, 30, 15),
+            'tags': frozenset(['only']),
+        }
+        parsed = json.loads(json_renderer.dumps(value))
+        assert parsed == {
+            'id': '12345678-1234-5678-1234-567812345678',
+            'when': '2026-07-06T12:30:15',
+            'tags': ['only'],
+        }
+
+    def test_dumps_returns_text(self):
+        assert isinstance(json_renderer.dumps({'a': 1}), str)
+
+
+class TestJSONResult:
+
+    def test_serializer_yields_utf8_bytes(self):
+        result = JSONResult.serializer({'a': 1})
+        assert isinstance(result, BinaryFromJSON)
+        assert b''.join(result) == b'{"a": 1}'
+
+    def test_binary_from_json_preserves_chunking(self):
+        wrapped = BinaryFromJSON(['ab', 'cd'])
+        assert len(wrapped) == 2
+        assert list(wrapped) == [b'ab', b'cd']

--- a/snovault/tests/test_local_roles.py
+++ b/snovault/tests/test_local_roles.py
@@ -1,0 +1,124 @@
+"""
+Unit tests for snovault.local_roles -- the pyramid_localroles-style authorization
+layer that expands principals via ``__ac_local_roles__`` mappings found on the
+context lineage. Security-sensitive (it feeds the principal set every ACL check
+sees) and previously had no direct test. Lightweight lineage nodes stand in for
+resources; no services required.
+"""
+import pytest
+
+from pyramid.security import Allow
+
+from ..local_roles import (
+    local_principals,
+    merged_local_principals,
+    LocalRolesAuthorizationPolicy,
+)
+
+
+pytestmark = [pytest.mark.unit]
+
+
+class Node:
+    """ Minimal resource with a __parent__ lineage, optional local roles/ACL. """
+
+    def __init__(self, parent=None, roles=None, block=False, acl=None):
+        self.__parent__ = parent
+        if roles is not None:
+            self.__ac_local_roles__ = roles
+        if block:
+            self.__ac_local_roles_block__ = True
+        if acl is not None:
+            self.__acl__ = acl
+
+
+class TestLocalPrincipals:
+
+    def test_no_local_roles_returns_principals_unchanged(self):
+        principals = ['userid.bob']
+        result = local_principals(Node(), principals)
+        assert result is principals
+
+    def test_no_matching_principal_returns_principals_unchanged(self):
+        principals = ['userid.bob']
+        node = Node(roles={'userid.alice': ['role.owner']})
+        result = local_principals(node, principals)
+        assert result is principals
+
+    def test_matching_principal_gains_local_roles(self):
+        node = Node(roles={'userid.alice': ['role.owner', 'role.viewer']})
+        result = local_principals(node, ['userid.alice', 'system.Everyone'])
+        assert result == {'userid.alice', 'system.Everyone', 'role.owner', 'role.viewer'}
+
+    def test_single_string_role_is_treated_as_singleton(self):
+        node = Node(roles={'userid.alice': 'role.owner'})
+        result = local_principals(node, ['userid.alice'])
+        assert result == {'userid.alice', 'role.owner'}
+
+    def test_callable_local_roles_is_invoked(self):
+        node = Node(roles=lambda: {'userid.carol': ['role.admin']})
+        result = local_principals(node, ['userid.carol'])
+        assert result == {'userid.carol', 'role.admin'}
+
+    def test_roles_accumulate_up_the_lineage(self):
+        root = Node(roles={'userid.alice': ['role.lab_member']})
+        child = Node(parent=root, roles={'userid.alice': 'role.owner'})
+        result = local_principals(child, ['userid.alice'])
+        assert result == {'userid.alice', 'role.owner', 'role.lab_member'}
+
+    def test_block_stops_parent_roles_but_keeps_own(self):
+        # __ac_local_roles_block__ on a node stops the walk *above* that node:
+        # the blocking node's own roles still apply, its ancestors' do not.
+        root = Node(roles={'userid.alice': ['role.lab_member']})
+        child = Node(parent=root, roles={'userid.alice': 'role.owner'}, block=True)
+        result = local_principals(child, ['userid.alice'])
+        assert result == {'userid.alice', 'role.owner'}
+
+
+class TestMergedLocalPrincipals:
+
+    def test_no_local_roles_returns_principals_unchanged(self):
+        principals = ['role.nonexistent']
+        result = merged_local_principals(Node(), principals)
+        assert result is principals
+
+    def test_no_matching_role_returns_principals_unchanged(self):
+        principals = ['role.nonexistent']
+        node = Node(roles={'userid.alice': ['role.owner']})
+        result = merged_local_principals(node, principals)
+        assert result is principals
+
+    def test_maps_roles_back_to_granting_principals(self):
+        # merged_local_principals is the reverse mapping: given allowed roles,
+        # add the principals whose local roles intersect them.
+        root = Node(roles={'userid.alice': ['role.lab_member', 'role.viewer']})
+        child = Node(parent=root, roles={'userid.alice': 'role.owner'})
+        result = merged_local_principals(child, ['role.owner', 'role.viewer'])
+        assert sorted(result) == ['role.owner', 'role.viewer', 'userid.alice']
+
+    def test_returns_a_list(self):
+        node = Node(roles={'userid.alice': ['role.owner']})
+        result = merged_local_principals(node, ['role.owner'])
+        assert isinstance(result, list)
+
+
+class TestLocalRolesAuthorizationPolicy:
+
+    def test_permits_via_local_role(self):
+        ctx = Node(roles={'userid.alice': ['role.owner']},
+                   acl=[(Allow, 'role.owner', 'edit')])
+        policy = LocalRolesAuthorizationPolicy()
+        assert bool(policy.permits(ctx, ['userid.alice'], 'edit')) is True
+
+    def test_denies_principal_without_local_role(self):
+        ctx = Node(roles={'userid.alice': ['role.owner']},
+                   acl=[(Allow, 'role.owner', 'edit')])
+        policy = LocalRolesAuthorizationPolicy()
+        assert bool(policy.permits(ctx, ['userid.bob'], 'edit')) is False
+
+    def test_principals_allowed_by_permission_includes_local_principals(self):
+        ctx = Node(roles={'userid.alice': ['role.owner']},
+                   acl=[(Allow, 'role.owner', 'edit')])
+        policy = LocalRolesAuthorizationPolicy()
+        allowed = policy.principals_allowed_by_permission(ctx, 'edit')
+        assert sorted(allowed) == ['role.owner', 'userid.alice']

--- a/snovault/tests/test_manager_lru_cache.py
+++ b/snovault/tests/test_manager_lru_cache.py
@@ -1,0 +1,71 @@
+"""
+Unit tests for snovault.cache.ManagerLRUCache -- the per-transaction LRU cache
+layered on pyramid's threadlocal stack (used for embed/collection caches on hot
+read paths). Locks the degraded no-op behavior outside a request, capacity
+resolution from registry settings, and the transaction-completion flush.
+No services required.
+"""
+import pytest
+
+from pyramid.threadlocal import manager
+
+from ..cache import ManagerLRUCache
+
+
+pytestmark = [pytest.mark.unit]
+
+
+class FakeRegistry:
+
+    def __init__(self, settings=None):
+        self.settings = settings or {}
+
+
+@pytest.fixture
+def threadlocal_registry():
+    """ Push a fake pyramid threadlocal frame so the cache has somewhere to live. """
+    registry = FakeRegistry()
+    manager.push({'registry': registry})
+    yield registry
+    manager.pop()
+
+
+class TestOutsideRequest:
+    """ With no pyramid threadlocal stack, every operation degrades to a no-op. """
+
+    def test_cache_is_none(self):
+        assert ManagerLRUCache('t.none').cache is None
+
+    def test_get_returns_default_and_set_is_noop(self):
+        cache = ManagerLRUCache('t.noop')
+        cache['key'] = 'value'
+        assert cache.get('key', 'default') == 'default'
+        assert 'key' not in cache
+
+
+class TestWithinRequest:
+
+    def test_set_get_contains_delete(self, threadlocal_registry):
+        cache = ManagerLRUCache('t.basic')
+        cache['key'] = 'value'
+        assert cache.get('key') == 'value'
+        assert 'key' in cache
+        del cache['key']
+        assert cache.get('key', 'missing') == 'missing'
+
+    def test_capacity_defaults_when_unconfigured(self, threadlocal_registry):
+        cache = ManagerLRUCache('t.sized', default_capacity=2)
+        assert cache.cache.capacity == 2
+
+    def test_capacity_read_from_registry_settings(self, threadlocal_registry):
+        threadlocal_registry.settings['t.configured.capacity'] = '7'
+        cache = ManagerLRUCache('t.configured', default_capacity=100)
+        assert cache.cache.capacity == 7
+
+    def test_after_completion_flushes_cache(self, threadlocal_registry):
+        # The ISynchronizer hook must drop the cache when a transaction
+        # completes, so retried transactions never see stale entries.
+        cache = ManagerLRUCache('t.flush')
+        cache['key'] = 'value'
+        cache.afterCompletion(transaction=None)
+        assert cache.get('key', 'flushed') == 'flushed'

--- a/snovault/tests/test_predicates.py
+++ b/snovault/tests/test_predicates.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for snovault.predicates -- the pyramid view predicates used in route
+configuration. Correctness matters (they decide whether a view matches a request)
+and the module had no direct test. Lightweight fakes stand in for context/request.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from ..predicates import SubpathSegmentsPredicate, AdditionalPermissionPredicate
+
+
+pytestmark = [pytest.mark.unit]
+
+
+class TestSubpathSegmentsPredicate:
+
+    def test_int_val_is_normalized_to_singleton(self):
+        pred = SubpathSegmentsPredicate(2, config=None)
+        assert pred.val == frozenset({2})
+
+    def test_iterable_val_is_stored_as_frozenset(self):
+        pred = SubpathSegmentsPredicate([0, 1, 2], config=None)
+        assert pred.val == frozenset({0, 1, 2})
+
+    def test_text_is_sorted_and_readable(self):
+        pred = SubpathSegmentsPredicate([2, 0, 1], config=None)
+        assert pred.text() == 'subpath_segments in [0, 1, 2]'
+
+    def test_phash_matches_text(self):
+        pred = SubpathSegmentsPredicate(1, config=None)
+        assert pred.phash() == pred.text()
+
+    @pytest.mark.parametrize('subpath,expected', [
+        ((), False),
+        (('a',), True),
+        (('a', 'b'), False),
+    ])
+    def test_call_matches_on_subpath_length(self, subpath, expected):
+        pred = SubpathSegmentsPredicate(1, config=None)
+        request = SimpleNamespace(subpath=subpath)
+        assert pred(context=None, request=request) is expected
+
+    def test_call_matches_any_allowed_length(self):
+        pred = SubpathSegmentsPredicate([0, 2], config=None)
+        assert pred(None, SimpleNamespace(subpath=())) is True
+        assert pred(None, SimpleNamespace(subpath=('a',))) is False
+        assert pred(None, SimpleNamespace(subpath=('a', 'b'))) is True
+
+
+class TestAdditionalPermissionPredicate:
+
+    def test_text_and_phash(self):
+        pred = AdditionalPermissionPredicate('edit', config=None)
+        assert pred.text() == "additional_permission = 'edit'"
+        assert pred.phash() == pred.text()
+
+    def test_call_delegates_to_has_permission(self):
+        calls = []
+
+        def has_permission(perm, ctx):
+            calls.append((perm, ctx))
+            return True
+
+        pred = AdditionalPermissionPredicate('edit', config=None)
+        context = object()
+        request = SimpleNamespace(has_permission=has_permission)
+        assert pred(context, request) is True
+        assert calls == [('edit', context)]
+
+    def test_call_returns_falsey_permission_result(self):
+        pred = AdditionalPermissionPredicate('view', config=None)
+        request = SimpleNamespace(has_permission=lambda perm, ctx: False)
+        assert pred(object(), request) is False

--- a/snovault/tests/test_schema_formats.py
+++ b/snovault/tests/test_schema_formats.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for snovault.schema_formats -- the pure regex validators used to
+recognize UUIDs and accessions. These are correctness-sensitive (they gate
+identity resolution) and previously had no direct unit test.
+"""
+import uuid as uuid_module
+
+import pytest
+
+from ..schema_formats import is_uuid, is_accession
+from ..server_defaults import GET_ACCESSION_PREFIX, ACCESSION_TEST_PREFIX
+
+
+pytestmark = [pytest.mark.unit]
+
+
+class TestIsUuid:
+
+    def test_canonical_uuid(self):
+        assert is_uuid(str(uuid_module.uuid4())) is True
+
+    def test_uuid_without_dashes(self):
+        # Python's UUID (and this checker) tolerate the dash-free form.
+        assert is_uuid(str(uuid_module.uuid4()).replace('-', '')) is True
+
+    def test_uuid_with_braces(self):
+        assert is_uuid('{' + str(uuid_module.uuid4()) + '}') is True
+
+    def test_uuid_is_case_insensitive(self):
+        u = str(uuid_module.uuid4()).upper()
+        assert is_uuid(u) is True
+
+    def test_too_short_is_rejected(self):
+        assert is_uuid('c78da883') is False
+
+    def test_empty_is_rejected(self):
+        assert is_uuid('') is False
+
+    def test_non_hex_is_rejected(self):
+        assert is_uuid('not-a-uuid-value-here') is False
+
+    def test_trailing_garbage_still_matches(self):
+        # Documents a KNOWN laxness: the checker uses re.match (not fullmatch),
+        # so trailing characters after a valid prefix are not rejected. Pinning
+        # this so a future tightening to fullmatch is a deliberate, visible change.
+        assert is_uuid(str(uuid_module.uuid4()) + 'ZZZ') is True
+
+
+class TestIsAccession:
+
+    def test_real_prefix_accession(self):
+        # Nine [1-9A-Z] characters following the project accession prefix.
+        assert is_accession(GET_ACCESSION_PREFIX() + 'ABC123XYZ') is True
+
+    def test_test_prefix_numeric_suffix(self):
+        # TST + 2-letter code + 4 digits + 3 digits.
+        assert is_accession(ACCESSION_TEST_PREFIX + 'BS1234567') is True
+
+    def test_test_prefix_alpha_suffix(self):
+        # TST + 2-letter code + 4 digits + 3 uppercase letters.
+        assert is_accession(ACCESSION_TEST_PREFIX + 'ES1234ABC') is True
+
+    def test_unknown_string_is_not_accession(self):
+        assert is_accession('HELLO') is False
+
+    def test_lowercase_is_not_accession(self):
+        assert is_accession(GET_ACCESSION_PREFIX().lower() + 'abc123xyz') is False
+
+    def test_test_prefix_with_unknown_code_is_rejected(self):
+        # 'ZZ' is not in ACCESSION_TEST_CODES.
+        assert is_accession(ACCESSION_TEST_PREFIX + 'ZZ1234567') is False
+
+    def test_wrong_length_is_rejected(self):
+        assert is_accession(GET_ACCESSION_PREFIX() + 'ABC12') is False

--- a/snovault/tests/test_server_defaults_misc.py
+++ b/snovault/tests/test_server_defaults_misc.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for snovault.server_defaults_misc.add_last_modified -- the helper that
+stamps system-managed last_modified metadata onto item properties. It has five
+distinct branches (real userid, NO_DEFAULT, no-request-with-userid-override,
+no-request-without-userid, custom field name) none of which were covered.
+
+get_userid / get_now are patched at the module under test so no request or clock
+is required.
+"""
+from unittest import mock
+
+import pytest
+
+from .. import server_defaults_misc as sdm
+from ..schema_validation import NO_DEFAULT
+
+
+pytestmark = [pytest.mark.unit]
+
+
+FIXED_NOW = '2026-01-01T00:00:00.000000+00:00'
+
+
+def test_add_last_modified_with_real_userid():
+    with mock.patch.object(sdm, 'get_userid', return_value='uuid-123'), \
+            mock.patch.object(sdm, 'get_now', return_value=FIXED_NOW):
+        props = {}
+        sdm.add_last_modified(props)
+    assert props == {
+        'last_modified': {'modified_by': 'uuid-123', 'date_modified': FIXED_NOW}
+    }
+
+
+def test_add_last_modified_no_default_userid_is_noop():
+    # When get_userid resolves to NO_DEFAULT (no logged-in user) nothing is written.
+    with mock.patch.object(sdm, 'get_userid', return_value=NO_DEFAULT), \
+            mock.patch.object(sdm, 'get_now', return_value=FIXED_NOW):
+        props = {}
+        sdm.add_last_modified(props)
+    assert props == {}
+
+
+def test_add_last_modified_outside_request_with_userid_override():
+    # get_userid raises AttributeError when there is no request in scope; an
+    # explicit userid kwarg is then used instead.
+    with mock.patch.object(sdm, 'get_userid', side_effect=AttributeError), \
+            mock.patch.object(sdm, 'get_now', return_value=FIXED_NOW):
+        props = {}
+        sdm.add_last_modified(props, userid='override-user')
+    assert props == {
+        'last_modified': {'modified_by': 'override-user', 'date_modified': FIXED_NOW}
+    }
+
+
+def test_add_last_modified_outside_request_without_userid_is_noop():
+    with mock.patch.object(sdm, 'get_userid', side_effect=AttributeError), \
+            mock.patch.object(sdm, 'get_now', return_value=FIXED_NOW):
+        props = {}
+        sdm.add_last_modified(props)
+    assert props == {}
+
+
+def test_add_last_modified_custom_field_name_portion():
+    # field_name_portion drives all three derived field names.
+    with mock.patch.object(sdm, 'get_userid', return_value='u1'), \
+            mock.patch.object(sdm, 'get_now', return_value=FIXED_NOW):
+        props = {}
+        sdm.add_last_modified(props, field_name_portion='text_edited')
+    assert props == {
+        'last_text_edited': {'text_edited_by': 'u1', 'date_text_edited': FIXED_NOW}
+    }
+
+
+def test_add_last_modified_preserves_existing_properties():
+    with mock.patch.object(sdm, 'get_userid', return_value='u1'), \
+            mock.patch.object(sdm, 'get_now', return_value=FIXED_NOW):
+        props = {'existing': 'value'}
+        sdm.add_last_modified(props)
+    assert props['existing'] == 'value'
+    assert 'last_modified' in props

--- a/snovault/tests/test_typedsheets.py
+++ b/snovault/tests/test_typedsheets.py
@@ -1,0 +1,133 @@
+"""
+Unit tests for snovault.typedsheets -- the pure value-casting helpers used when
+loading typed CSV/insert data. This module had no direct test coverage; the
+functions here are fully deterministic (the only dependency is
+``pyramid.settings.asbool``) so they can be exercised without any live services.
+"""
+import pytest
+
+from .. import typedsheets as ts
+
+
+pytestmark = [pytest.mark.unit]
+
+
+class TestCast:
+
+    def test_cast_defaults_to_string_when_no_types(self):
+        # An empty type stack falls back to 'string', so the value passes through.
+        assert ts.cast([], 'hello') == 'hello'
+
+    def test_cast_strips_whitespace(self):
+        assert ts.cast(['string'], '  spaced  ') == 'spaced'
+
+    @pytest.mark.parametrize('type_name', ['string', 'integer', 'number', 'boolean'])
+    def test_cast_null_is_none_regardless_of_type(self, type_name):
+        # The literal 'null' (any case) always becomes None, before type parsing.
+        assert ts.cast([type_name], 'null') is None
+        assert ts.cast([type_name], 'NULL') is None
+
+    def test_cast_empty_non_string_is_none(self):
+        assert ts.cast(['integer'], '') is None
+        assert ts.cast(['number'], '') is None
+
+    def test_cast_empty_string_type_stays_empty(self):
+        # Asymmetry worth pinning: '' for a 'string' type is kept as '', NOT None.
+        assert ts.cast(['string'], '') == ''
+
+    def test_cast_integer(self):
+        assert ts.cast(['integer'], '42') == 42
+
+    def test_cast_number_int_then_float(self):
+        assert ts.parse_number([], '5') == 5
+        assert isinstance(ts.parse_number([], '5'), int)
+        assert ts.parse_number([], '5.5') == 5.5
+        assert isinstance(ts.parse_number([], '5.5'), float)
+
+    def test_cast_number_non_numeric_raises(self):
+        with pytest.raises(ValueError):
+            ts.parse_number([], 'not-a-number')
+
+    def test_parse_integer_rejects_float_string(self):
+        with pytest.raises(ValueError):
+            ts.parse_integer([], '5.5')
+
+    @pytest.mark.parametrize('raw,expected', [
+        ('true', True), ('True', True), ('1', True), ('yes', True),
+        ('false', False), ('False', False), ('0', False), ('no', False),
+    ])
+    def test_cast_boolean(self, raw, expected):
+        assert ts.cast(['boolean'], raw) is expected
+
+    def test_parse_string_asserts_no_remaining_types(self):
+        # The scalar parsers assert their type stack is empty; misordered casts fail loudly.
+        with pytest.raises(AssertionError):
+            ts.parse_integer(['array'], '5')
+
+
+class TestParseArray:
+
+    def test_parse_array_basic(self):
+        assert ts.parse_array([], 'a;b;c') == ['a', 'b', 'c']
+
+    def test_parse_array_skips_blank_entries(self):
+        assert ts.parse_array([], 'a;;b; ;c') == ['a', 'b', 'c']
+
+    def test_parse_array_empty(self):
+        assert ts.parse_array([], '') == []
+
+    def test_parse_array_of_integers(self):
+        assert ts.parse_array(['integer'], '1;2;3') == [1, 2, 3]
+
+
+class TestParseObject:
+
+    def test_parse_object_basic(self):
+        assert ts.parse_object([], 'k:v,x:y') == {'k': 'v', 'x': 'y'}
+
+    def test_parse_object_strips_keys_and_values(self):
+        assert ts.parse_object([], ' k : v ') == {'k': 'v'}
+
+    def test_parse_object_empty_yields_empty_dict(self):
+        # The generator's `if value.strip()` guard means empty input -> {}.
+        assert ts.parse_object([], '') == {}
+
+    def test_parse_object_value_without_colon_raises(self):
+        # 'k:v,bad' -> the 'bad' item has no ':' so split(':', 1) yields one element.
+        with pytest.raises(ValueError):
+            ts.parse_object([], 'k:v,bad')
+
+
+class TestConvert:
+
+    def test_convert_simple(self):
+        assert ts.convert('field:integer', '5') == ('field', 5)
+
+    def test_convert_plain_field_is_string(self):
+        assert ts.convert('name', 'value') == ('name', 'value')
+
+    def test_convert_array_of_integers(self):
+        # Casts apply right-to-left: pop 'array', which casts each element as integer.
+        assert ts.convert('f:integer:array', '1;2;3') == ('f', [1, 2, 3])
+
+    def test_convert_ignore_yields_none(self):
+        assert ts.convert('f:ignore', 'whatever') == ('f', None)
+
+
+class TestRowGenerators:
+
+    def test_cast_row_values(self):
+        rows = [{'a:integer': '5', 'b': 'hi'}]
+        assert list(ts.cast_row_values(rows)) == [{'a': 5, 'b': 'hi'}]
+
+    def test_cast_row_values_coerces_none_to_empty_string(self):
+        # `value or ''` protects against a None cell in the source dict.
+        assert list(ts.cast_row_values([{'a': None}])) == [{'a': ''}]
+
+    def test_remove_nulls_drops_none_and_blank_names(self):
+        rows = [{'a': None, 'b': 1, '': 2, 'c': 0}]
+        # None values dropped; the entry with a falsy name ('') dropped; 0 kept.
+        assert list(ts.remove_nulls(rows)) == [{'b': 1, 'c': 0}]
+
+    def test_remove_nulls_empty(self):
+        assert list(ts.remove_nulls([])) == []

--- a/snovault/tests/test_typeinfo.py
+++ b/snovault/tests/test_typeinfo.py
@@ -1,0 +1,68 @@
+"""
+Unit tests for snovault.typeinfo.extract_schema_links -- a pure recursive
+generator that walks a JSON schema and yields the dotted paths to linkTo fields.
+It is used to build type link metadata and had no direct test.
+"""
+import pytest
+
+from ..typeinfo import extract_schema_links
+
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_falsy_schema_yields_nothing():
+    assert list(extract_schema_links(None)) == []
+    assert list(extract_schema_links({})) == []
+
+
+def test_top_level_link():
+    schema = {'properties': {'lab': {'linkTo': 'Lab'}}}
+    assert list(extract_schema_links(schema)) == [('lab',)]
+
+
+def test_non_link_properties_ignored():
+    schema = {'properties': {'name': {'type': 'string'}, 'lab': {'linkTo': 'Lab'}}}
+    assert list(extract_schema_links(schema)) == [('lab',)]
+
+
+def test_array_of_links_unwraps_items():
+    schema = {'properties': {'files': {'items': {'linkTo': 'File'}}}}
+    assert list(extract_schema_links(schema)) == [('files',)]
+
+
+def test_nested_object_prefixes_path():
+    schema = {
+        'properties': {
+            'sub': {'properties': {'award': {'linkTo': 'Award'}}}
+        }
+    }
+    assert list(extract_schema_links(schema)) == [('sub', 'award')]
+
+
+def test_mixed_schema_collects_all_paths():
+    schema = {
+        'properties': {
+            'lab': {'linkTo': 'Lab'},
+            'plain': {'type': 'string'},
+            'sub': {'properties': {'award': {'linkTo': 'Award'}}},
+            'arr': {'items': {'linkTo': 'Y'}},
+        }
+    }
+    assert sorted(extract_schema_links(schema)) == [('arr',), ('lab',), ('sub', 'award')]
+
+
+def test_deeply_nested_paths():
+    schema = {
+        'properties': {
+            'a': {'properties': {'b': {'properties': {'c': {'linkTo': 'Z'}}}}}
+        }
+    }
+    assert list(extract_schema_links(schema)) == [('a', 'b', 'c')]
+
+
+def test_truthy_schema_missing_properties_key_raises():
+    # Documents that a non-empty schema without a 'properties' key is a hard error
+    # (KeyError) rather than yielding nothing -- callers must pass real schemas.
+    with pytest.raises(KeyError):
+        list(extract_schema_links({'type': 'object'}))

--- a/snovault/tests/test_util_helpers.py
+++ b/snovault/tests/test_util_helpers.py
@@ -1,0 +1,184 @@
+"""
+Unit tests for pure helper functions in snovault.util that were not directly
+covered by tests/test_util.py. These are all deterministic and need no live
+services. (test_util.py already covers dictionary_lookup, CachedField and the
+common merge_calculated_into_properties paths; this file targets the remaining
+untested helpers and the merge edge branches.)
+"""
+import gzip
+import os
+
+import pytest
+
+from ..util import (
+    deduplicate_list,
+    ensurelist,
+    gunzip_content,
+    convert_integer_to_comma_string,
+    simple_path_ids,
+    recursively_process_field,
+    resolve_file_path,
+    merge_calculated_into_properties,
+)
+
+
+pytestmark = [pytest.mark.unit]
+
+
+class TestDeduplicateList:
+
+    def test_removes_duplicates(self):
+        assert sorted(deduplicate_list([1, 1, 2, 3, 3])) == [1, 2, 3]
+
+    def test_empty_list(self):
+        assert deduplicate_list([]) == []
+
+    def test_accepts_tuple_returns_list(self):
+        result = deduplicate_list(('a', 'a', 'b'))
+        assert isinstance(result, list)
+        assert sorted(result) == ['a', 'b']
+
+    def test_unhashable_elements_raise(self):
+        with pytest.raises(TypeError):
+            deduplicate_list([{'a': 1}, {'a': 1}])
+
+
+class TestEnsurelist:
+
+    def test_string_becomes_singleton_list(self):
+        assert ensurelist('abc') == ['abc']
+
+    def test_list_passes_through(self):
+        value = ['a', 'b']
+        assert ensurelist(value) is value
+
+    def test_none_passes_through(self):
+        assert ensurelist(None) is None
+
+    def test_int_passes_through(self):
+        # Only str is special-cased; other scalars are returned unchanged.
+        assert ensurelist(5) == 5
+
+
+class TestGunzipContent:
+
+    def test_round_trip(self):
+        assert gunzip_content(gzip.compress(b'hello world')) == 'hello world'
+
+    def test_round_trip_unicode(self):
+        assert gunzip_content(gzip.compress('héllo'.encode('utf-8'))) == 'héllo'
+
+    def test_malformed_content_raises(self):
+        with pytest.raises(Exception):
+            gunzip_content(b'not gzipped data')
+
+
+class TestConvertIntegerToCommaString:
+
+    def test_formats_large_integer(self):
+        assert convert_integer_to_comma_string(1234567) == '1,234,567'
+
+    def test_small_integer(self):
+        assert convert_integer_to_comma_string(42) == '42'
+
+    def test_negative_integer(self):
+        assert convert_integer_to_comma_string(-1234567) == '-1,234,567'
+
+    def test_non_integer_returns_none(self):
+        assert convert_integer_to_comma_string('123') is None
+        assert convert_integer_to_comma_string(1.5) is None
+        assert convert_integer_to_comma_string(None) is None
+
+
+class TestSimplePathIds:
+
+    def test_leaf_with_empty_path_yields_object(self):
+        assert list(simple_path_ids('x', [])) == ['x']
+
+    def test_dotted_string_path(self):
+        obj = {'a': {'b': 'value'}}
+        assert list(simple_path_ids(obj, 'a.b')) == ['value']
+
+    def test_flattens_lists(self):
+        obj = {'a': {'b': [1, 2, 3]}}
+        assert list(simple_path_ids(obj, 'a.b')) == [1, 2, 3]
+
+    def test_missing_key_yields_nothing(self):
+        assert list(simple_path_ids({'a': 1}, 'x.y')) == []
+
+    def test_none_value_yields_nothing(self):
+        assert list(simple_path_ids({'a': None}, 'a')) == []
+
+    def test_list_path_argument(self):
+        obj = {'a': {'b': 'value'}}
+        assert list(simple_path_ids(obj, ['a', 'b'])) == ['value']
+
+
+class TestRecursivelyProcessField:
+
+    def test_simple_nested(self):
+        assert recursively_process_field({'a': {'b': 'v'}}, ['a', 'b']) == 'v'
+
+    def test_list_at_intermediate_level(self):
+        assert recursively_process_field({'a': [{'b': 1}, {'b': 2}]}, ['a', 'b']) == [1, 2]
+
+    def test_missing_intermediate_returns_none(self):
+        assert recursively_process_field({'a': None}, ['a', 'b']) is None
+
+    def test_cannot_drill_into_scalar_returns_scalar(self):
+        # A scalar encountered before the path ends is returned as-is.
+        assert recursively_process_field({'a': 5}, ['a', 'b']) == 5
+
+    def test_scalar_top_level_returns_item(self):
+        # AttributeError on .get -> returns the item itself.
+        assert recursively_process_field('scalar', ['a']) == 'scalar'
+
+    def test_single_field_path(self):
+        assert recursively_process_field({'a': 'v'}, ['a']) == 'v'
+
+
+class TestResolveFilePath:
+
+    def test_relative_to_default_root(self):
+        result = resolve_file_path('schemas/foo.json')
+        assert os.path.isabs(result)
+        assert result.endswith(os.path.join('schemas', 'foo.json'))
+
+    def test_relative_to_file_loc(self):
+        result = resolve_file_path('bar.json', file_loc='/some/dir/module.py')
+        assert result == os.path.join('/some/dir', 'bar.json')
+
+    def test_custom_root_dir(self):
+        result = resolve_file_path('x.json', root_dir='/custom/root')
+        assert result == os.path.join('/custom/root', 'x.json')
+
+    def test_tilde_expansion(self):
+        result = resolve_file_path('~/thing.json', root_dir='/ignored')
+        assert '~' not in result
+        assert result == os.path.expanduser('~/thing.json')
+
+
+class TestMergeCalculatedEdgeCases:
+    """ Complements the base-path tests in test_util.py. """
+
+    def test_uuid_type_mismatch_is_tolerated(self):
+        # Special-case: a 'uuid' key with mismatched calc/props types does NOT raise;
+        # the base property value is preserved (added for frame=raw view handling).
+        props = {'uuid': 'base-value'}
+        merge_calculated_into_properties(props, {'uuid': ['calc', 'value']})
+        assert props == {'uuid': 'base-value'}
+
+    def test_non_uuid_type_mismatch_raises(self):
+        props = {'foo': 'a-string'}
+        with pytest.raises(ValueError):
+            merge_calculated_into_properties(props, {'foo': ['a', 'list']})
+
+    def test_list_of_dicts_merged_by_position(self):
+        props = {'items': [{'a': 1}, {'a': 2}]}
+        merge_calculated_into_properties(props, {'items': [{'b': 10}, {'b': 20}]})
+        assert props == {'items': [{'a': 1, 'b': 10}, {'a': 2, 'b': 20}]}
+
+    def test_new_key_is_added(self):
+        props = {'existing': 1}
+        merge_calculated_into_properties(props, {'brand_new': 2})
+        assert props == {'existing': 1, 'brand_new': 2}


### PR DESCRIPTION
## Summary

Adds **138 direct unit tests across 8 new files** (initial audit), plus a **follow-up
round of ~50 more tests across 4 new files + 2 extended files** closing the gaps the
initial audit had explicitly deferred. **No production code was changed**; the new tests
run without ElasticSearch or Postgres. Also folds in a known CI-flakiness fix
(flaky-rerun decorators in `test_indexing.py`) and repairs a version/changelog mismatch
introduced by the master merge.

## What I audited (round 1)

I mapped the 30 existing `test_*.py` files against the 60 top-level `snovault/*.py`
modules, ran a targeted read of the pure-logic candidates, and checked each for
(a) testability without live services, (b) correctness-sensitivity, and (c) current
coverage. I confirmed gaps by grepping the whole test tree for each target function
and by exercising actual runtime behavior before pinning it in assertions.

## Gaps found and closed (round 1 — 8 new files, 138 tests)

| New test file | Module under test | Why it mattered |
|---|---|---|
| `test_typedsheets.py` | `typedsheets.py` | Zero coverage. Deterministic CSV/insert value casting used at load time. Pins the `null`/empty-string asymmetry, right-to-left cast ordering, array/object parsing, and row generators. |
| `test_authorization.py` | `authorization.py` | Security-critical `groupfinder` had only indirect coverage. Covers all synthetic `remoteuser.*` results, user + access-key lookup branches, `_create_principals`, and `is_admin_request`. |
| `test_etag.py` | `etag.py` | Caching-correctness decorators with no test. Covers the HTTP 304 short-circuit, ETag setting, private/no-cache headers, and per-principal ETag distinctness. |
| `test_schema_formats.py` | `schema_formats.py` | `is_uuid` / `is_accession` identity validators, untested; documents the known `re.match` laxness. |
| `test_server_defaults_misc.py` | `server_defaults_misc.py` | All 5 `add_last_modified` branches covered via mocked `get_userid`/`get_now`. |
| `test_predicates.py` | `predicates.py` | View predicates (route matching) untested; covers int→tuple normalization, `text`/`phash`, and `__call__` matching. |
| `test_typeinfo.py` | `typeinfo.extract_schema_links` | Pure recursive schema-walk generator; empty/top-level/nested/array `linkTo` cases plus the `KeyError` edge. |
| `test_util_helpers.py` | `util.py` (pure helpers) | `deduplicate_list`, `ensurelist`, `gunzip_content`, `simple_path_ids`, `recursively_process_field`, `merge_calculated_into_properties` edge branches, and more. |

## Round 2 — follow-up gaps implemented (4 new files, 2 extended)

These are the items round 1 listed under "deliberately left as follow-up", now done:

| Test file | Module under test | What it locks |
|---|---|---|
| `test_local_roles.py` (new) | `local_roles.py` | Security-sensitive principal expansion: `local_principals` (lineage accumulation, callable roles, string-role normalization, `__ac_local_roles_block__` stopping ancestors but keeping the blocking node's own roles, identity-return when nothing matches), `merged_local_principals` (reverse role→principal mapping), and `LocalRolesAuthorizationPolicy.permits` / `principals_allowed_by_permission` end-to-end against a real ACL. |
| `test_calculated_registry.py` (new) | `calculated.py` | `CalculatedProperty` schema `default` guard (ValueError), schema copy + `calculatedProperty: True` marking, condition gating, `attr` dispatch to context methods, fn-arg resolution from the namespace; `ItemNamespace` per-fn memoization and string-name resolution; `CalculatedProperties.props_for` MRO ordering (subclass overrides base), instance-or-class input, and category isolation. |
| `test_json_renderer.py` (new) | `json_renderer.py` | UUID/set/frozenset/datetime adapters, `dumps()` working outside any request (the indexer calls it that way), `JSONResult.serializer` → `BinaryFromJSON` UTF-8 chunk encoding. |
| `test_manager_lru_cache.py` (new) | `cache.py` | `ManagerLRUCache` degrading to a no-op with no threadlocal stack, capacity resolution from registry settings vs. default, and the `afterCompletion` transaction flush (stale-entry protection for retried transactions). |
| `test_edw_hash.py` (extended) | `edw_hash.py` | Previously hash-only golden values; adds `verify()` round-trip, bytes/str secret equivalence, and the exact "Password too long" boundary (454-char max secret, computed from the salt layout). |

## CI flakiness fix folded in (test-only, known issue)

- Re-enabled `@pytest.mark.flaky(max_runs=3, rerun_filter=delay_rerun)` on
  `test_aggregated_items` (was commented out).
- Added the same decorator to `test_indexer_namespacing` and
  `test_indexer_queue_adds_telemetry_id`, which use the same SQS/ES polling pattern as
  their already-protected neighbors but never had it.
- Documented the convention in `AGENTS.md`.

## Post-merge repair

The master merge (`6b7ef67c9`) resolved `pyproject.toml` to `11.31.7` but left this PR's
CHANGELOG entry headed `11.31.1`, which failed the changelog checker in **both** the
Static Checks and UNIT CI jobs. Fixed the heading, then bumped to **11.31.8** for the new
work (checked open PRs for collisions: #321 is at 11.30.8, #308 at 11.24.0 — none).

## Notes / observations (no action taken)

- **`ItemNamespace.__getattr__` sharp edge (not a production bug):** if an
  `ItemNamespace` is constructed with `request=None` (or a request lacking `.registry`),
  looking up an unknown attribute recurses to `RecursionError` instead of raising a clean
  `AttributeError`, because the `reify`-based `registry`/`_properties` properties raise
  `AttributeError` inside `__getattr__` and re-enter it. Unreachable in production
  (`calculate_properties` always passes a real request); documented in `AGENTS.md` for
  future test authors.
- PR #321 also adds a root `AGENTS.md`/`CLAUDE.md`; since master now has them (via #319),
  #321 will need conflict resolution on those files when it takes a master merge — noted
  here because this PR's merge already integrated master's copies.

## Testing

- All new tests pass locally.
- Full **non-ES** suite: `pytest -m "not es and not indexing and not performance"` →
  **790 passed, 28 skipped**, with the single pre-existing environment-specific failure
  (`test_postgresql_fixture.py::test_snovault_db_test_port`), which fails identically on
  a clean baseline.
- `test_indexing.py` (ES-marked, not runnable locally) collects cleanly with the new
  decorators; `delay_rerun` was already imported in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
