### PR TITLE
Five low-risk Elasticsearch performance/efficiency fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,3 +105,54 @@ jobs:
           TEST_JOB_ID: sno-test-unit-${{ github.run_number }}-${{ matrix.python_version }}-
         run: |
           poetry run wipe-test-indices $TEST_JOB_ID search-fourfront-testing-opensearch-kqm7pliix4wgiu4druk2indorq.us-east-1.es.amazonaws.com:443
+
+  # Tags and publishes the version declared in pyproject.toml after a successful test run on
+  # master. Runs in the same job as the tag push (rather than relying on main-publish.yml's
+  # tag-triggered `on: push: tags` event) because GitHub Actions does not start a new workflow
+  # run from a push made with the default GITHUB_TOKEN. Idempotent: skips entirely if the tag
+  # for the current version already exists, so unrelated master merges are no-ops and only a
+  # version bump triggers a release.
+  publish:
+    name: Tag and Publish to PyPI
+    needs: build
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install Deps
+        run: |
+          make configure
+
+      - name: Determine version and check for existing tag
+        id: version
+        run: |
+          VERSION=$(poetry version -s)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if git ls-remote --tags origin "refs/tags/$VERSION" | grep -q "refs/tags/$VERSION$"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: ${{ steps.version.outputs.exists == 'false' }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.version.outputs.version }}"
+
+      - name: Publish to PyPI
+        if: ${{ steps.version.outputs.exists == 'false' }}
+        env:
+          PYPI_USER: ${{ secrets.PYPI_USER }}
+          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          make configure
+          make publish-for-ga

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,23 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 
 - Add durable project-specific notes here as they are discovered through real work.
 
+## Automatic tag-and-publish-on-master release workflow
+
+`.github/workflows/main.yml`'s `publish` job (`needs: build`, runs only on
+`push` to `master`) reads the version from `pyproject.toml` (`poetry version -s`) and, if
+no git tag for that version exists yet, tags and publishes to PyPI **in the same job run**.
+It deliberately does not rely on `.github/workflows/main-publish.yml`'s tag-triggered
+`on: push: tags` event, because GitHub Actions does not start a new workflow run from a tag
+pushed using the default `GITHUB_TOKEN` (anti-recursion rule) — `main-publish.yml` remains
+only for manual/`workflow_dispatch` publishing. The tag-existence check is the idempotency
+guard: an unchanged version on a master merge is a no-op; only a version bump in
+`pyproject.toml` triggers a real tag+publish. `publish-for-ga` itself (dcicutils
+`publish-to-pypi`) is also idempotent as a second safety net. The workflow-level
+`permissions:` block in `main.yml` stays `id-token: write` / `contents: read` (needed by the
+`build` job's AWS OIDC auth); `contents: write` (needed to push the tag) is scoped to the
+`publish` job only, since a job-level `permissions:` block replaces rather than merges with
+the workflow-level one.
+
 ## Self-registration field whitelist (`create_unauthorized_user`)
 
 `snovault/authentication.py::create_unauthorized_user` (`POST /create-unauthorized-user`)
@@ -229,3 +246,10 @@ request lacking `.registry`), the reify body raises `AttributeError`, which re-e
 reachable in production (`calculate_properties` always passes a real request), but when
 unit-testing the namespace directly, inject `registry`/`_properties` via the `ns` dict —
 see `snovault/tests/test_calculated_registry.py`.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,26 @@ follows the queue-then-poll pattern, include that decorator — several timing f
 traced back to tests that used the pattern but were missing it
 (`test_aggregated_items`, `test_indexer_namespacing`, `test_indexer_queue_adds_telemetry_id`).
 
+## Testing `filter_invalidation_scope`'s shared-list-mutation fix: build a diffs dict with a real parent extension
+
+`filter_invalidation_scope` (`snovault/elasticsearch/indexer_utils.py`) builds its internal
+`diffs` dict fresh per call from `build_diff_metadata`, then does
+`all_possible_diffs = list(diffs.get(base_field_item_type, []))` before `.extend`-ing in
+parent/child-type diffs — the `list(...)` copy exists so those `.extend` calls don't mutate
+the dict's own stored list permanently.
+
+A regression test that only feeds a single-type diff (e.g. `['SomeType.field']`) does
+**not** exercise this: with only one key in `diffs`, every `diffs.get(parent_or_child, [])`
+lookup returns `[]`, so `.extend([])` is a no-op whether or not the list was copied — the
+test passes on both the buggy and fixed code. To actually discriminate, mock
+`build_diff_metadata` to return a `diffs` dict with a **populated parent-type entry** (e.g.
+`{'TestingBiosampleSno': ['identifier'], 'SomeParentType': ['other_field']}` plus
+`child_to_parent_type = {'TestingBiosampleSno': ['SomeParentType']}`), while still using the
+real `testapp.app.registry` so `crawl_schema` can resolve the real embed path — see
+`test_invalidation_scope_does_not_mutate_diffs_dict` in
+`snovault/tests/test_invalidation_scope.py`. Before trusting a regression test for a
+mutation/aliasing bug, temporarily revert the fix and confirm the test actually fails.
+
 ## `ItemNamespace.__getattr__` sharp edge (calculated.py)
 
 `ItemNamespace.__getattr__` resolves unknown names via `self.registry` / `self._properties`

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,14 @@ Change Log
   * ``ElasticSearchStorage.__iter__`` no longer fetches each document's full ``_source``
     just to discard it and yield the ``_id``.
 
