### PR TITLE
Fix self-registration privilege-escalation in create_unauthorized_user

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- Add durable project-specific notes here as they are discovered through real work.
+
+## Self-registration field whitelist (`create_unauthorized_user`)
+
+`snovault/authentication.py::create_unauthorized_user` (`POST /create-unauthorized-user`)
+lets an Auth0-authenticated-but-not-yet-registered caller self-register a new `User`. It
+runs with `request.remote_user = 'EMBED'` (grants the `restricted_fields` write
+permission) while validating/creating the User, so the submitted body must be filtered
+before validation or a caller could self-assign privileged fields (e.g.
+`"groups": ["admin"]`, `"status": "deleted"`) on their own new account.
+
+The fix is a **whitelist** (`SELF_REGISTRATION_ALLOWED_FIELDS`), not a blocklist:
+snovault is consumed by apps with different `User` schemas (e.g. fourfront's
+`lab`/`submits_for`/`groups`/`viewing_groups`/`pending_lab` vs. other consumers'
+equivalents), so enumerating "dangerous" field names only protects against the specific
+names an author thought of and silently misses a differently-named privileged field on
+another consumer's schema. A whitelist of known-safe fields fails safe everywhere
+instead.
+
+Current whitelist: `email`, `first_name`, `last_name`, `preferred_email`, `job_title`,
+`institution`, `pending_lab` (plus `was_unauthorized`, which the endpoint force-sets
+itself). `pending_lab` is a deliberate documented exception: although its schema
+`permission` is restricted like the truly privileged fields, it is only a self-declared
+request that an admin must separately review and promote to `lab` before it grants any
+real access — unlike `lab`/`groups`/`submits_for`/`viewing_groups`, which grant real
+access immediately if set. If a future consumer's registration form needs to submit an
+additional legitimate field, add it to `SELF_REGISTRATION_ALLOWED_FIELDS` (in the shared
+snovault base, not a per-app override) after confirming it doesn't itself grant
+privilege.
+
+Note: `smaht-portal` has its own independent, redundant-but-harmless override
+(`smaht_create_unauthorized_user`) that already blocklist-strips
+`groups`/`submission_centers`/`consortia`/`submits_for`/`status`/`uuid` for that app
+specifically. It doesn't need to be touched — it's just now also protected at the
+framework level, as is every other consumer (e.g. fourfront, which has no override at
+all).
+
+## Testing views that call `create_unauthorized_user` (or similar) directly
+
+To unit-test a view function that hits the DB by calling it directly against
+`dummy_request` (bypassing the normal WSGI/`testapp` request cycle):
+- The test's root's ACL must actually grant whatever permission the view relies on.
+  `snovault/tests/root.py::TestRoot.__acl__` had drifted from the production
+  `snovault/root.py::SnovaultRoot.__acl__` and was missing
+  `(Allow, 'remoteuser.EMBED', 'restricted_fields')` — added back since
+  `create_unauthorized_user` depends on it.
+- Set `request.context = request.root` before calling schema validation directly (schema
+  `permission` checks read `request.context`, which real route dispatch would set but a
+  bare `dummy_request` does not).
+- Request the `transaction` fixture (from `snovault/tests/serverfixtures.py`) in the test
+  signature before calling `transaction.commit()` on a direct (non-WSGI) call. Skipping
+  this and calling `import transaction; transaction.commit()` ad hoc bypasses the
+  `zsa_savepoints`/`external_tx` per-test savepoint machinery that every other test
+  relies on for isolation, and leaves real committed rows that leak into and break later
+  tests (e.g. `test_storage.py`'s row-count assertions) even though `external_tx` is
+  autoused.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ snovault
 Change Log
 ----------
 
-11.30.5
+11.30.8
 =======
 
 * Fix a self-registration privilege-escalation vulnerability in

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,18 @@ snovault
 Change Log
 ----------
 
+11.30.5
+=======
+
+* Fix a self-registration privilege-escalation vulnerability in
+  ``create_unauthorized_user`` (``POST /create-unauthorized-user``): the endpoint now
+  whitelists which submitted fields are applied to the newly created User (email,
+  first_name, last_name, preferred_email, job_title, institution, pending_lab), instead
+  of passing the caller-submitted body through almost as-is while running with an
+  elevated (``restricted_fields``) write permission. Previously a caller could self-assign
+  privileged fields (e.g. ``"groups": ["admin"]``) on their own new account.
+
+
 11.30.3
 =======
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.30.5"
+version = "11.30.8"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.30.3"
+version = "11.30.5"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/authentication.py
+++ b/snovault/authentication.py
@@ -741,6 +741,30 @@ def generate_password():
     return password
 
 
+# Fields the self-registration endpoint (create_unauthorized_user) is allowed to accept from
+# the caller-submitted request body. This is a whitelist rather than a blocklist: the endpoint
+# sets request.remote_user = 'EMBED' (which carries the 'restricted_fields' write permission)
+# before validating/creating the User, so any field NOT filtered out here would be written
+# through as submitted, letting a caller self-assign privileged fields such as "groups" or
+# "submits_for". A blocklist only protects against field names its author thought to
+# enumerate, and snovault is consumed by apps with different User schemas (e.g. fourfront's
+# lab/submits_for/groups/viewing_groups vs. other consumers' equivalents), so a whitelist of
+# known-safe fields fails safe across all current and future consumers where a blocklist would
+# not. `pending_lab` is included as a documented exception: although its schema permission is
+# restricted like the truly privileged fields, it is only a self-declared request that an admin
+# must separately review and promote to `lab` before it grants any real access - unlike
+# lab/groups/submits_for/viewing_groups, which grant real access immediately if set.
+SELF_REGISTRATION_ALLOWED_FIELDS = frozenset({
+    'email',
+    'first_name',
+    'last_name',
+    'preferred_email',
+    'job_title',
+    'institution',
+    'pending_lab',
+})
+
+
 @view_config(route_name='create-unauthorized-user', request_method='POST',
              permission=NO_PERMISSION_REQUIRED)
 @debug_log
@@ -825,6 +849,12 @@ def create_unauthorized_user(context, request):
 
     # set user insert props
     del user_props['g-recaptcha-response']
+    # Strip any field not explicitly whitelisted for self-registration before validation, so a
+    # caller cannot self-assign privileged fields (e.g. "groups": ["admin"]) via the elevated
+    # write permission granted below. See SELF_REGISTRATION_ALLOWED_FIELDS for rationale.
+    for key in list(user_props):
+        if key not in SELF_REGISTRATION_ALLOWED_FIELDS:
+            del user_props[key]
     user_props['was_unauthorized'] = True
     user_props['email'] = user_props_email  # lower-cased
     user_coll = request.registry[COLLECTIONS]['User']

--- a/snovault/tests/root.py
+++ b/snovault/tests/root.py
@@ -67,7 +67,8 @@ class TestRoot(Root):
     def __acl__(self):
         acl = acl_from_settings(self.registry.settings) + [
             (Allow, Everyone, ['list', 'search']),
-            (Allow, 'group.admin', ALL_PERMISSIONS)
+            (Allow, 'group.admin', ALL_PERMISSIONS),
+            (Allow, 'remoteuser.EMBED', 'restricted_fields'),
         ] + [(Allow, 'remoteuser.INDEXER', ['view', 'view_raw', 'list', 'index']),
         (Allow, 'remoteuser.EMBED', ['view', 'view_raw', 'expand']),
         (Allow, Everyone, ['visible_for_edit'])]

--- a/snovault/tests/test_create_unauthorized_user.py
+++ b/snovault/tests/test_create_unauthorized_user.py
@@ -1,0 +1,104 @@
+"""
+Regression tests for the self-registration endpoint create_unauthorized_user.
+
+The endpoint runs with request.remote_user = 'EMBED' (permission = restricted_fields) while
+validating/creating the new User, so any caller-submitted field not explicitly filtered out
+would be written through as-is - letting a caller self-assign privileged fields such as
+"groups": ["admin"] on their own new account. These tests confirm the whitelist filtering in
+create_unauthorized_user strips such fields while preserving normal registration behavior.
+"""
+import json
+from unittest import mock
+
+import pytest
+import transaction as transaction_management
+
+from ..authentication import create_unauthorized_user
+from dcicutils.qa_utils import notice_pytest_fixtures
+
+
+def _set_request_json(request, payload):
+    request.body = json.dumps(payload).encode('utf-8')
+    request.content_type = 'application/json'
+
+
+def _mock_recaptcha_success():
+    response = mock.Mock()
+    response.json.return_value = {'success': True}
+    return mock.patch('snovault.authentication.requests.get', return_value=response)
+
+
+@pytest.fixture
+def registration_request(dummy_request, threadlocals):
+    notice_pytest_fixtures(threadlocals)
+    dummy_request.method = 'POST'
+    dummy_request.context = dummy_request.root
+    dummy_request.registry.settings['g.recaptcha.secret'] = 'dummy-recaptcha-secret'
+    return dummy_request
+
+
+def test_create_unauthorized_user_strips_privileged_fields(registration_request, testapp, transaction):
+    """ A registrant who submits privileged fields (groups, status) alongside their
+        legitimate registration info must not have those fields applied to the new User -
+        only the whitelisted self-registration fields (plus the server-forced
+        was_unauthorized=True) should land.
+    """
+    notice_pytest_fixtures(transaction)
+    email = 'sneaky-registrant@example.com'
+    payload = {
+        'email': email,
+        'first_name': 'Sneaky',
+        'last_name': 'Registrant',
+        'groups': ['admin'],
+        'status': 'deleted',
+        'g-recaptcha-response': 'dummy-response',
+    }
+    _set_request_json(registration_request, payload)
+    registration_request._auth0_authenticated = email
+
+    with _mock_recaptcha_success():
+        result = create_unauthorized_user(None, registration_request)
+
+    assert result['status'] == 'success'
+    transaction_management.commit()
+
+    item_uri = result['@graph'][0]
+    user = testapp.get('{}?frame=object'.format(item_uri)).json
+
+    assert user['email'] == email
+    assert user['first_name'] == 'Sneaky'
+    assert user['last_name'] == 'Registrant'
+    assert user['was_unauthorized'] is True
+    # Privileged fields the registrant tried to self-assign must not have landed.
+    assert 'groups' not in user
+    assert user['status'] == 'current'  # schema default, NOT the submitted 'deleted'
+
+
+def test_create_unauthorized_user_normal_registration_unaffected(registration_request, testapp, transaction):
+    """ A normal registration with no extra/privileged fields must still succeed with the
+        expected fields applied.
+    """
+    notice_pytest_fixtures(transaction)
+    email = 'normal-registrant@example.com'
+    payload = {
+        'email': email,
+        'first_name': 'Normal',
+        'last_name': 'Registrant',
+        'g-recaptcha-response': 'dummy-response',
+    }
+    _set_request_json(registration_request, payload)
+    registration_request._auth0_authenticated = email
+
+    with _mock_recaptcha_success():
+        result = create_unauthorized_user(None, registration_request)
+
+    assert result['status'] == 'success'
+    transaction_management.commit()
+
+    item_uri = result['@graph'][0]
+    user = testapp.get('{}?frame=object'.format(item_uri)).json
+
+    assert user['email'] == email
+    assert user['first_name'] == 'Normal'
+    assert user['last_name'] == 'Registrant'
+    assert user['was_unauthorized'] is True


### PR DESCRIPTION
## Vulnerability

`create_unauthorized_user` (`POST /create-unauthorized-user`) lets an
Auth0-authenticated-but-not-yet-registered caller self-register a new `User`. The handler
sets `request.remote_user = 'EMBED'` — an internal role that carries the
`restricted_fields` write permission — *before* validating and creating the User, but
took the caller-submitted JSON body almost as-is. That meant a caller could include
privileged fields in their own registration body (e.g. `"groups": ["admin"]`,
`"status": "deleted"`) and have them applied to their new account: a privilege-escalation
bug.

`smaht-portal` already independently patched this in its own app-level override
(`smaht_create_unauthorized_user`), by stripping a hardcoded list of fields (`groups`,
`submission_centers`, `consortia`, `submits_for`, `status`, `uuid`). This PR fixes it
directly in the shared snovault base implementation instead, so every consumer gets the
protection automatically — including fourfront, which currently has **no** override at
all and was unprotected.

## Fix: whitelist, not blocklist

I chose a **whitelist** of fields the endpoint accepts, rather than generalizing smaht's
blocklist:

- snovault is consumed by apps with different `User` schemas (fourfront's
  `lab`/`submits_for`/`groups`/`viewing_groups`/`pending_lab` vs. smaht's
  `groups`/`submission_centers`/`consortia`/`submits_for`/`status`/`uuid`, vs. whatever a
  future consumer adds). A blocklist only protects against the specific field names its
  author thought to enumerate, and silently misses a differently-named privileged field
  on another consumer's schema — exactly the weakness smaht's own fix has, just not yet
  exploited there.
- The endpoint's own docstring says *"For CGAP, an 'unauthorized user' has cgap-core
  project association and nothing else"* — it was only ever meant to create a
  bare-minimum placeholder account, which a whitelist fits more naturally than a
  blocklist.

I inspected the actual registration front-ends (`UserRegistrationForm.js`) in both
fourfront and smaht-portal to determine the real field set a legitimate registration
submits:
- Both: `email`, `first_name`, `last_name`, `g-recaptcha-response`
- smaht-portal additionally: `institution`
- fourfront additionally: `preferred_email`, `job_title`, `pending_lab`

Final whitelist (`SELF_REGISTRATION_ALLOWED_FIELDS` in `snovault/authentication.py`):
`email`, `first_name`, `last_name`, `preferred_email`, `job_title`, `institution`,
`pending_lab` (plus `was_unauthorized`, which the endpoint force-sets itself regardless
of what's whitelisted).

**`pending_lab` exception:** its schema `permission` is restricted just like the truly
privileged fields (`lab`, `groups`, `submits_for`, `viewing_groups`), but semantically it
is only a self-declared *request* — an admin must separately review it and promote it to
`lab` before it grants any real access. Unlike the others, allowing a caller to set
`pending_lab` on their own new account cannot itself grant privilege, so it's safe to
keep in the whitelist and avoids silently breaking fourfront's existing "request a lab
during registration" UX.

## Testing

No test coverage existed for this endpoint at all. Added
`snovault/tests/test_create_unauthorized_user.py` with two tests using the existing
`dummy_request`/`testapp` fixtures (recaptcha HTTP call mocked):
- A registrant submitting `groups: ["admin"]` and `status: "deleted"` alongside legit
  fields: asserts `groups` is absent and `status` is the schema default (`current`), not
  the submitted value, while `email`/`first_name`/`last_name`/`was_unauthorized=True`
  land correctly.
- A normal registration with no extra fields: unaffected, succeeds as before.

Verified both tests fail on the pre-fix code (the privilege-escalation test fails without
the fix, passes with it) and confirmed they don't leak DB state into other tests (see
AGENTS.md notes on test-harness gotchas discovered along the way — `TestRoot`'s ACL was
missing `(Allow, 'remoteuser.EMBED', 'restricted_fields')`, present in production
`SnovaultRoot`, needed for schema validation to actually run).

Full non-ES suite: 450 passed, 28 skipped, only the pre-existing
`test_snovault_db_test_port` baseline failure (unrelated, environment-specific — fails on
a clean checkout too).

## Not touched

`smaht-portal`'s `smaht_create_unauthorized_user` override is untouched — it's now
redundant (its own blocklist already independently fixed this for that app) but harmless,
and every consumer (including it) is now also protected at the framework level.

## Version / changelog

Bumped `11.30.3` -> `11.30.5` (checked open PRs against this repo first — several land on
`11.30.4`/`11.31.0`, so picked a number that doesn't collide) and added a `CHANGELOG.rst`
entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
