### PR TITLE
Fix ingestion queue deletion retries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ snovault
 Change Log
 ----------
 
+11.33.1
+=======
+
+* Fix ingestion SQS message deletion retries by correlating batch failure ``Id`` values
+  back to the original received messages and reusing their current ``ReceiptHandle``.
+  Bound deletion to three retries after the initial attempt, avoiding listener crashes,
+  unbounded retry loops, and unnecessary duplicate processing after transient failures.
+
 11.33.0
 =======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.33.0"
+version = "11.33.1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/ingestion/ingestion_listener.py
+++ b/snovault/ingestion/ingestion_listener.py
@@ -377,6 +377,7 @@ def get_queue_manager(request, *, override_name):
 class IngestionListener(IngestionListenerBase):
     """ Organizes helper functions for the ingestion listener """
     POLL_INTERVAL = 10  # seconds between each poll
+    DELETE_RETRIES = 3
     INGEST_AS_USER = environ_bool('INGEST_AS_USER', default=True)  # The new way, but possible to disable for now
 
     def __init__(self, vapp, _queue_manager=None, _update_status=None):
@@ -423,20 +424,17 @@ class IngestionListener(IngestionListenerBase):
         :param messages: messages to be deleted
         """
         failed = self.queue_manager.delete_messages(messages)
-        while True:
+        retries_remaining = self.DELETE_RETRIES
+        while failed and retries_remaining > 0:
             debuglog("Trying to delete messages")
-            tries = 3
-            if failed:
-                debuglog("Failed to delete messages")
-                if tries > 0:
-                    failed = self.queue_manager.delete_messages(failed)  # try again
-                    tries -= 1
-                else:
-                    log.error('Failed to delete messages from SQS: %s' % failed)
-                    break
-            else:
-                debuglog("Deleted messages")
-                break
+            debuglog("Failed to delete messages")
+            failed = self.queue_manager.delete_messages(failed)
+            retries_remaining -= 1
+        if failed:
+            log.error('Failed to delete messages from SQS after %s retries: %s' %
+                      (self.DELETE_RETRIES, failed))
+        else:
+            debuglog("Deleted messages")
 
     def _patch_value(self, uuid, field, value):
         """ Patches field with value on item uuid """

--- a/snovault/ingestion/queue_utils.py
+++ b/snovault/ingestion/queue_utils.py
@@ -118,29 +118,42 @@ class IngestionQueueManager:
         Called after a message has been successfully received and processed.
         Removes message from the queue.
         Input should be the messages directly from receive messages. At the
-        very least, needs a list of messages with 'Id' and 'ReceiptHandle' as this
-        metadata is necessary to identify the message in SQS internals.
+        very least, each message needs 'MessageId' and 'ReceiptHandle'. The
+        receipt handle identifies the received message to SQS; the message ID is
+        used only as the batch request's correlation ID.
 
         NOTE: deletion does NOT have a retry mechanism
 
         :param messages: messages to be deleted
-        :returns: a list with any failed messages
+        :returns: the original received-message dictionaries for any failed
+            entries, preserving their receipt handles so callers can retry
         """
         failed = []
         for batch in self._chunk_messages(messages):