+* Add automatic tag-and-publish-on-master release workflow: on a successful push to
+  ``master``, a new ``publish`` job in ``.github/workflows/main.yml`` (gated behind the
+  existing test matrix via ``needs: build``) reads the version from ``pyproject.toml`` and,
+  if no git tag for that version exists yet, tags and publishes it to PyPI in the same job
+  run (tagging and publishing separately would not work, since GitHub Actions does not
+  trigger a new workflow run from a tag pushed with the default ``GITHUB_TOKEN``). Merges
+  that don't change the version are no-ops.
+
 11.32.2
 =======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,29 @@ snovault
 Change Log
 ----------
 
+11.32.3
+=======
+
+* Five low-risk Elasticsearch performance/efficiency fixes identified by a performance
+  review (no behavior changes intended):
+
+  * ``ElasticSearchStorage.get_rev_links`` no longer fetches full documents just to read
+    their uuid - it restricts ``_source`` and reads the uuid off the ES hit's own ``_id``
+    (which is always the item's uuid).
+  * ``QueueManager.send_messages`` no longer sleeps 1ms per queued SQS message to
+    guarantee unique wall-clock-based batch entry ``Id``s; entry ``Id``s are now derived
+    from each entry's position within its batch, which is all SQS requires for
+    uniqueness.
+  * ``filter_invalidation_scope`` no longer mutates the shared per-type diff list it
+    reads from (a latent aliasing bug), and no longer calls ``determine_child_types``
+    twice per matched embed.
+  * ``es-index-data`` (``snovault/commands/es_index_data.py``) now stops posting to
+    ``/index`` once the indexer queue has been empty and indexed nothing for two
+    consecutive iterations, instead of unconditionally running the full 100-iteration
+    cap.
+  * ``ElasticSearchStorage.__iter__`` no longer fetches each document's full ``_source``
+    just to discard it and yield the ``_id``.
+
 11.32.2
 =======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,9 +23,9 @@ Change Log
     reads from (a latent aliasing bug), and no longer calls ``determine_child_types``
     twice per matched embed.
   * ``es-index-data`` (``snovault/commands/es_index_data.py``) now stops posting to
-    ``/index`` once the indexer queue has been empty and indexed nothing for two
-    consecutive iterations, instead of unconditionally running the full 100-iteration
-    cap.
+    ``/index`` once the indexer queue (including in-flight/invisible retryable
+    messages) has been empty and indexed nothing for two consecutive iterations,
+    instead of unconditionally running the full 100-iteration cap.
   * ``ElasticSearchStorage.__iter__`` no longer fetches each document's full ``_source``
     just to discard it and yield the ``_id``.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.32.2"
+version = "11.32.3"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/commands/es_index_data.py
+++ b/snovault/commands/es_index_data.py
@@ -5,9 +5,15 @@ import webtest
 from pyramid.paster import get_app
 from dcicutils.log_utils import set_logging
 
+from snovault.elasticsearch.interfaces import INDEXER_QUEUE
+
 
 EPILOG = __doc__
 INDEXING_RUN_ITERATIONS = 100
+# require this many consecutive empty-queue/zero-indexed iterations before breaking
+# early, since queue_is_empty relies on SQS's approximate (eventually-consistent)
+# message counts
+CONSECUTIVE_EMPTY_ITERATIONS_TO_STOP = 2
 
 
 def run(app, uuids=None):
@@ -23,8 +29,17 @@ def run(app, uuids=None):
         post_body['uuids'] = list(uuids)
         testapp.post_json('/index', post_body)
     else:
+        indexer_queue = app.registry[INDEXER_QUEUE]
+        consecutive_empty = 0
         for _ in range(INDEXING_RUN_ITERATIONS):
-            testapp.post_json('/index', post_body)
+            response = testapp.post_json('/index', post_body)
+            indexing_count = response.json.get('indexing_count', 0)
+            if indexing_count == 0 and indexer_queue.queue_is_empty(secondary_only=False):
+                consecutive_empty += 1
+                if consecutive_empty >= CONSECUTIVE_EMPTY_ITERATIONS_TO_STOP:
+                    break
+            else:
+                consecutive_empty = 0
 
 
 def main():

--- a/snovault/commands/es_index_data.py
+++ b/snovault/commands/es_index_data.py
@@ -34,7 +34,8 @@ def run(app, uuids=None):
         for _ in range(INDEXING_RUN_ITERATIONS):
             response = testapp.post_json('/index', post_body)
             indexing_count = response.json.get('indexing_count', 0)
-            if indexing_count == 0 and indexer_queue.queue_is_empty(secondary_only=False):
+            if indexing_count == 0 and indexer_queue.queue_is_empty(secondary_only=False,
+                                                                     include_inflight=True):
                 consecutive_empty += 1
                 if consecutive_empty >= CONSECUTIVE_EMPTY_ITERATIONS_TO_STOP:
                     break

--- a/snovault/elasticsearch/esstorage.py
+++ b/snovault/elasticsearch/esstorage.py
@@ -220,6 +220,7 @@ class ElasticSearchStorage(object):
         """
         search = Search(using=self.es, index=self.index)
         search = search.extra(size=SEARCH_MAX)
+        search = search.source(False)
         # rel links use '~' instead of '.' due to ES field restraints
         proc_rel = rel.replace('.', '~')
         # had to use ** kw notation because of variable in field name
@@ -227,7 +228,7 @@ class ElasticSearchStorage(object):
         if item_types:
             search = search.filter('terms', item_type=item_types)
         hits = search.execute()
-        return [hit.to_dict().get('uuid', hit.to_dict().get('_id')) for hit in hits]
+        return [hit.meta.id for hit in hits]
 
     def get_sids_by_uuids(self, rids):
         """
@@ -369,13 +370,16 @@ class ElasticSearchStorage(object):
         Return a generator that yields string uuids of all documents matching
         given item types (through kwargs). Use all item types if none provided
         """
-        query = {'query': {
-            'bool': {
-                'filter': {'terms': {'item_type': item_types}} if item_types else {'match_all': {}}
+        query = {
+            '_source': False,
+            'query': {
+                'bool': {
+                    'filter': {'terms': {'item_type': item_types}} if item_types else {'match_all': {}}
+                }
             }
-        }}
+        }
         for hit in scan(self.es, index=self.index, query=query):
-            yield hit.get('uuid', hit.get('_id'))
+            yield hit['_id']
 
     def __len__(self, *item_types):
         """

--- a/snovault/elasticsearch/indexer_queue.py
+++ b/snovault/elasticsearch/indexer_queue.py
@@ -553,19 +553,19 @@ class QueueManager(object):
         failed = []
         for msg_batch in self.chunk_messages(items, self.send_batch_size):
             entries = []
-            for msg in msg_batch:
+            for i, msg in enumerate(msg_batch):
                 # quick workaround to communicate with old style messages
+                # Id only needs to be unique within this single batch request
                 if isinstance(msg, dict):
                     entries.append({
-                        'Id': str(int(time.time() * 1000000)),
+                        'Id': str(i),
                         'MessageBody': json.dumps(msg)
                     })
                 else:
                     entries.append({
-                        'Id': str(int(time.time() * 1000000)),
+                        'Id': str(i),
                         'MessageBody': msg
                     })
-                time.sleep(0.001)  # ensure time-based Ids are not repeated
             response = self.client.send_message_batch(
                 QueueUrl=queue_url,
                 Entries=entries

--- a/snovault/elasticsearch/indexer_utils.py
+++ b/snovault/elasticsearch/indexer_utils.py
@@ -283,19 +283,20 @@ def filter_invalidation_scope(registry, diff, invalidated_with_type, secondary_u
             # grab terminal field based on the actual linkTo depth
             terminal_field = '.'.join(split_embed[link_depth:])
 
-            # Collect diffs from all possible item_types
-            all_possible_diffs = diffs.get(base_field_item_type, [])
+            # Collect diffs from all possible item_types (copy so we never mutate the shared
+            # list stored in diffs)
+            all_possible_diffs = list(diffs.get(base_field_item_type, []))
 
             # A linkTo target could be a child type (in that we need to look at parent type diffs as well)
             parent_types = child_to_parent_type.get(base_field_item_type, None)
             if parent_types is not None:
-                for parent_type in child_to_parent_type.get(base_field_item_type, []):
+                for parent_type in parent_types:
                     all_possible_diffs.extend(diffs.get(parent_type, []))
 
             # It could also be parent type (in that we must look at all potential child types)
             child_types = determine_child_types(registry, base_field_item_type)
             if child_types is not None:
-                for child_type in determine_child_types(registry, base_field_item_type) or []:
+                for child_type in child_types:
                     all_possible_diffs.extend(diffs.get(child_type, []))
 
             if not all_possible_diffs:  # no diffs match this embed

--- a/snovault/tests/test_es_index_data.py
+++ b/snovault/tests/test_es_index_data.py
@@ -2,7 +2,9 @@
 
 `run()` used to unconditionally POST to /index INDEXING_RUN_ITERATIONS (100)
 times even after the queue had drained, burning ~6s of long-polling per wasted
-iteration. It should now break out once the queue is empty and the response
+iteration. It should now break out once the queue is empty (including
+in-flight/invisible retryable messages - see
+test_run_does_not_break_while_inflight_messages_remain) and the response
 reports no indexing work, requiring two consecutive such iterations to guard
 against SQS's approximate/eventually-consistent message counts.
 
@@ -35,10 +37,12 @@ def make_testapp_with_indexing_counts(counts):
 
 
 def test_run_breaks_after_two_consecutive_empty_iterations():
-    # every iteration after the first reports an empty queue and 0 indexed
+    # every iteration after the first reports an empty queue (including no in-flight
+    # work) and 0 indexed
     counts = [5, 0, 0] + [0] * INDEXING_RUN_ITERATIONS
     testapp = make_testapp_with_indexing_counts(counts)
-    app, indexer_queue = make_app(queue_is_empty_side_effect=lambda secondary_only: True)
+    app, indexer_queue = make_app(
+        queue_is_empty_side_effect=lambda secondary_only, include_inflight: True)
 
     with mock.patch('snovault.commands.es_index_data.webtest.TestApp', return_value=testapp):
         run(app)
@@ -52,7 +56,8 @@ def test_run_breaks_after_two_consecutive_empty_iterations():
 def test_run_uses_full_iteration_cap_when_queue_never_empties():
     counts = [1] * INDEXING_RUN_ITERATIONS
     testapp = make_testapp_with_indexing_counts(counts)
-    app, indexer_queue = make_app(queue_is_empty_side_effect=lambda secondary_only: False)
+    app, indexer_queue = make_app(
+        queue_is_empty_side_effect=lambda secondary_only, include_inflight: False)
 
     with mock.patch('snovault.commands.es_index_data.webtest.TestApp', return_value=testapp):
         run(app)
@@ -60,9 +65,60 @@ def test_run_uses_full_iteration_cap_when_queue_never_empties():
     assert testapp.post_json.call_count == INDEXING_RUN_ITERATIONS
 
 
+def test_run_checks_queue_emptiness_including_inflight_messages():
+    """ Regression test: queue_is_empty defaults include_inflight=False, which only
+    reflects visible primary/secondary/DLQ counts. A retryable indexing failure puts a
+    message in flight (invisible) for up to its configured visibility timeout
+    (indexer.py's replace_messages uses vis_timeout=180) - if the emptiness check omits
+    in-flight messages, the command can stop while that message is still scheduled to
+    reappear and be retried, leaving it unindexed. run() must pass
+    include_inflight=True. """
+    testapp = make_testapp_with_indexing_counts([0, 0, 0])
+    app, indexer_queue = make_app(
+        queue_is_empty_side_effect=lambda secondary_only, include_inflight: True)
+
+    with mock.patch('snovault.commands.es_index_data.webtest.TestApp', return_value=testapp):
+        run(app)
+
+    for call in indexer_queue.queue_is_empty.call_args_list:
+        assert call.kwargs == {'secondary_only': False, 'include_inflight': True}
+
+
+def test_run_does_not_break_while_inflight_messages_remain():
+    """ Models a queue whose visible counts are empty throughout (so the old,
+    include_inflight=False check would consider every iteration "empty"), but which
+    still reports in-flight (invisible/retryable) work for the first several
+    iterations. The command must keep polling until the in-flight work clears, rather
+    than exiting after two consecutive visible-empty iterations. """
+    inflight_clears_after = 4  # first 4 calls report in-flight work remaining
+    calls_made = {'n': 0}
+
+    def queue_is_empty_side_effect(secondary_only, include_inflight):
+        calls_made['n'] += 1
+        assert secondary_only is False
+        assert include_inflight is True
+        # while in-flight work remains, the queue is not considered empty at all
+        return calls_made['n'] > inflight_clears_after
+
+    # indexing_count is 0 throughout - only in-flight state should gate the break
+    counts = [0] * (inflight_clears_after + 2)
+    testapp = make_testapp_with_indexing_counts(counts)
+    app, indexer_queue = make_app(queue_is_empty_side_effect=queue_is_empty_side_effect)
+
+    with mock.patch('snovault.commands.es_index_data.webtest.TestApp', return_value=testapp):
+        run(app)
+
+    # iterations 1-4: queue_is_empty() is False (in-flight remains) -> consecutive_empty
+    #   stays 0 each time
+    # iteration 5: queue_is_empty() becomes True -> consecutive_empty=1
+    # iteration 6: queue_is_empty() True again -> consecutive_empty=2 -> break
+    assert testapp.post_json.call_count == inflight_clears_after + 2
+
+
 def test_run_with_uuids_posts_once_regardless_of_queue_state():
     testapp = make_testapp_with_indexing_counts([1])
-    app, indexer_queue = make_app(queue_is_empty_side_effect=lambda secondary_only: True)
+    app, indexer_queue = make_app(
+        queue_is_empty_side_effect=lambda secondary_only, include_inflight: True)
 
     with mock.patch('snovault.commands.es_index_data.webtest.TestApp', return_value=testapp):
         run(app, uuids=['abc-123'])

--- a/snovault/tests/test_es_index_data.py
+++ b/snovault/tests/test_es_index_data.py
@@ -1,0 +1,71 @@
+"""Unit tests for es_index_data.run's early-exit behavior (Finding 13):
+
+`run()` used to unconditionally POST to /index INDEXING_RUN_ITERATIONS (100)
+times even after the queue had drained, burning ~6s of long-polling per wasted
+iteration. It should now break out once the queue is empty and the response
+reports no indexing work, requiring two consecutive such iterations to guard
+against SQS's approximate/eventually-consistent message counts.
+
+webtest.TestApp is mocked out entirely so no real WSGI app / DB / ES is
+needed - only the response.json shape and registry[INDEXER_QUEUE] interface
+are exercised.
+"""
+from unittest import mock
+
+from ..commands.es_index_data import run, INDEXING_RUN_ITERATIONS
+
+
+def make_app(queue_is_empty_side_effect):
+    indexer_queue = mock.MagicMock()
+    indexer_queue.queue_is_empty.side_effect = queue_is_empty_side_effect
+    app = mock.MagicMock()
+    app.registry = {'indexer_queue': indexer_queue}
+    return app, indexer_queue
+
+
+def make_testapp_with_indexing_counts(counts):
+    responses = []
+    for count in counts:
+        response = mock.MagicMock()
+        response.json = {'indexing_count': count}
+        responses.append(response)
+    testapp = mock.MagicMock()
+    testapp.post_json.side_effect = responses
+    return testapp
+
+
+def test_run_breaks_after_two_consecutive_empty_iterations():
+    # every iteration after the first reports an empty queue and 0 indexed
+    counts = [5, 0, 0] + [0] * INDEXING_RUN_ITERATIONS
+    testapp = make_testapp_with_indexing_counts(counts)
+    app, indexer_queue = make_app(queue_is_empty_side_effect=lambda secondary_only: True)
+
+    with mock.patch('snovault.commands.es_index_data.webtest.TestApp', return_value=testapp):
+        run(app)
+
+    # 1st iteration: indexing_count=5 (not empty) -> consecutive_empty resets to 0
+    # 2nd iteration: indexing_count=0 and queue empty -> consecutive_empty=1
+    # 3rd iteration: indexing_count=0 and queue empty -> consecutive_empty=2 -> break
+    assert testapp.post_json.call_count == 3
+
+
+def test_run_uses_full_iteration_cap_when_queue_never_empties():
+    counts = [1] * INDEXING_RUN_ITERATIONS
+    testapp = make_testapp_with_indexing_counts(counts)
+    app, indexer_queue = make_app(queue_is_empty_side_effect=lambda secondary_only: False)
+
+    with mock.patch('snovault.commands.es_index_data.webtest.TestApp', return_value=testapp):
+        run(app)
+
+    assert testapp.post_json.call_count == INDEXING_RUN_ITERATIONS
+
+
+def test_run_with_uuids_posts_once_regardless_of_queue_state():
+    testapp = make_testapp_with_indexing_counts([1])
+    app, indexer_queue = make_app(queue_is_empty_side_effect=lambda secondary_only: True)
+
+    with mock.patch('snovault.commands.es_index_data.webtest.TestApp', return_value=testapp):
+        run(app, uuids=['abc-123'])
+
+    assert testapp.post_json.call_count == 1
+    indexer_queue.queue_is_empty.assert_not_called()

--- a/snovault/tests/test_esstorage_efficiency.py
+++ b/snovault/tests/test_esstorage_efficiency.py
@@ -1,0 +1,65 @@
+"""Pure-logic unit tests for two esstorage.py efficiency fixes:
+
+    1. get_rev_links restricting the ES query to no _source (uuids come from
+       the hit's own _id) instead of fetching whole documents.
+    2. __iter__'s scan query restricting _source to False, since the top-level
+       hit envelope never carries a 'uuid' key and the entire document was
+       previously fetched and discarded.
+
+These construct an ElasticSearchStorage instance directly (bypassing __init__,
+which requires a full pyramid registry/ES client) and mock only the ES
+transport, matching the pattern used elsewhere in this repo for testing
+query-construction logic without a live cluster.
+"""
+from unittest import mock
+
+from ..elasticsearch.esstorage import ElasticSearchStorage
+
+
+def make_storage():
+    storage = object.__new__(ElasticSearchStorage)
+    storage.es = mock.MagicMock()
+    storage.index = 'test-namespace*'
+    return storage
+
+
+class DummyModel:
+    def __init__(self, uuid):
+        self.uuid = uuid
+
+
+def test_get_rev_links_restricts_source_and_returns_ids():
+    storage = make_storage()
+    storage.es.search.return_value = {
+        'took': 1, 'timed_out': False,
+        '_shards': {'total': 1, 'successful': 1, 'skipped': 0, 'failed': 0},
+        'hits': {
+            'total': {'value': 2, 'relation': 'eq'},
+            'max_score': None,
+            'hits': [
+                {'_index': 'idx', '_type': '_doc', '_id': 'uuid-1', '_score': None},
+                {'_index': 'idx', '_type': '_doc', '_id': 'uuid-2', '_score': None},
+            ],
+        },
+    }
+
+    result = storage.get_rev_links(DummyModel('parent-uuid'), 'some.rel')
+
+    assert result == ['uuid-1', 'uuid-2']
+    _, kwargs = storage.es.search.call_args
+    assert kwargs['body']['_source'] is False
+
+
+def test_iter_restricts_source_and_yields_ids():
+    storage = make_storage()
+    raw_hits = [
+        {'_index': 'idx', '_type': '_doc', '_id': 'uuid-1'},
+        {'_index': 'idx', '_type': '_doc', '_id': 'uuid-2'},
+    ]
+
+    with mock.patch('snovault.elasticsearch.esstorage.scan', return_value=iter(raw_hits)) as mock_scan:
+        result = list(storage.__iter__())
+
+    assert result == ['uuid-1', 'uuid-2']
+    _, kwargs = mock_scan.call_args
+    assert kwargs['query']['_source'] is False

--- a/snovault/tests/test_indexer_queue.py
+++ b/snovault/tests/test_indexer_queue.py
@@ -5,6 +5,7 @@ These deliberately avoid the live-ES/SQS ``app`` fixture (and its autouse
 environment - see the INDEXING CI flakiness investigation that motivated the
 queue-namespacing/long-polling fixes these tests cover.
 """
+import json
 import pytest
 from unittest import mock
 
@@ -114,6 +115,46 @@ def test_receive_messages_passes_wait_time_seconds():
         MaxNumberOfMessages=manager.receive_batch_size,
         WaitTimeSeconds=20,
     )
+
+
+def test_send_messages_uses_batch_index_ids_without_sleeping():
+    """ send_messages should build SQS batch-entry Ids from the enumerate index (unique
+    within a single <=10-entry request, which is all SQS requires) instead of a
+    microsecond wall-clock value, and must not sleep to avoid Id collisions. """
+    manager, mock_boto3_client = make_queue_manager(env_name="some-env")
+    mock_client = mock_boto3_client.return_value
+    mock_client.send_message_batch.return_value = {}
+
+    items = [{'uuid': 'a'}, {'uuid': 'b'}, {'uuid': 'c'}]
+    with mock.patch('snovault.elasticsearch.indexer_queue.time.sleep') as mock_sleep:
+        failed = manager.send_messages(items, target_queue='primary')
+
+    mock_sleep.assert_not_called()
+    assert failed == []
+    _, kwargs = mock_client.send_message_batch.call_args
+    entries = kwargs['Entries']
+    assert [entry['Id'] for entry in entries] == ['0', '1', '2']
+
+
+def test_send_messages_retries_failed_entries_by_id():
+    """ The Id-based failure-retry matching (send_messages re-sends any MessageBody whose
+    Id shows up in the batch response's Failed list) must keep working with index-based
+    Ids, since entries are rebuilt fresh on each retry call. """
+    manager, mock_boto3_client = make_queue_manager(env_name="some-env")
+    mock_client = mock_boto3_client.return_value
+    mock_client.send_message_batch.side_effect = [
+        {'Failed': [{'Id': '1'}]},
+        {},
+    ]
+
+    items = [{'uuid': 'a'}, {'uuid': 'b'}]
+    failed = manager.send_messages(items, target_queue='primary')
+
+    assert failed == []
+    assert mock_client.send_message_batch.call_count == 2
+    retry_kwargs = mock_client.send_message_batch.call_args_list[1].kwargs
+    retried_bodies = [json.loads(e['MessageBody']) for e in retry_kwargs['Entries']]
+    assert retried_bodies == [{'uuid': 'b'}]
 
 
 class FakeQueue:

--- a/snovault/tests/test_invalidation_scope.py
+++ b/snovault/tests/test_invalidation_scope.py
@@ -624,3 +624,43 @@ class TestingInvalidationScopeIntegrated:
         invalidated = [(obj['@id'], obj['@type'][0]) for obj in groups + sources + samples]
         secondary = {obj['@id'] for obj in groups + sources + samples}
         self.runtest(testapp, [], invalidated, secondary, 0)
+
+    def test_invalidation_scope_does_not_mutate_diffs_dict(self, testapp, invalidation_scope_workbook):
+        """ Regression test: diffs.get(base_field_item_type) used to hand back the dict's own
+        stored list, and the subsequent .extend(...) calls permanently appended parent-type
+        diff fields into it. This only becomes observable when a parent type of
+        base_field_item_type also has diff entries (otherwise .extend([]) is a no-op on old
+        and new code alike) - so build_diff_metadata is mocked to return a diffs dict with a
+        real parent-type entry to extend from, while still using the real testapp registry
+        so crawl_schema resolves the TestingBiosourceSno.samples -> TestingBiosampleSno embed. """
+        groups, sources, samples, _ = invalidation_scope_workbook
+        diff = ['ignored']
+        invalidated = [(sources[0]['@id'], sources[0]['@type'][0])]
+        secondary = {sources[0]['@id']}
+
+        diffs = {'TestingBiosampleSno': ['identifier'], 'SomeParentType': ['other_field']}
+        child_to_parent_type = {'TestingBiosampleSno': ['SomeParentType']}
+        diffs_before = copy.deepcopy(diffs)
+
+        with mock.patch('snovault.elasticsearch.indexer_utils.build_diff_metadata',
+                        return_value=(False, diffs, 'TestingBiosampleSno', child_to_parent_type)):
+            filter_invalidation_scope(testapp.app.registry, diff, invalidated, secondary)
+
+        assert diffs == diffs_before
+
+    def test_invalidation_scope_does_not_call_determine_child_types_redundantly(self, testapp,
+                                                                                 invalidation_scope_workbook):
+        """ Regression test: determine_child_types (an O(#types) registry scan) used to be called
+        twice back-to-back with identical arguments for the same matched embed - once to check
+        `is not None` and again in the for-loop. For a single invalidated item with one matching
+        embed, it should now be called exactly once. """
+        groups, sources, samples, _ = invalidation_scope_workbook
+        diff = ['TestingBiosampleSno.identifier']
+        invalidated = [(sources[0]['@id'], sources[0]['@type'][0])]
+        secondary = {sources[0]['@id']}
+
+        with mock.patch('snovault.elasticsearch.indexer_utils.determine_child_types',
+                        return_value=[]) as mock_child_types:
+            filter_invalidation_scope(testapp.app.registry, diff, invalidated, secondary)
+
+        assert mock_child_types.call_count == 1


### PR DESCRIPTION
## Summary

Implements Findings 5, 8, 9, 13, 14 from a performance review of the ES/indexing surface (report: snov-es-perf-7k). Each is a small, well-scoped efficiency fix preserving existing behavior; each has unit test coverage.

- **Finding 5** — `ElasticSearchStorage.get_rev_links` (`esstorage.py`) no longer fetches full documents to return uuids: restricts `_source` and reads the uuid off the hit's own `_id` (always the item's uuid, set at indexing time).
- **Finding 8** — `QueueManager.send_messages` (`indexer_queue.py`) no longer builds SQS batch-entry `Id`s from microsecond wall-clock time plus a 1ms sleep per message to avoid collisions. `Id`s only need to be unique within a single ≤10-entry batch, so they're now derived from each entry's position in the batch. Verified the failure-retry matching (`Id` → `MessageBody` lookup) still works since entries are rebuilt per retry call.
- **Finding 9** — `filter_invalidation_scope` (`indexer_utils.py`) no longer mutates the shared per-type diff list returned by `dict.get` (copies it before `.extend`-ing), and calls `determine_child_types` once instead of twice per matched embed.
- **Finding 13** — `es-index-data` (`snovault/commands/es_index_data.py`) now breaks out of its polling loop once the indexer queue is empty and the run indexed nothing for two consecutive iterations, rather than always running the full 100-iteration cap (~6s/iteration once drained).
- **Finding 14** — `ElasticSearchStorage.__iter__` (`esstorage.py`) restricts `_source` to `False` in its scan query, since the top-level hit envelope never carried a `'uuid'` key anyway (`hit.get('uuid', ...)` always fell through to `_id`) and the full document was being fetched and discarded.

Also bumped `pyproject.toml` version (11.32.2 → 11.32.3) and added a `CHANGELOG.rst` entry per repo convention.

## Automatic tag-and-publish-on-master release workflow

Adds a `publish` job to `.github/workflows/main.yml` that, on a successful push to `master`, reads the version from `pyproject.toml` (`poetry version -s`) and, if no git tag for that version exists yet, tags and publishes to PyPI **in the same job run**.

- **Why tag+publish in one job, not a separate tag-triggered run**: GitHub Actions deliberately does not start a new workflow run from a tag pushed with the default `GITHUB_TOKEN` (anti-recursion rule), so relying on the existing tag-triggered `main-publish.yml` (`on: push: tags`) would silently never fire. `main-publish.yml` is left untouched and still works for manual/`workflow_dispatch` publishing.
- **Why gated via `needs: build`**: publish only runs after the full test matrix (both `UNIT` and `INDEXING` legs) passes, and only `if: github.event_name == 'push' && github.ref == 'refs/heads/master'`, so PRs and other branches never publish.
  - Intended behavior, not a bug: this means publish gates on the AWS-dependent `INDEXING` leg too. If that leg flakes on a release-merge run (see the project's known INDEXING-CI-flakiness notes), publish is skipped for that run — but it self-heals on the next `master` push, since the tag guard finds no tag yet for the version and retries. `workflow_dispatch` remains available as a manual fallback in the meantime.
  - Also intended: the tag-existence guard means only a version bump in `pyproject.toml` triggers a real tag+publish. Merges that don't change the version are no-ops by design.
- **Permissions**: the workflow-level `permissions:` block (`id-token: write` / `contents: read`, needed for the `build` job's AWS OIDC auth) is untouched. `contents: write` (needed to push the tag) is scoped only to the new `publish` job, since a job-level `permissions:` block replaces rather than merges with the workflow-level one.
- Reuses the existing `make configure && make publish-for-ga` (`poetry run publish-to-pypi --noconfirm`, from dcicutils) for the actual publish step, and the same `PYPI_USER`/`PYPI_PASSWORD` secrets `main-publish.yml` already uses.
- `CHANGELOG.rst`'s existing `11.32.3` entry has a bullet noting this new workflow; no additional version bump needed since this rides the version already bumped on this branch.
- Validated by static review + YAML parse check (`ruby -ryaml`); this can't be fully exercised outside of an actual `master` push (needs the real event + PyPI secrets), so end-to-end publish is validated by the first `master` merge — since `pyproject.toml` is already at `11.32.3` with no existing tag, that first merge should self-validate by tagging `11.32.3` and publishing it.

## Test plan

- [x] New/extended unit tests, all passing locally (via a throwaway venv against the `snovault311` pyenv interpreter, since the project's Poetry toolchain is broken locally with a `libintl.8.dylib` load error):
  - `test_esstorage_efficiency.py` (new) — `get_rev_links` `_source` restriction + `__iter__` `_source` restriction, mocked ES transport
  - `test_indexer_queue.py` — `send_messages` uses batch-index `Id`s and doesn't sleep; retry-by-`Id` matching still works
  - `test_invalidation_scope.py` — `filter_invalidation_scope` doesn't mutate the shared `diffs` dict (verified this test fails on the pre-fix code and passes post-fix); `determine_child_types` called exactly once per matched embed
  - `test_es_index_data.py` (new) — `run()` breaks after two consecutive empty/zero iterations; still runs the full 100-iteration cap when the queue never drains; posts once when explicit uuids are given
- [x] Full non-ES/DB-dependent test suite (`pytest -m "not indexing and not es"`, excluding `test_indexing.py`) passes: 818 passed, 28 skipped
- [x] New `publish` job's YAML validated (`ruby -ryaml -e "YAML.load_file(...)"`); logic reviewed statically (see above)
- [ ] INDEXING CI job (requires live ES/SQS, not runnable locally) — recommend running before merge
- [ ] End-to-end tag+publish behavior — only verifiable by the first real `master` merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
