### PR TITLE
Fix publish job: install deps for publish, decouple publish gate from tag guard

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,9 +109,11 @@ jobs:
   # Tags and publishes the version declared in pyproject.toml after a successful test run on
   # master. Runs in the same job as the tag push (rather than relying on main-publish.yml's
   # tag-triggered `on: push: tags` event) because GitHub Actions does not start a new workflow
-  # run from a push made with the default GITHUB_TOKEN. Idempotent: skips entirely if the tag
-  # for the current version already exists, so unrelated master merges are no-ops and only a
-  # version bump triggers a release.
+  # run from a push made with the default GITHUB_TOKEN. The tag-push step is gated on the
+  # tag-existence check (only tag once per version); the publish step deliberately is NOT
+  # gated on it, and always runs, relying on `publish-to-pypi --noconfirm`'s own idempotent
+  # per-version PyPI check as the sole guard against redundant publishes. This lets publish
+  # self-heal if a prior run tagged successfully but crashed before publishing.
   publish:
     name: Tag and Publish to PyPI
     needs: build
@@ -127,7 +129,7 @@ jobs:
 
       - name: Install Deps
         run: |
-          make configure
+          make build-for-ga
 
       - name: Determine version and check for existing tag
         id: version
@@ -149,10 +151,8 @@ jobs:
           git push origin "${{ steps.version.outputs.version }}"
 
       - name: Publish to PyPI
-        if: ${{ steps.version.outputs.exists == 'false' }}
         env:
           PYPI_USER: ${{ secrets.PYPI_USER }}
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          make configure
           make publish-for-ga

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,18 +8,29 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 
 `.github/workflows/main.yml`'s `publish` job (`needs: build`, runs only on
 `push` to `master`) reads the version from `pyproject.toml` (`poetry version -s`) and, if