-            # need to change message format, since deleting takes slightly
-            # different fields what's return from receiving
-            for i in range(len(batch)):
-                to_delete = {
-                    'Id': batch[i]['MessageId'],
-                    'ReceiptHandle': batch[i]['ReceiptHandle']
+            entries = [
+                {
+                    'Id': message['MessageId'],
+                    'ReceiptHandle': message['ReceiptHandle']
                 }
-                batch[i] = to_delete
+                for message in batch
+            ]
+            messages_by_id = {
+                entry['Id']: message
+                for entry, message in zip(entries, batch)
+            }
             response = self.client.delete_message_batch(
                 QueueUrl=self.queue_url,
-                Entries=batch
+                Entries=entries
             )
-            failed.extend(response.get('Failed', []))
+            for failure in response.get('Failed', []):
+                log.warning(
+                    'SQS delete_message_batch entry failed',
+                    batch_id=failure['Id'],
+                    sender_fault=failure.get('SenderFault'),
+                    code=failure.get('Code'),
+                    message=failure.get('Message'),
+                )
+                failed.append(messages_by_id[failure['Id']])
         return failed
 
     def add_uuids(self, uuids, ingestion_type='vcf'):

--- a/snovault/tests/test_ingestion_queue.py
+++ b/snovault/tests/test_ingestion_queue.py
@@ -1,0 +1,161 @@
+"""Pure mocked tests for ingestion queue deletion and listener retries."""
+
+from unittest import mock
+
+from ..ingestion import ingestion_listener as ingestion_listener_module
+from ..ingestion import queue_utils
+from ..ingestion.ingestion_listener import IngestionListener
+from ..ingestion.queue_utils import IngestionQueueManager
+
+
+QUEUE_URL = "https://sqs.example.test/ingestion"
+
+
+def make_message(message_id, receipt_handle):
+    return {
+        "MessageId": message_id,
+        "ReceiptHandle": receipt_handle,
+        "Body": '{"uuid": "some-uuid"}',
+    }
+
+
+def make_queue_manager(responses, batch_size=1):
+    """Build a queue manager without initializing boto3 or contacting SQS."""
+    manager = object.__new__(IngestionQueueManager)
+    manager.batch_size = batch_size
+    manager.queue_url = QUEUE_URL
+    manager.client = mock.Mock()
+    manager.client.delete_message_batch.side_effect = responses
+    return manager
+
+
+def make_listener(manager):
+    return IngestionListener(object(), _queue_manager=manager)
+
+
+def test_delete_messages_builds_delete_entries_without_mutating_received_messages():
+    message = make_message("logical-message-id", "current-receipt-handle")
+    messages = [message]
+    manager = make_queue_manager([{}])
+
+    failed = manager.delete_messages(messages)
+
+    assert failed == []
+    assert messages == [message]
+    assert messages[0] is message
+    manager.client.delete_message_batch.assert_called_once_with(
+        QueueUrl=QUEUE_URL,
+        Entries=[{
+            "Id": "logical-message-id",
+            "ReceiptHandle": "current-receipt-handle",
+        }],
+    )
+    entry = manager.client.delete_message_batch.call_args.kwargs["Entries"][0]
+    assert entry["Id"] != entry["ReceiptHandle"]
+
+
+def test_delete_messages_correlates_aws_failure_to_original_received_message():
+    message = make_message("logical-message-id", "current-receipt-handle")
+    aws_failure = {
+        "Id": "logical-message-id",
+        "SenderFault": False,
+        "Code": "InternalError",
+    }
+    manager = make_queue_manager([{"Failed": [aws_failure]}])
+
+    with mock.patch.object(queue_utils.log, "warning") as mock_warning:
+        failed = manager.delete_messages([message])
+
+    assert failed == [message]
+    assert failed[0] is message
+    assert failed[0]["ReceiptHandle"] == "current-receipt-handle"
+    assert "MessageId" not in aws_failure
+    assert "ReceiptHandle" not in aws_failure
+    mock_warning.assert_called_once_with(
+        "SQS delete_message_batch entry failed",
+        batch_id="logical-message-id",
+        sender_fault=False,
+        code="InternalError",
+        message=None,
+    )
+
+
+def test_listener_retries_with_original_receipt_handle_and_succeeds():
+    message = make_message("logical-message-id", "current-receipt-handle")
+    manager = make_queue_manager([
+        {
+            "Failed": [{
+                "Id": "logical-message-id",
+                "SenderFault": False,
+                "Code": "InternalError",
+                "Message": "transient failure",
+            }],
+        },
+        {},
+    ])
+
+    make_listener(manager).delete_messages([message])
+
+    assert manager.client.delete_message_batch.call_count == 2
+    retry_entry = manager.client.delete_message_batch.call_args_list[1].kwargs["Entries"][0]
+    assert retry_entry == {
+        "Id": "logical-message-id",
+        "ReceiptHandle": "current-receipt-handle",
+    }
+
+
+def test_listener_retries_only_failed_message_from_multi_message_batch():
+    messages = [
+        make_message("message-a", "receipt-a"),
+        make_message("message-b", "receipt-b"),
+        make_message("message-c", "receipt-c"),
+    ]
+    manager = make_queue_manager([
+        {
+            "Successful": [{"Id": "message-a"}, {"Id": "message-c"}],
+            "Failed": [{
+                "Id": "message-b",
+                "SenderFault": False,
+                "Code": "InternalError",
+            }],
+        },
+        {"Successful": [{"Id": "message-b"}]},
+    ], batch_size=10)
+
+    make_listener(manager).delete_messages(messages)
+
+    assert manager.client.delete_message_batch.call_count == 2
+    initial_entries = manager.client.delete_message_batch.call_args_list[0].kwargs["Entries"]
+    retry_entries = manager.client.delete_message_batch.call_args_list[1].kwargs["Entries"]
+    assert initial_entries == [
+        {"Id": "message-a", "ReceiptHandle": "receipt-a"},
+        {"Id": "message-b", "ReceiptHandle": "receipt-b"},
+        {"Id": "message-c", "ReceiptHandle": "receipt-c"},
+    ]
+    assert retry_entries == [{"Id": "message-b", "ReceiptHandle": "receipt-b"}]
+
+
+def test_listener_stops_after_three_delete_retries():
+    message = make_message("logical-message-id", "current-receipt-handle")
+    persistent_failure = {
+        "Failed": [{
+            "Id": "logical-message-id",
+            "SenderFault": False,
+            "Code": "InternalError",
+            "Message": "still failing",
+        }],
+    }
+    manager = make_queue_manager([persistent_failure] * 4)
+
+    with mock.patch.object(ingestion_listener_module.log, "error") as mock_error:
+        make_listener(manager).delete_messages([message])
+
+    assert manager.client.delete_message_batch.call_count == 4
+    for call in manager.client.delete_message_batch.call_args_list:
+        assert call.kwargs["Entries"] == [{
+            "Id": "logical-message-id",
+            "ReceiptHandle": "current-receipt-handle",
+        }]
+    mock_error.assert_called_once_with(
+        "Failed to delete messages from SQS after 3 retries: %s" % [message]
+    )


### PR DESCRIPTION
## Summary

- preserve original received-message dictionaries while building separate `DeleteMessageBatch` request entries
- correlate each AWS failure `Id` back to its original message so retries reuse the exact `ReceiptHandle`
- log the entry-level SQS failure diagnostics and document the corrected return contract
- cap listener deletion at the initial attempt plus three retries
- cover request shape, modeled AWS failures, retry success, partial batches, identifier separation, and retry exhaustion with pure mocked tests

## Root cause and impact

SQS `DeleteMessageBatch` failures contain `Id`, `SenderFault`, `Code`, and optionally `Message`; they do not contain a received message's `MessageId` or `ReceiptHandle`. The queue manager returned those raw failure objects, and the listener passed them back as though they were received messages, causing `KeyError: 'MessageId'`. Its retry counter was also reset inside the loop, which would make persistent failures unbounded after fixing the shape mismatch.

This happens after ingestion processing succeeds. A failed deletion therefore crashed the listener instead of retrying, leaving the message to become visible and be delivered again. The main risk is duplicate processing and repeated non-idempotent downstream effects, not direct message loss.

## Validation

- `NO_SERVER_FIXTURES=TRUE PYENV_VERSION=snovault311 python -m pytest -q snovault/tests/test_ingestion_queue.py` (`5 passed`)
- `PYENV_VERSION=snovault311 python -m flake8 snovault/ingestion/queue_utils.py snovault/ingestion/ingestion_listener.py snovault/tests/test_ingestion_queue.py`
- supplemental deterministic mocked harness against the real queue-manager module and listener class body: all 5 scenarios passed
- `git diff --check`

The repository's Poetry interpreter remains unusable because it references missing `/usr/local/opt/gettext/lib/libintl.8.dylib`; the default PostgreSQL fixture also cannot start because the host `initdb` references missing ICU 74. The focused tests are pure mocks and passed in the repository's `snovault311` environment with server fixtures disabled. No host libraries were modified and no live AWS/SQS calls were made.
