### PR TITLE
Fix post-merge PyPI publish workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,10 +110,9 @@ jobs:
   # master. Runs in the same job as the tag push (rather than relying on main-publish.yml's
   # tag-triggered `on: push: tags` event) because GitHub Actions does not start a new workflow
   # run from a push made with the default GITHUB_TOKEN. The tag-push step is gated on the
-  # tag-existence check (only tag once per version); the publish step deliberately is NOT
-  # gated on it, and always runs, relying on `publish-to-pypi --noconfirm`'s own idempotent
-  # per-version PyPI check as the sole guard against redundant publishes. This lets publish
-  # self-heal if a prior run tagged successfully but crashed before publishing.
+  # tag-existence check (only tag once per version). The publish step is independently gated
+  # on whether the version exists on PyPI, so it can self-heal if a prior run tagged
+  # successfully but crashed before publishing without failing for an already-published version.
   publish:
     name: Tag and Publish to PyPI
     needs: build
@@ -121,6 +120,8 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
+    env:
+      POETRY_VIRTUALENVS_CREATE: "true"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -131,7 +132,10 @@ jobs:
         run: |
           make build-for-ga
 
-      - name: Determine version and check for existing tag
+      - name: Assert clean release checkout
+        run: git diff --exit-code
+
+      - name: Determine version and check for existing tag and PyPI release
         id: version
         run: |
           VERSION=$(poetry version -s)
@@ -141,6 +145,13 @@ jobs:
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
+          PYPI_STATUS=$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+            "https://pypi.org/pypi/dcicsnovault/${VERSION}/json")
+          case "$PYPI_STATUS" in
+            200) echo "pypi_exists=true" >> "$GITHUB_OUTPUT" ;;
+            404) echo "pypi_exists=false" >> "$GITHUB_OUTPUT" ;;
+            *) echo "Unexpected PyPI status ${PYPI_STATUS} for ${VERSION}" >&2; exit 1 ;;
+          esac
 
       - name: Create and push tag
         if: ${{ steps.version.outputs.exists == 'false' }}
@@ -151,6 +162,7 @@ jobs:
           git push origin "${{ steps.version.outputs.version }}"
 
       - name: Publish to PyPI
+        if: ${{ steps.version.outputs.pypi_exists == 'false' }}
         env:
           PYPI_USER: ${{ secrets.PYPI_USER }}
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,25 +7,27 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 ## Automatic tag-and-publish-on-master release workflow
 
 `.github/workflows/main.yml`'s `publish` job (`needs: build`, runs only on
-`push` to `master`) reads the version from `pyproject.toml` (`poetry version -s`) and, if
-no git tag for that version exists yet, tags it, then always attempts to publish to PyPI
-**in the same job run**. It deliberately does not rely on
+`push` to `master`) reads the version from `pyproject.toml` (`poetry version -s`) and checks
+both for its git tag and for an existing PyPI release. It creates the tag if missing and
+publishes only if PyPI does not already have the version, all **in the same job run**. It deliberately does not rely on
 `.github/workflows/main-publish.yml`'s tag-triggered `on: push: tags` event, because GitHub
 Actions does not start a new workflow run from a tag pushed using the default
 `GITHUB_TOKEN` (anti-recursion rule) — `main-publish.yml` remains only for manual/
 `workflow_dispatch` publishing.
 
 The "Create and push tag" step is gated on the tag-existence check (`exists == 'false'`) —
-tag once per version. The "Publish to PyPI" step is deliberately **not** gated on that same
-check; it always runs, relying solely on `publish-to-pypi --noconfirm`'s own idempotent
-per-version PyPI check as the guard against redundant publishes. This split exists because
-the first real run (CI run 29052379561, from PR #324 landing) tagged `11.32.3` successfully
-but then the publish step crashed (`ModuleNotFoundError: no module named 'dcicutils'` — the
-job's "Install Deps" step ran `make configure`, which only installs pip/wheel/poetry, not
-project deps; it now runs `make build-for-ga`, which also runs `poetry install`). With both
-steps sharing one guard, the tag existing after that crash meant publish would have been
-skipped forever on every subsequent master push — no self-healing possible. Decoupling them
-means a tag-exists-but-never-published state (however it arises) always gets a retry.
+tag once per version. The "Publish to PyPI" step instead uses the independently checked
+`pypi_exists == 'false'` condition. Its curl request treats only HTTP 200 (present) and 404
+(absent) as valid; any other status fails the job closed. This split preserves recovery from
+a tag-exists-but-never-published state, while avoiding a failing duplicate-upload attempt on
+later merges. `publish-to-pypi` itself treats an existing release as an error, rather than
+an idempotent success.
+
+`make build-for-ga` must use `POETRY_VIRTUALENVS_CREATE=true poetry install`, never
+`poetry config --local virtualenvs.create true`: the latter changes tracked `poetry.toml` and
+makes the release checkout dirty, causing `publish-to-pypi` to abort. The workflow also sets
+the variable job-wide and asserts `git diff --exit-code` directly after dependency install so
+any future mutation names the affected file at the source of the failure.
 
 The workflow-level `permissions:` block in `main.yml` stays `id-token: write` / `contents:
 read` (needed by the `build` job's AWS OIDC auth); `contents: write` (needed to push the

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,7 @@ fix-dist-info:
 
 build-for-ga:
 	make configure
-	poetry config --local virtualenvs.create true
-	poetry install
+	POETRY_VIRTUALENVS_CREATE=true poetry install
 
 deploy1:  # starts postgres/ES locally and loads inserts, and also starts ingestion engine
 	@DEBUGLOG=`pwd` SNOVAULT_DB_TEST_PORT=`grep 'sqlalchemy[.]url =' development.ini | sed -E 's|.*:([0-9]+)/.*|\1|'` dev-servers-snovault development.ini --app-name app --clear --init --load


### PR DESCRIPTION
Fixes the master post-merge publish job.

- Avoids mutating tracked poetry.toml during build-for-ga.
- Adds a clean-checkout assertion and job-wide Poetry setting.
- Gates publishing on a fail-closed PyPI version check while retaining independent tag recovery.

Validation: ran PYENV_VERSION=snovault311 make build-for-ga with no unstaged tracked changes; parsed the workflow YAML; verified PyPI status handling for existing 11.32.3 and nonexistent 999999.0.0.