### PR TITLE
Fix attachment downloads and JWT algorithm allowlist

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,16 @@ snovault
 Change Log
 ----------
 
+11.32.2
+=======
+
+* Fix a stored-XSS risk in attachment downloads: RDB-backed downloads and S3 presigned
+  URLs now force ``Content-Disposition: attachment`` so uploaded HTML/SVG/etc. content is
+  downloaded instead of rendered inline. Attachment filenames used in the header are
+  sanitized to remove control characters and quotes.
+* Remove the JWT ``none`` algorithm from the decode allow-list, avoiding a well-known
+  unsigned-token authentication-bypass footgun.
+
 11.32.1
 =======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.32.1"
+version = "11.32.2"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/attachment.py
+++ b/snovault/attachment.py
@@ -1,6 +1,7 @@
 import magic
 import mimetypes
 import os
+import re
 import uuid
 
 from base64 import b64decode
@@ -33,6 +34,21 @@ log = getLogger(__name__)
 
 def file_type(filename):
     return os.path.splitext(filename)[1]
+
+
+# Matches any ASCII control character (including CR/LF) so it can be stripped from
+# values that get embedded in HTTP header fields, preventing header injection /
+# response splitting via a crafted attachment filename.
+_CONTROL_CHARS_RE = re.compile(r'[\x00-\x1f\x7f]')
+
+
+def safe_content_disposition_filename(filename):
+    """ Sanitize a filename for safe use inside a Content-Disposition header value:
+        strips control characters (notably \\r and \\n, which could otherwise inject
+        extra header lines) and double quotes (which would break out of the quoted
+        filename value).
+    """
+    return _CONTROL_CHARS_RE.sub('', filename).replace('"', '')
 
 
 FALLBACK_MIMETYPES = {
@@ -313,5 +329,8 @@ def download(context, request):
     blob = blob_storage.get_blob(download_meta)
     headers = {
         'Content-Type': mimetype,
+        # Force a download rather than inline rendering so that uploaded HTML/SVG/etc.
+        # content cannot execute as script in the portal's origin (stored XSS).
+        'Content-Disposition': 'attachment; filename="%s"' % safe_content_disposition_filename(filename),
     }
     return Response(body=blob, headers=headers)

--- a/snovault/authentication.py
+++ b/snovault/authentication.py
@@ -47,7 +47,10 @@ JWT_ENCODING_ALGORITHM = 'HS256'
 # default_algorithms() method used to be what we've got in JWT_ALL_ALGORITHMS here.
 #  -kmp 15-May-2020
 
-JWT_ALL_ALGORITHMS = ['ES512', 'RS384', 'HS512', 'ES256', 'none',
+# 'none' is intentionally excluded: allowing it in the decode algorithm list means an
+# attacker-supplied, unsigned token (alg=none) would be accepted as authentic, which is a
+# well-known JWT authentication bypass. See CWE-347 / "JWT alg:none" attack.
+JWT_ALL_ALGORITHMS = ['ES512', 'RS384', 'HS512', 'ES256',
                       'RS256', 'PS512', 'ES384', 'HS384', 'ES521',
                       'PS384', 'HS256', 'PS256', 'RS512']
 

--- a/snovault/storage.py
+++ b/snovault/storage.py
@@ -1,5 +1,6 @@
 import boto3
 from copy import deepcopy
+import re
 import structlog
 import uuid
 
@@ -21,6 +22,20 @@ from .interfaces import BLOBS, DBSESSION, STORAGE, TYPES
 log = structlog.getLogger(__name__)
 
 _DBSESSION = None
+
+# Matches any ASCII control character (including CR/LF) so it can be stripped from
+# values that get embedded in HTTP header fields, preventing header injection /
+# response splitting via a crafted attachment filename.
+_CONTROL_CHARS_RE = re.compile(r'[\x00-\x1f\x7f]')
+
+
+def _safe_content_disposition_filename(filename):
+    """ Sanitize a filename for safe use inside a Content-Disposition header value:
+        strips control characters (notably \\r and \\n, which could otherwise inject
+        extra header lines) and double quotes (which would break out of the quoted
+        filename value).
+    """
+    return _CONTROL_CHARS_RE.sub('', filename).replace('"', '')
 
 
 def includeme(config):
@@ -778,10 +793,18 @@ class S3BlobStorage(object):
             url to the data
         """
         bucket_name, key = self._get_bucket_key(download_meta)
+        params = {'Bucket': bucket_name, 'Key': key}
+        # Force a download rather than inline rendering so that uploaded HTML/SVG/etc.
+        # content cannot execute as script when opened from the presigned URL.
+        filename = download_meta.get('download')
+        if filename:
+            params['ResponseContentDisposition'] = (
+                'attachment; filename="%s"' % _safe_content_disposition_filename(filename)
+            )
         location = self.s3.generate_presigned_url(
             ClientMethod='get_object',
             ExpiresIn=36*60*60,
-            Params={'Bucket': bucket_name, 'Key': key})
+            Params=params)
         return location
 
     def get_blob(self, download_meta):

--- a/snovault/tests/test_attachment.py
+++ b/snovault/tests/test_attachment.py
@@ -5,8 +5,16 @@ import boto3
 from base64 import b64decode
 from dcicutils.ff_utils import parse_s3_bucket_and_key_url
 from unittest import mock
+from urllib.parse import parse_qs, urlparse
 from .. import attachment as attachment_module
-from ..attachment import file_type, guess_mime_type, system_mime_type, fallback_mime_type, DEFAULT_FALLBACK_MIME_TYPE
+from ..attachment import (
+    DEFAULT_FALLBACK_MIME_TYPE,
+    fallback_mime_type,
+    file_type,
+    guess_mime_type,
+    safe_content_disposition_filename,
+    system_mime_type,
+)
 
 
 # Test for blob storage
@@ -57,6 +65,7 @@ class TestAttachment:
         url = testing_download + '/' + attachment['href']
         res = testapp.get(url)
         assert res.content_type == 'image/png'
+        assert res.headers['Content-Disposition'] == 'attachment; filename="red-dot.png"'
         assert res.body == b64decode(RED_DOT.split(',', 1)[1])
 
         assert attachment2['href'] == '@@download/attachment2/blue-dot.png'
@@ -304,6 +313,8 @@ class TestAttachmentEncrypted:
 
         res = encrypted_testapp.get(url)  # follow redirect to s3
         assert res.content_type == 'application/json'
+        query = parse_qs(urlparse(res.location).query)
+        assert query['response-content-disposition'] == ['attachment; filename="red-dot.png"']
         self.attachment_is_red_dot(boto3.client('s3'), res.location)
 
         assert attachment2['href'] == '@@download/attachment2/blue-dot.png'
@@ -487,6 +498,11 @@ def test_file_type():
 
     assert file_type("xyz/foo.abc") == ".abc"
     assert file_type("foo.abc") == ".abc"
+
+
+def test_safe_content_disposition_filename():
+    assert safe_content_disposition_filename('safe-name.png') == 'safe-name.png'
+    assert safe_content_disposition_filename('bad\r\n"x.png') == 'badx.png'
 
 
 def test_system_mime_type():

--- a/snovault/tests/test_authentication.py
+++ b/snovault/tests/test_authentication.py
@@ -4,7 +4,12 @@ from pyramid.interfaces import IAuthenticationPolicy
 from pyramid.security import Authenticated, Everyone
 from pyramid.testing import DummyRequest
 from zope.interface.verify import verifyObject, verifyClass
-from ..authentication import NamespacedAuthenticationPolicy
+from ..authentication import JWT_ALL_ALGORITHMS, JWT_DECODING_ALGORITHMS, NamespacedAuthenticationPolicy
+
+
+def test_jwt_algorithms_exclude_none():
+    assert 'none' not in JWT_ALL_ALGORITHMS
+    assert 'none' not in JWT_DECODING_ALGORITHMS
 
 
 class TestNamespacedAuthenticationPolicy(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Force uploaded attachment downloads through `Content-Disposition: attachment` for RDB-backed downloads and S3 presigned URLs.
- Sanitize attachment filenames before embedding them in `Content-Disposition` values.
- Remove `none` from JWT decoding algorithm allow-lists.

## Tests
- `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 python -m pytest snovault/tests/test_attachment.py snovault/tests/test_authentication.py -q`
- `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 python -m pytest snovault/tests/test_attachment.py::test_safe_content_disposition_filename snovault/tests/test_authentication.py::test_jwt_algorithms_exclude_none -q`

Note: the same suite failed before test execution under the inherited `LC_ALL=C` shell because Postgres `initdb` rejected the locale; rerunning with explicit `en_US.UTF-8` passed.