-no git tag for that version exists yet, tags and publishes to PyPI **in the same job run**.
-It deliberately does not rely on `.github/workflows/main-publish.yml`'s tag-triggered
-`on: push: tags` event, because GitHub Actions does not start a new workflow run from a tag
-pushed using the default `GITHUB_TOKEN` (anti-recursion rule) — `main-publish.yml` remains
-only for manual/`workflow_dispatch` publishing. The tag-existence check is the idempotency
-guard: an unchanged version on a master merge is a no-op; only a version bump in
-`pyproject.toml` triggers a real tag+publish. `publish-for-ga` itself (dcicutils
-`publish-to-pypi`) is also idempotent as a second safety net. The workflow-level
-`permissions:` block in `main.yml` stays `id-token: write` / `contents: read` (needed by the
-`build` job's AWS OIDC auth); `contents: write` (needed to push the tag) is scoped to the
-`publish` job only, since a job-level `permissions:` block replaces rather than merges with
-the workflow-level one.
+no git tag for that version exists yet, tags it, then always attempts to publish to PyPI
+**in the same job run**. It deliberately does not rely on
+`.github/workflows/main-publish.yml`'s tag-triggered `on: push: tags` event, because GitHub
+Actions does not start a new workflow run from a tag pushed using the default
+`GITHUB_TOKEN` (anti-recursion rule) — `main-publish.yml` remains only for manual/
+`workflow_dispatch` publishing.
+
+The "Create and push tag" step is gated on the tag-existence check (`exists == 'false'`) —
+tag once per version. The "Publish to PyPI" step is deliberately **not** gated on that same
+check; it always runs, relying solely on `publish-to-pypi --noconfirm`'s own idempotent
+per-version PyPI check as the guard against redundant publishes. This split exists because
+the first real run (CI run 29052379561, from PR #324 landing) tagged `11.32.3` successfully
+but then the publish step crashed (`ModuleNotFoundError: no module named 'dcicutils'` — the
+job's "Install Deps" step ran `make configure`, which only installs pip/wheel/poetry, not
+project deps; it now runs `make build-for-ga`, which also runs `poetry install`). With both
+steps sharing one guard, the tag existing after that crash meant publish would have been
+skipped forever on every subsequent master push — no self-healing possible. Decoupling them
+means a tag-exists-but-never-published state (however it arises) always gets a retry.
+
+The workflow-level `permissions:` block in `main.yml` stays `id-token: write` / `contents:
+read` (needed by the `build` job's AWS OIDC auth); `contents: write` (needed to push the
+tag) is scoped to the `publish` job only, since a job-level `permissions:` block replaces
+rather than merges with the workflow-level one.
 
 ## Self-registration field whitelist (`create_unauthorized_user`)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,14 @@ Change Log
   trigger a new workflow run from a tag pushed with the default ``GITHUB_TOKEN``). Merges
   that don't change the version are no-ops.
 
+* Fix the ``publish`` job added just above: its "Install Deps" step now runs
+  ``make build-for-ga`` (not just ``make configure``), since ``poetry run publish-to-pypi``
+  needs project dependencies (``dcicutils``) installed, which ``configure`` alone doesn't
+  provide. Also decouples the "Publish to PyPI" step from the tag-existence guard - it now
+  always runs (relying on ``publish-to-pypi --noconfirm``'s own idempotent per-version PyPI
+  check) instead of being skipped whenever a tag already exists, so a run that tags
+  successfully but crashes before publishing can self-heal on the next master push.
+
 11.32.2
 =======
 


### PR DESCRIPTION
## Summary

Fixes the release mechanism added in #324, which merged to master and ran for the first time as CI run 29052379561. That run tagged `11.32.3` on GitHub successfully, but the publish step then crashed — so `dcicsnovault==11.32.3` is tagged but was **never published to PyPI**. Both test legs (UNIT, INDEXING) passed; only the `publish` job failed.

Two bugs, both in `.github/workflows/main.yml`'s `publish` job:

1. **Missing dependencies in the publish job.** "Install Deps" ran `make configure`, which only installs pip/wheel/poetry itself — not the project's own dependencies. `poetry run publish-to-pypi` (invoked via `make publish-for-ga`) needs `dcicutils` for that console script, and without `poetry install` it isn't there: `ModuleNotFoundError: No module named 'dcicutils'`.
   - Fix: "Install Deps" now runs `make build-for-ga` (= `configure` + `poetry config --local virtualenvs.create true` + `poetry install`), matching what the `build` job already does.

2. **Publish step wrongly gated on the same tag-existence check, so it can never self-heal.** Both "Create and push tag" and "Publish to PyPI" shared `if: exists == 'false'`. Because bug 1 let the tag get created and pushed before publish crashed, the tag for `11.32.3` now exists — so on every future master push the guard sees `exists == true` and skips **both** steps forever, even though the package was never actually published.
   - Fix: decouple them. "Create and push tag" keeps its `exists == 'false'` guard (tag once). "Publish to PyPI" drops that guard entirely and always runs, relying on `publish-to-pypi --noconfirm`'s own idempotent per-version PyPI check as the sole safety net against redundant publishes.

## Why no version bump

This PR fixes the release mechanism; it is not a feature change to snovault itself, so `pyproject.toml` stays at `11.32.3` (overriding the usual DCIC "bump the version every PR" convention deliberately, per this repo's documented convention). The whole point of the bug-2 fix is that merging this PR (a push to master) re-runs the publish job for the *current* `pyproject.toml` version: the tag step will see the tag already exists and correctly no-op (no duplicate tag), while the now-unconditional publish step will run `make build-for-ga && make publish-for-ga` and actually publish `dcicsnovault==11.32.3` to PyPI for the first time — closing out the stalled release. Bumping the version here would leave `11.32.3` tagged-but-never-published forever.

`CHANGELOG.rst` gets a bullet extending the existing `11.32.3` entry (not a new version section) describing this fix.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/main.yml'))"` confirms the YAML is well-formed.
- [ ] Cannot fully execute the publish job here — it needs PyPI secrets and a real push to master. **Firstmate will watch the next master-merge run end-to-end to confirm `dcicsnovault==11.32.3` actually reaches PyPI this time.**

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
