### PR TITLE
feat(elasticsearch): add secondary-only indexing coalescing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -380,6 +380,19 @@ exists receives one conservative full type reindex the first time selective mode
 enabled; subsequent unchanged deployments can skip it. See
 `snovault/tests/test_selective_reindex.py` for the decision matrix.
 
+## Secondary-only indexing coalescing
+
+`snovault/elasticsearch/secondary_indexing.py` coalesces only the final strict targets
+from `Indexer.find_and_queue_secondary_items`; primary edit hooks, bulk reindexing, and
+manual queueing bypass it. The PostgreSQL state key must remain `(rid, queue namespace)`
+because blue and green fan out to separate secondary queues. Preserve the protocol's
+commit-before-send, unconditional target locking, `queued_sid` stale-snapshot defer,
+claim-before-render, and sweeper repair invariants together; simplifying the row to a
+boolean can strand or lose invalidations. Operational settings, rollout/reset rules,
+DB capacity notes, and query interfaces are documented in
+`docs/source/embedding-and-indexing.rst`; local-only race/failure coverage is in
+`snovault/tests/test_secondary_indexing.py`.
+
 ## Maintaining this file
 
 Keep this file for knowledge useful to almost every future agent session in this project.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,8 +384,9 @@ enabled; subsequent unchanged deployments can skip it. See
 
 `snovault/elasticsearch/secondary_indexing.py` coalesces only the final strict targets
 from `Indexer.find_and_queue_secondary_items`; primary edit hooks, bulk reindexing, and
-manual queueing bypass it. The PostgreSQL state key must remain `(rid, queue namespace)`
-because blue and green fan out to separate secondary queues. Preserve the protocol's
+manual queueing bypass coalescing suppression. The PostgreSQL state key must remain
+`(rid, queue namespace)` because blue and green fan out to separate secondary queues.
+Preserve the protocol's
 commit-before-send, unconditional target locking, `queued_sid` stale-snapshot defer,
 claim-before-render, and sweeper repair invariants together; simplifying the row to a
 boolean can strand or lose invalidations. Operational settings, rollout/reset rules,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,15 @@ snovault
 Change Log
 ----------
 
+11.34.0
+========
+
+* Add rollout-gated PostgreSQL coalescing for secondary-only indexing fan-out while
+  retaining SQS transport and leaving primary edit events unchanged. Namespace-keyed
+  pending state, sid-aware consumer claims, stranded-send sweeping, bounded audited
+  controls, and structured pressure/latency instrumentation preserve at-least-once
+  full renders across concurrency, redelivery, crashes, and blue/green operation.
+
 11.33.1
 =======
 

--- a/docs/source/embedding-and-indexing.rst
+++ b/docs/source/embedding-and-indexing.rst
@@ -89,7 +89,7 @@ for the same target while retaining SQS as the transport.  The allowed rollout
 values are ``off`` (the default), ``shadow`` (run the state machine and measure
 suppression, but send every message), and ``on`` (suppress work already covered by
 an outstanding message).  Primary POST/PATCH messages, bulk reindex messages, and
-manual ``/queue_indexing`` requests do not use this state.
+manual ``/queue_indexing`` requests bypass coalescing suppression.
 
 Coalescing happens in ``Indexer.find_and_queue_secondary_items`` only after the ES
 linker lookup, invalidation-scope filtering, and new reverse-link augmentation have
@@ -185,8 +185,6 @@ The queue is only actively cleared when create-mapping is run for a total reinde
 Please note that you must have the correct AWS credentials configured for your project to use it.
 
 Further possible improvements to the queue system include:
-- Evolving the single-slot PostgreSQL state into a full durable work/outbox table while retaining SQS as a doorbell during migration.
-- Change the /index endpoint to only pull and index one item per transaction, which would eliminate need for the deferred queue.
 - Ordering of items on the queue, either at time of create_mapping (initial indexing) or for ongoing indexing.
 - Speed up indexing by refining what items are considered invalid when an item is indexed (in most cases, secondary items do not need to be reindexed).
 

--- a/docs/source/embedding-and-indexing.rst
+++ b/docs/source/embedding-and-indexing.rst
@@ -75,21 +75,113 @@ Currently, the anatomy of a item to be put on the queue is:
 }
 ```
 
-uuid and timestamp are pretty self-explanatory. The sid is the DB transaction count, which is used as the version number in ES. Because sid is incremented for each transaction in the DB, this allows us a convenient method for ES versioning. The strict parameter is a boolean that controls whether or not associated uuids are also reindexed for the given uuid. In essence, if true, strict will also cause all items that embed the indexed item to also be reindexed. Currently, if an sid is provided (i.e. the item is queued through a POST or PATCH), then the embedded uuids within the item itself will also be queued. The method property shows whether an item was added to the queue through a POST or PATCH; if the item is on the seconday queue, this field will not be present, since the item was queued as a result of invalidation caused by a primary item.
+uuid and timestamp are pretty self-explanatory. The sid is the DB transaction count, which is used as the version number in ES. Because sid is incremented for each transaction in the DB, this allows us a convenient method for ES versioning. The strict parameter is a boolean that controls whether associated uuids are also reindexed for the given uuid. A false value causes the consumer to find and queue associated targets after the item is rendered; a true value is a full-render terminal job and does not fan out again. The method property shows whether an item was added to the queue through a POST or PATCH; if the item is on the secondary queue, this field will not be present, since the item was queued as a result of invalidation caused by a primary item.
 
-There are currently 4 different queues for each Fourfront environment. The `primary` queue contains all items that are posted or patched. The `secondary` queue contains all items that are found as a result of finding associated uuids with a primary item (if strict == False) and also the embedded uuids of items in the primary queue. The secondary queue is also the target of items queued by create_mapping. The `deferred` queue has similar priority to `primary` and is used to contain items that cannot be updated in the scope of the currently running indexing process. They must wait for the indexer to finish and restart with a new transaction to go through. Note that if there are items in `deferred` and also `secondary`, the indexer will restart in order to index the deferred items before moving on to the secondary items. The last queue is the dead letter queue, or `dlq`. It is used for items that have failed to go through the other queues 4 times and simply holds those actions until cleared manually. The contents of the dlq are never automatically indexed again.
+There are currently three queues for each environment. The ``primary`` queue contains items posted or patched. The ``secondary`` queue contains terminal invalidation targets and is also used by create-mapping. A message whose sid is newer than the indexer's repeatable-read snapshot is resent to its current queue and the worker restarts with a fresh snapshot; there is no separate deferred queue. The dead letter queue, or ``dlq``, receives messages that exhaust the SQS redrive policy and holds them for operator replay.
 
 The process of finding the secondary uuids that need to be indexed when a primary item is created or edited is called invalidation and has it's own document (./invalidation.rst). This process is complex and has been one of the largest pain points in creating and optimizing our indexing system. Please read that document for an in-depth overview of invalidation. From the indexing standpoint, all secondary items that are invalidated are indexed on the secondary queue so that they themselves do not cause a further cascading of more items on the secondary queue. Reverse links (rev_links) are taken into account during the invalidation process.
 
-A couple endpoints were added to make the queue more useful. First, /indexing_status takes a GET request and returns the counts of items in each of the 4 queues. The /queue_indexing endpoint is a POST endpoint used to manually queue items. It requires administrator privileges and takes a JSON body where you can either specify a list of `collections` (e.g. file_fastq or biosample) or a list of `uuids` for indexing. You can also specify whether the items should be indexed in strict mode using the `strict` keyword and a boolean value. Lastly, you can specify which queue you want to send your items to using the `target_queue` keyword and a value of `primary`, `secondary`, or `deferred`. The default strict value is False and the default target is primary.
+Secondary fan-out coalescing
+----------------------------
+
+``indexer.coalesce_secondary`` optionally coalesces duplicate invalidation fan-out
+for the same target while retaining SQS as the transport.  The allowed rollout
+values are ``off`` (the default), ``shadow`` (run the state machine and measure
+suppression, but send every message), and ``on`` (suppress work already covered by
+an outstanding message).  Primary POST/PATCH messages, bulk reindex messages, and
+manual ``/queue_indexing`` requests do not use this state.
+
+Coalescing happens in ``Indexer.find_and_queue_secondary_items`` only after the ES
+linker lookup, invalidation-scope filtering, and new reverse-link augmentation have
+selected the final target UUIDs.  A secondary fan-out message contains no field
+diff: the diff has already served its purpose by deciding target membership, and
+the consumer renders the selected target's complete index document.  The table
+``secondary_indexing_pending`` therefore needs only ``(rid, namespace)``,
+``pending``, ``queued_sid``, and ``queued_at``.  Namespace is the sanitized queue
+environment name and is part of the primary key because blue and green indexers fan
+out independently to their own secondary queues.
+
+The producer arms sorted UUID batches in a short READ COMMITTED write transaction,
+commits, and only then sends marker messages to SQS.  Inserts plus unconditional
+``FOR UPDATE`` locking serialize concurrent producers and consumer claims.  A
+consumer claims a marker before rendering.  If the indexer's repeatable-read
+snapshot has a maximum sid below the row's latest ``queued_sid``, the claim rolls
+back and the existing SQS defer/resend path obtains a fresh snapshot.  Otherwise
+the claim releases ``pending`` before the full render.  SQS deletion remains after
+a successful ES write; a crash or redelivery after release causes a harmless full
+render with a no-op claim.
+
+A failed send after the state commit leaves a recoverable pending row.  The index
+listener periodically re-arms old rows and commits before resending marker messages.
+If the state table itself is unavailable, the producer fails open by sending the
+legacy unmarked secondary payload; if both PostgreSQL state and that SQS send fail,
+the error propagates so the causing primary message is not deleted and can retry.
+Defaults are 1,800 seconds before repair, a 300 second sweep interval, and 500 rows
+per sweep; configure these with
+``indexer.coalesce_secondary.stale_seconds``,
+``indexer.coalesce_secondary.sweep_interval``, and
+``indexer.coalesce_secondary.sweep_limit``.  The sweeper uses the partial covering
+index and ``FOR UPDATE SKIP LOCKED`` so multiple listeners or operator actions do
+not wait on hot rows.
+
+Operations and rollout
+~~~~~~~~~~~~~~~~~~~~~~
+
+* ``GET /secondary_coalescing_status`` returns aggregate pressure for the current
+  namespace, or per-target state for every namespace when passed ``?uuid=...``.
+  During ``shadow`` and ``on``, the same information is also included in the
+  existing ``/indexing_status`` and ``/indexing-info`` responses. ``off`` leaves
+  those existing response contracts unchanged.
+* ``POST /queue_indexing`` remains a force-queue/bypass interface and never changes
+  pending state.
+* ``POST /reset_secondary_coalescing`` requires ``index`` permission and accepts
+  exactly one of ``{"uuids": [...]}`` or ``{"all": true}``.  It is dry-run by
+  default, is capped at 1,000 rows, and is audit-logged with the authenticated
+  principal.  ``requeue=true`` keeps rows pending, commits a fresh ``queued_at``,
+  and then sends; a failed administrative send is therefore still sweepable.
+* Moving from ``off`` or ``shadow`` to ``on`` requires a dry run followed by a
+  namespace reset.  Turning ``on`` back to ``off`` is an immediate safe kill
+  switch because off mode sends every fan-out target through the original path.
+
+Structured logs use ``coalescing_event`` to expose fan-out targets/suppression,
+database and SQS enqueue failures, claims and stale deferrals, sweeper repairs,
+administrative actions, and operation latency.  SQS receive logs include
+``ApproximateReceiveCount``, ``SentTimestamp``-derived queue latency, message
+origin, and claim outcome, distinguishing producer duplication from redelivery.
+Queue deletion failures are logged and remain safe because the message is deleted
+only after successful indexing.
+
+PostgreSQL deployment and capacity
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The table is registered in ``snovault.storage.Base`` and is created by the normal
+``Base.metadata.create_all`` path when ``create_tables=true``.  Deployments that
+disable automatic table creation must apply the SQLAlchemy-generated table, index,
+and storage-parameter DDL before enabling ``shadow``; no backfill is required.
+The table uses fillfactor 70 and aggressive per-table autovacuum scale factors
+(0.02 vacuum, 0.05 analyze).  Suppression updates normally touch only the unindexed
+``queued_sid`` and are HOT-eligible; transitions necessarily change the partial
+index predicate.  Resource deletion cascades to state rows, and inactive rows are
+bounded by resources multiplied by active environment namespaces.
+
+Each producer batch or consumer claim checks out one additional connection only
+for its short write transaction; it does not hold a connection across an SQS API
+call or an ES render.  Before enabling ``shadow``, operators must verify database
+pool and PostgreSQL ``max_connections`` headroom for the maximum concurrent indexer
+workers, then measure actual table/index growth, WAL, dead tuples/autovacuum cadence,
+batch transaction latency, sweep lag, and suppression ratio.  The implementation
+batches at 500 targets, uses primary-key point locks, and uses a covering partial
+index for sweeps; these measurements, rather than an assumed production item or
+edit count, determine capacity.
+
+A couple endpoints were added to make the queue more useful. First, /indexing_status takes a GET request and returns waiting and in-flight counts for the three queues. The /queue_indexing endpoint is a POST endpoint used to manually queue items. It requires administrator privileges and takes a JSON body where you can either specify a list of `collections` (e.g. file_fastq or biosample) or a list of `uuids` for indexing. You can also specify whether the items should be indexed in strict mode using the `strict` keyword and a boolean value. Lastly, you can specify which queue you want to send your items to using the `target_queue` keyword and a value of `primary`, `secondary`, or `dlq`. The default strict value is False and the default target is primary.
 
 The queue is only actively cleared when create-mapping is run for a total reindex. This is because past records should not be lost for the alternate create-mapping functions, such as --check-first or --index-diff. The queue can be managed directly from the AWS console.
 
 Please note that you must have the correct AWS credentials configured for your project to use it.
 
 Further possible improvements to the queue system include:
-- Creating a metadata layer that would allow for deduplication of <uuid/sid> combinations within the queue.
-- Using an SQS FIFO queue, which could address the task above by using deduplication.
+- Evolving the single-slot PostgreSQL state into a full durable work/outbox table while retaining SQS as a doorbell during migration.
 - Change the /index endpoint to only pull and index one item per transaction, which would eliminate need for the deferred queue.
 - Ordering of items on the queue, either at time of create_mapping (initial indexing) or for ongoing indexing.
 - Speed up indexing by refining what items are considered invalid when an item is indexed (in most cases, secondary items do not need to be reindexed).

--- a/docs/source/embedding-and-indexing.rst
+++ b/docs/source/embedding-and-indexing.rst
@@ -139,9 +139,11 @@ Operations and rollout
   default, is capped at 1,000 rows, and is audit-logged with the authenticated
   principal.  ``requeue=true`` keeps rows pending, commits a fresh ``queued_at``,
   and then sends; a failed administrative send is therefore still sweepable.
-* Moving from ``off`` or ``shadow`` to ``on`` requires a dry run followed by a
-  namespace reset.  Turning ``on`` back to ``off`` is an immediate safe kill
-  switch because off mode sends every fan-out target through the original path.
+* Treat rollout as one-way after the state table is deployed: use a dry run
+  followed by a namespace reset before moving from ``off`` or ``shadow`` to
+  ``on``, then keep coalescing enabled.  If rollback is required, roll back the
+  database and the associated application version together rather than changing
+  the runtime mode independently.
 
 Structured logs use ``coalescing_event`` to expose fan-out targets/suppression,
 database and SQS enqueue failures, claims and stale deferrals, sweeper repairs,

--- a/docs/source/embedding-and-indexing.rst
+++ b/docs/source/embedding-and-indexing.rst
@@ -120,9 +120,9 @@ Defaults are 1,800 seconds before repair, a 300 second sweep interval, and 500 r
 per sweep; configure these with
 ``indexer.coalesce_secondary.stale_seconds``,
 ``indexer.coalesce_secondary.sweep_interval``, and
-``indexer.coalesce_secondary.sweep_limit``.  The sweeper uses the partial covering
-index and ``FOR UPDATE SKIP LOCKED`` so multiple listeners or operator actions do
-not wait on hot rows.
+``indexer.coalesce_secondary.sweep_limit``.  The sweeper uses the partial
+``(namespace, queued_at) WHERE pending`` index and ``FOR UPDATE SKIP LOCKED`` so
+multiple listeners or operator actions do not wait on hot rows.
 
 Operations and rollout
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -159,9 +159,11 @@ The table is registered in ``snovault.storage.Base`` and is created by the norma
 disable automatic table creation must apply the SQLAlchemy-generated table, index,
 and storage-parameter DDL before enabling ``shadow``; no backfill is required.
 The table uses fillfactor 70 and aggressive per-table autovacuum scale factors
-(0.02 vacuum, 0.05 analyze).  Suppression updates normally touch only the unindexed
-``queued_sid`` and are HOT-eligible; transitions necessarily change the partial
-index predicate.  Resource deletion cascades to state rows, and inactive rows are
+(0.02 vacuum, 0.05 analyze).  ``queued_sid`` is deliberately kept out of every
+index (keys and INCLUDE lists alike; INCLUDE columns also block HOT), so
+suppression updates that only merge a newer sid into an already-pending row are
+HOT-eligible; pending transitions and sweeper re-arms necessarily touch the
+partial index.  Resource deletion cascades to state rows, and inactive rows are
 bounded by resources multiplied by active environment namespaces.
 
 Each producer batch or consumer claim checks out one additional connection only
@@ -170,8 +172,8 @@ call or an ES render.  Before enabling ``shadow``, operators must verify databas
 pool and PostgreSQL ``max_connections`` headroom for the maximum concurrent indexer
 workers, then measure actual table/index growth, WAL, dead tuples/autovacuum cadence,
 batch transaction latency, sweep lag, and suppression ratio.  The implementation
-batches at 500 targets, uses primary-key point locks, and uses a covering partial
-index for sweeps; these measurements, rather than an assumed production item or
+batches at 500 targets, uses primary-key point locks, and uses a partial index
+for sweeps; these measurements, rather than an assumed production item or
 edit count, determine capacity.
 
 A couple endpoints were added to make the queue more useful. First, /indexing_status takes a GET request and returns waiting and in-flight counts for the three queues. The /queue_indexing endpoint is a POST endpoint used to manually queue items. It requires administrator privileges and takes a JSON body where you can either specify a list of `collections` (e.g. file_fastq or biosample) or a list of `uuids` for indexing. You can also specify whether the items should be indexed in strict mode using the `strict` keyword and a boolean value. Lastly, you can specify which queue you want to send your items to using the `target_queue` keyword and a value of `primary`, `secondary`, or `dlq`. The default strict value is False and the default target is primary.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.33.1"
+version = "11.34.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/elasticsearch/__init__.py
+++ b/snovault/elasticsearch/__init__.py
@@ -48,6 +48,7 @@ def includeme(config):
     config.include('.cached_views')
     config.include('.esstorage')
     config.include('.indexer_queue')
+    config.include('.secondary_indexing')
     config.include('.indexer_utils')  # has invalidation_scope route
     config.include('.indexer')
     if asbool(settings.get('mpindexer')):

--- a/snovault/elasticsearch/create_mapping.py
+++ b/snovault/elasticsearch/create_mapping.py
@@ -1239,10 +1239,28 @@ def _release_secondary_coalescing(registry):
         coalescer.release_all()
 
 
-def _release_secondary_coalescing_targets(registry, target_uuids):
+def _snapshot_secondary_coalescing_targets(registry, target_uuids):
     coalescer = registry.get(SECONDARY_INDEXING_COALESCER)
     if coalescer is not None and target_uuids:
-        coalescer.release_targets(target_uuids)
+        return coalescer.snapshot_targets(target_uuids)
+    return {}
+
+
+def _release_secondary_coalescing_targets(registry, target_states):
+    coalescer = registry.get(SECONDARY_INDEXING_COALESCER)
+    if coalescer is not None and target_states:
+        coalescer.release_targets(target_states)
+
+
+def _successful_secondary_targets(queued, failed):
+    if not failed:
+        return list(queued)
+    failed_uuids = set()
+    for failure in failed:
+        if not isinstance(failure, dict) or not failure.get('uuid'):
+            return []
+        failed_uuids.add(failure['uuid'])
+    return [target for target in queued if target not in failed_uuids]
 
 
 # Will thinks this is no longer needed. -kmp 11-Mar-2023
@@ -1433,9 +1451,11 @@ def run(app, collections=None, dry_run=False, check_first=False, skip_indexing=F
                      cat='uuids to index', count=len(to_index_list))
 
             # Will suggested this substitute way to implement this indexing action. -kmp 11-Mar-2023
+            target_states = _snapshot_secondary_coalescing_targets(registry, to_index_list)
             vapp = make_indexer_testapp(app)
-            vapp.post_json('/index', {'record': True, 'uuids': to_index_list})
-            _release_secondary_coalescing_targets(registry, to_index_list)
+            result = vapp.post_json('/index', {'record': True, 'uuids': to_index_list})
+            if result.json.get('errors') == []:
+                _release_secondary_coalescing_targets(registry, target_states)
             # run_indexing(app, to_index_list)
 
         else:
@@ -1454,17 +1474,14 @@ def run(app, collections=None, dry_run=False, check_first=False, skip_indexing=F
             to_index_list = flatten_and_sort_uuids(app.registry, uuids_to_index, item_order)
             log.info('\n___UUIDS TO INDEX (QUEUED)___: %s\n' % len(to_index_list),
                      cat='uuids to index', count=len(to_index_list))
+            target_states = _snapshot_secondary_coalescing_targets(registry, to_index_list)
             queued, failed = indexer_queue.add_uuids(
                 app.registry, to_index_list, strict=use_strict,
                 target_queue='secondary', telemetry_id=telemetry_id)
-            failed_uuids = {
-                failure.get('uuid')
-                for failure in failed or []
-                if isinstance(failure, dict) and failure.get('uuid')
-            }
+            successful = _successful_secondary_targets(queued, failed)
             _release_secondary_coalescing_targets(
                 registry,
-                [target for target in queued if target not in failed_uuids],
+                {target: target_states[target] for target in successful if target in target_states},
             )
     return timings
 
@@ -1495,16 +1512,13 @@ def reindex_by_type_staggered(app):
         build_index(app, es, namespaced_index, i_type, mapping, uuids, False)
         mapping_end = timer()
         to_index_list = flatten_and_sort_uuids(app.registry, uuids, None)  # none here is fine since we pre-ordered
+        target_states = _snapshot_secondary_coalescing_targets(registry, to_index_list)
         queued, failed = indexer_queue.add_uuids(
             app.registry, to_index_list, strict=True, target_queue='secondary')
-        failed_uuids = {
-            failure.get('uuid')
-            for failure in failed or []
-            if isinstance(failure, dict) and failure.get('uuid')
-        }
+        successful = _successful_secondary_targets(queued, failed)
         _release_secondary_coalescing_targets(
             registry,
-            [target for target in queued if target not in failed_uuids],
+            {target: target_states[target] for target in successful if target in target_states},
         )
         log.warning(f'Queued type {i_type} ({len(to_index_list)} total items) in {mapping_end - current_start}')
         log.warning(f'First 10 items: {list(uuid for uuid in to_index_list[0:10])}')

--- a/snovault/elasticsearch/create_mapping.py
+++ b/snovault/elasticsearch/create_mapping.py
@@ -1232,6 +1232,13 @@ def flatten_and_sort_uuids(registry, uuids_to_index, item_order):
         to_index_list.extend(uuids_to_index[itype])
     return to_index_list
 
+
+def _release_secondary_coalescing(registry):
+    coalescer = registry.get(SECONDARY_INDEXING_COALESCER)
+    if coalescer is not None:
+        coalescer.release_all()
+
+
 # Will thinks this is no longer needed. -kmp 11-Mar-2023
 #
 # def run_indexing(app, indexing_uuids):
@@ -1320,9 +1327,7 @@ def run(app, collections=None, dry_run=False, check_first=False, skip_indexing=F
         if not indexer_queue.queue_is_empty(secondary_only=False, include_inflight=True):
             indexer_queue.purge_queue()
         else:
-            coalescer = registry.get(SECONDARY_INDEXING_COALESCER)
-            if coalescer is not None:
-                coalescer.release_all()
+            _release_secondary_coalescing(registry)
         # we also want to remove the 'indexing' index, which stores old records
         # it's not guaranteed to be there, though
         es_safe_execute(es.indices.delete, index=namespaced_index, ignore=[404])
@@ -1383,6 +1388,9 @@ def run(app, collections=None, dry_run=False, check_first=False, skip_indexing=F
              cat='overall mapping time', duration=str(overall_end - overall_start))
     if skip_indexing or print_count_only:
         return timings
+
+    if uuids_to_index and not dry_run:
+        _release_secondary_coalescing(registry)
 
     # now, queue items for indexing in the secondary queue
     # get a total list of all uuids to index among types for invalidation checking
@@ -1473,6 +1481,7 @@ def reindex_by_type_staggered(app):
         build_index(app, es, namespaced_index, i_type, mapping, uuids, False)
         mapping_end = timer()
         to_index_list = flatten_and_sort_uuids(app.registry, uuids, None)  # none here is fine since we pre-ordered
+        _release_secondary_coalescing(registry)
         indexer_queue.add_uuids(app.registry, to_index_list, strict=True,
                                 target_queue='secondary')
         log.warning(f'Queued type {i_type} ({len(to_index_list)} total items) in {mapping_end - current_start}')

--- a/snovault/elasticsearch/create_mapping.py
+++ b/snovault/elasticsearch/create_mapping.py
@@ -1239,6 +1239,12 @@ def _release_secondary_coalescing(registry):
         coalescer.release_all()
 
 
+def _release_secondary_coalescing_targets(registry, target_uuids):
+    coalescer = registry.get(SECONDARY_INDEXING_COALESCER)
+    if coalescer is not None and target_uuids:
+        coalescer.release_targets(target_uuids)
+
+
 # Will thinks this is no longer needed. -kmp 11-Mar-2023
 #
 # def run_indexing(app, indexing_uuids):
@@ -1389,9 +1395,6 @@ def run(app, collections=None, dry_run=False, check_first=False, skip_indexing=F
     if skip_indexing or print_count_only:
         return timings
 
-    if uuids_to_index and not dry_run:
-        _release_secondary_coalescing(registry)
-
     # now, queue items for indexing in the secondary queue
     # get a total list of all uuids to index among types for invalidation checking
     len_all_uuids = sum([len(uuids_to_index[i_type]) for i_type in uuids_to_index])
@@ -1432,6 +1435,7 @@ def run(app, collections=None, dry_run=False, check_first=False, skip_indexing=F
             # Will suggested this substitute way to implement this indexing action. -kmp 11-Mar-2023
             vapp = make_indexer_testapp(app)
             vapp.post_json('/index', {'record': True, 'uuids': to_index_list})
+            _release_secondary_coalescing_targets(registry, to_index_list)
             # run_indexing(app, to_index_list)
 
         else:
@@ -1450,8 +1454,18 @@ def run(app, collections=None, dry_run=False, check_first=False, skip_indexing=F
             to_index_list = flatten_and_sort_uuids(app.registry, uuids_to_index, item_order)
             log.info('\n___UUIDS TO INDEX (QUEUED)___: %s\n' % len(to_index_list),
                      cat='uuids to index', count=len(to_index_list))
-            indexer_queue.add_uuids(app.registry, to_index_list, strict=use_strict,
-                                    target_queue='secondary', telemetry_id=telemetry_id)
+            queued, failed = indexer_queue.add_uuids(
+                app.registry, to_index_list, strict=use_strict,
+                target_queue='secondary', telemetry_id=telemetry_id)
+            failed_uuids = {
+                failure.get('uuid')
+                for failure in failed or []
+                if isinstance(failure, dict) and failure.get('uuid')
+            }
+            _release_secondary_coalescing_targets(
+                registry,
+                [target for target in queued if target not in failed_uuids],
+            )
     return timings
 
 
@@ -1481,9 +1495,17 @@ def reindex_by_type_staggered(app):
         build_index(app, es, namespaced_index, i_type, mapping, uuids, False)
         mapping_end = timer()
         to_index_list = flatten_and_sort_uuids(app.registry, uuids, None)  # none here is fine since we pre-ordered
-        _release_secondary_coalescing(registry)
-        indexer_queue.add_uuids(app.registry, to_index_list, strict=True,
-                                target_queue='secondary')
+        queued, failed = indexer_queue.add_uuids(
+            app.registry, to_index_list, strict=True, target_queue='secondary')
+        failed_uuids = {
+            failure.get('uuid')
+            for failure in failed or []
+            if isinstance(failure, dict) and failure.get('uuid')
+        }
+        _release_secondary_coalescing_targets(
+            registry,
+            [target for target in queued if target not in failed_uuids],
+        )
         log.warning(f'Queued type {i_type} ({len(to_index_list)} total items) in {mapping_end - current_start}')
         log.warning(f'First 10 items: {list(uuid for uuid in to_index_list[0:10])}')
         time.sleep(10)  # give queue some time to catch up

--- a/snovault/elasticsearch/create_mapping.py
+++ b/snovault/elasticsearch/create_mapping.py
@@ -51,7 +51,7 @@ from .calculated_property_signature import (
     calculated_properties_signature,
 )
 from ..schema_utils import load_schema
-from .interfaces import ELASTIC_SEARCH, INDEXER_QUEUE
+from .interfaces import ELASTIC_SEARCH, INDEXER_QUEUE, SECONDARY_INDEXING_COALESCER
 from ..settings import Settings
 
 
@@ -1319,6 +1319,10 @@ def run(app, collections=None, dry_run=False, check_first=False, skip_indexing=F
         log.info('___PURGING THE QUEUE (IF NECESSARY) AND CLEARING INDEXING RECORDS BEFORE MAPPING___\n', cat=cat)
         if not indexer_queue.queue_is_empty(secondary_only=False, include_inflight=True):
             indexer_queue.purge_queue()
+        else:
+            coalescer = registry.get(SECONDARY_INDEXING_COALESCER)
+            if coalescer is not None:
+                coalescer.release_all()
         # we also want to remove the 'indexing' index, which stores old records
         # it's not guaranteed to be there, though
         es_safe_execute(es.indices.delete, index=namespaced_index, ignore=[404])

--- a/snovault/elasticsearch/es_index_listener.py
+++ b/snovault/elasticsearch/es_index_listener.py
@@ -24,7 +24,11 @@ from dcicutils.log_utils import set_logging
 from dcicutils.misc_utils import ignored
 from pyramid import paster
 
-from .interfaces import ELASTIC_SEARCH, INDEXER_QUEUE
+from .interfaces import ELASTIC_SEARCH, INDEXER_QUEUE, SECONDARY_INDEXING_COALESCER
+from .secondary_indexing import (
+    COALESCING_SWEEP_INTERVAL_SETTING,
+    DEFAULT_SWEEP_INTERVAL,
+)
 
 
 log = structlog.getLogger(__name__)
@@ -52,9 +56,23 @@ def run(testapp, interval=DEFAULT_INTERVAL, dry_run=False, path='/index', update
     es.info()
 
     queue = testapp.app.registry[INDEXER_QUEUE]
+    coalescer = testapp.app.registry.get(SECONDARY_INDEXING_COALESCER)
+    last_coalescing_sweep = 0
 
     # main listening loop
     while True:
+        sweep_interval = int(testapp.app.registry.settings.get(
+            COALESCING_SWEEP_INTERVAL_SETTING, DEFAULT_SWEEP_INTERVAL))
+        if (coalescer is not None and coalescer.enabled and sweep_interval > 0
+                and time.monotonic() - last_coalescing_sweep >= sweep_interval):
+            # Rearm rows in PostgreSQL and commit before contacting SQS. A send
+            # failure therefore remains recoverable on a later bounded sweep.
+            try:
+                coalescer.sweep()
+            except Exception:
+                log.exception('Secondary coalescing sweep failed')
+            finally:
+                last_coalescing_sweep = time.monotonic()
         # if not messages to index, skip the /index call. Counts are approximate
         queue_counts = queue.number_of_messages()
         if not queue_counts['primary_waiting'] and not queue_counts['secondary_waiting']:

--- a/snovault/elasticsearch/es_index_listener.py
+++ b/snovault/elasticsearch/es_index_listener.py
@@ -36,6 +36,17 @@ log = structlog.getLogger(__name__)
 EPILOG = __doc__
 DEFAULT_INTERVAL = 3  # 3 second default
 
+
+def coalescing_sweep_interval(settings):
+    try:
+        interval = int(settings.get(COALESCING_SWEEP_INTERVAL_SETTING, DEFAULT_SWEEP_INTERVAL))
+        return max(0, interval)
+    except (TypeError, ValueError, OverflowError):
+        log.error('Invalid secondary coalescing sweep interval; using default',
+                  configured_interval=settings.get(COALESCING_SWEEP_INTERVAL_SETTING),
+                  default_interval=DEFAULT_SWEEP_INTERVAL)
+        return DEFAULT_SWEEP_INTERVAL
+
 # We need this because of MVCC visibility.
 # See slide 9 at http://momjian.us/main/writings/pgsql/mvcc.pdf
 # https://devcenter.heroku.com/articles/postgresql-concurrency
@@ -57,13 +68,13 @@ def run(testapp, interval=DEFAULT_INTERVAL, dry_run=False, path='/index', update
 
     queue = testapp.app.registry[INDEXER_QUEUE]
     coalescer = testapp.app.registry.get(SECONDARY_INDEXING_COALESCER)
+    coalescing_enabled = coalescer is not None and coalescer.enabled
+    sweep_interval = coalescing_sweep_interval(testapp.app.registry.settings) if coalescing_enabled else 0
     last_coalescing_sweep = 0
 
     # main listening loop
     while True:
-        sweep_interval = int(testapp.app.registry.settings.get(
-            COALESCING_SWEEP_INTERVAL_SETTING, DEFAULT_SWEEP_INTERVAL))
-        if (coalescer is not None and coalescer.enabled and sweep_interval > 0
+        if (coalescing_enabled and sweep_interval > 0
                 and time.monotonic() - last_coalescing_sweep >= sweep_interval):
             # Rearm rows in PostgreSQL and commit before contacting SQS. A send
             # failure therefore remains recoverable on a later bounded sweep.

--- a/snovault/elasticsearch/es_index_listener.py
+++ b/snovault/elasticsearch/es_index_listener.py
@@ -47,6 +47,12 @@ def coalescing_sweep_interval(settings):
                   default_interval=DEFAULT_SWEEP_INTERVAL)
         return DEFAULT_SWEEP_INTERVAL
 
+
+def coalescing_sweep_configuration(coalescer, settings):
+    enabled = coalescer is not None and coalescer.enabled
+    return enabled, coalescing_sweep_interval(settings) if enabled else 0
+
+
 # We need this because of MVCC visibility.
 # See slide 9 at http://momjian.us/main/writings/pgsql/mvcc.pdf
 # https://devcenter.heroku.com/articles/postgresql-concurrency
@@ -68,12 +74,16 @@ def run(testapp, interval=DEFAULT_INTERVAL, dry_run=False, path='/index', update
 
     queue = testapp.app.registry[INDEXER_QUEUE]
     coalescer = testapp.app.registry.get(SECONDARY_INDEXING_COALESCER)
-    coalescing_enabled = coalescer is not None and coalescer.enabled
-    sweep_interval = coalescing_sweep_interval(testapp.app.registry.settings) if coalescing_enabled else 0
+    coalescing_enabled = False
     last_coalescing_sweep = 0
 
     # main listening loop
     while True:
+        next_coalescing_enabled, sweep_interval = coalescing_sweep_configuration(
+            coalescer, testapp.app.registry.settings)
+        if next_coalescing_enabled and not coalescing_enabled:
+            last_coalescing_sweep = 0
+        coalescing_enabled = next_coalescing_enabled
         if (coalescing_enabled and sweep_interval > 0
                 and time.monotonic() - last_coalescing_sweep >= sweep_interval):
             # Rearm rows in PostgreSQL and commit before contacting SQS. A send

--- a/snovault/elasticsearch/indexer.py
+++ b/snovault/elasticsearch/indexer.py
@@ -23,7 +23,9 @@ from .indexer_utils import get_namespaced_index, find_uuids_for_indexing, filter
 from .interfaces import (
     ELASTIC_SEARCH,
     INDEXER,
-    INDEXER_QUEUE, INVALIDATION_SCOPE_ENABLED
+    INDEXER_QUEUE,
+    INVALIDATION_SCOPE_ENABLED,
+    SECONDARY_INDEXING_COALESCER,
 )
 from ..embed import MissingIndexItemException
 from ..util import debug_log, dictionary_lookup
@@ -168,6 +170,7 @@ class Indexer(object):
         self.registry = registry
         self.es = registry[ELASTIC_SEARCH]
         self.queue = registry[INDEXER_QUEUE]
+        self.secondary_coalescer = registry[SECONDARY_INDEXING_COALESCER]
 
     def update_objects(self, request, counter):
         """
@@ -232,6 +235,14 @@ class Indexer(object):
         secondary_uuids |= rev_linked_uuids
 
         # items queued through this function are ALWAYS strict in secondary queue
+        # and contain no field diffs. Coalescing happens only here, after linker
+        # discovery, invalidation-scope filtering, and rev-link augmentation have
+        # selected the final full-render target set.
+        if self.secondary_coalescer.enabled:
+            return self.secondary_coalescer.enqueue(
+                secondary_uuids, sid=sid, telemetry_id=telemetry_id)
+        # Keep the rollout-off path byte-for-byte behavior-compatible with the
+        # original secondary producer (including payload shape and queue call).
         return self.queue.add_uuids(self.registry, list(secondary_uuids), strict=True,
                                     target_queue='secondary', sid=sid,
                                     telemetry_id=telemetry_id)
@@ -269,6 +280,25 @@ class Indexer(object):
         while len(messages) > 0:
             for idx, msg in enumerate(messages):
                 msg_body = json.loads(msg['Body'])
+                msg_attributes = msg.get('Attributes', {})
+                receive_count = msg_attributes.get('ApproximateReceiveCount')
+                sent_timestamp = msg_attributes.get('SentTimestamp')
+                queue_latency_ms = None
+                try:
+                    if sent_timestamp is not None:
+                        queue_latency_ms = max(0, int(time.time() * 1000) - int(sent_timestamp))
+                except (TypeError, ValueError):
+                    pass
+                log.info(
+                    'Indexer queue message received',
+                    target_queue=target_queue,
+                    item_uuid=msg_body.get('uuid'),
+                    strict=msg_body.get('strict'),
+                    coalesced=msg_body.get('coalesced', False),
+                    origin=msg_body.get('origin'),
+                    approximate_receive_count=receive_count,
+                    queue_latency_ms=queue_latency_ms,
+                )
 
                 # handle case where worker needs to restart
                 # recycle additional messages (no effect on dlq count) and
@@ -294,18 +324,48 @@ class Indexer(object):
                 msg_telemetry = msg_body.get('telemetry_id')
                 msg_diff = msg_body.get('diff', None)
 
+                effective_sid = msg_sid
+                error = None
+                if msg_body.get('coalesced') and self.secondary_coalescer.enabled:
+                    try:
+                        claim = self.secondary_coalescer.claim(
+                            msg_uuid,
+                            msg_sid,
+                            max_sid,
+                            origin=msg_body.get('origin'),
+                            receive_count=receive_count,
+                        )
+                    except Exception as claim_error:
+                        log.exception(
+                            'Secondary coalescing consumer claim failed',
+                            coalescing_event='claim_failure',
+                            item_uuid=msg_uuid,
+                            namespace=self.secondary_coalescer.namespace,
+                        )
+                        error = {
+                            'error_message': repr(claim_error),
+                            'time': msg_curr_time,
+                            'uuid': str(msg_uuid),
+                        }
+                    else:
+                        effective_sid = claim['effective_sid']
+                        if claim['outcome'] == 'deferred_stale':
+                            # The claim transaction rolled back, so pending remains true
+                            # while the existing defer/resend path obtains a fresh snapshot.
+                            error = {'error_message': 'defer_resend'}
+
                 # build the object and index into ES
                 # if strict, do not add uuids rev_linking to item to queue
-                if msg_body['strict'] is True:
+                if error is None and msg_body['strict'] is True:
                     error = self.update_object(request, msg_uuid,
                                                add_to_secondary=None,
-                                               sid=msg_sid, max_sid=max_sid,
+                                               sid=effective_sid, max_sid=max_sid,
                                                curr_time=msg_curr_time,
                                                telemetry_id=msg_telemetry)
-                else:
+                elif error is None:
                     error = self.update_object(request, msg_uuid,
                                                add_to_secondary=rev_linked_uuids,
-                                               sid=msg_sid, max_sid=max_sid,
+                                               sid=effective_sid, max_sid=max_sid,
                                                curr_time=msg_curr_time,
                                                telemetry_id=msg_telemetry)
                 if error:
@@ -481,21 +541,49 @@ class Indexer(object):
                 # this may be somewhat common and is not harmful
                 # do not return an error so item is removed from queue
                 duration = timer() - start
-                log.warning('Conflict indexing', sid=result['sid'], duration=duration, cat=cat)
+                log.warning(
+                    'Conflict indexing',
+                    sid=result['sid'],
+                    requested_sid=sid,
+                    snapshot_max_sid=max_sid,
+                    index_outcome='conflict_stale_write',
+                    duration=duration,
+                    cat=cat,
+                )
                 return
             except (ConnectionError, ReadTimeoutError, TransportError) as e:
                 duration = timer() - start
-                log.warning('Retryable error indexing', error=str(e), duration=duration, cat=cat)
+                log.warning(
+                    'Retryable error indexing',
+                    error=str(e),
+                    index_outcome='retryable_failure',
+                    duration=duration,
+                    cat=cat,
+                )
                 last_exc = repr(e)
             except Exception as e:
                 duration = timer() - start
-                log.error('Error indexing', duration=duration, exc_info=True, cat=cat)
+                log.error(
+                    'Error indexing',
+                    index_outcome='failure',
+                    duration=duration,
+                    exc_info=True,
+                    cat=cat,
+                )
                 last_exc = repr(e)
                 break
             else:
                 # success! Do not return an error so item is removed from queue
                 duration = timer() - start
-                log.info('Time to index', duration=duration, cat=cat)
+                log.info(
+                    'Time to index',
+                    sid=result['sid'],
+                    requested_sid=sid,
+                    snapshot_max_sid=max_sid,
+                    index_outcome='success',
+                    duration=duration,
+                    cat=cat,
+                )
                 return
         # returning an error message means item did not index
         return {'error_message': last_exc, 'time': curr_time, 'uuid': str(uuid)}

--- a/snovault/elasticsearch/indexer.py
+++ b/snovault/elasticsearch/indexer.py
@@ -341,12 +341,8 @@ class Indexer(object):
                             coalescing_event='claim_failure',
                             item_uuid=msg_uuid,
                             namespace=self.secondary_coalescer.namespace,
+                            error=repr(claim_error),
                         )
-                        error = {
-                            'error_message': repr(claim_error),
-                            'time': msg_curr_time,
-                            'uuid': str(msg_uuid),
-                        }
                     else:
                         effective_sid = claim['effective_sid']
                         if claim['outcome'] == 'deferred_stale':

--- a/snovault/elasticsearch/indexer.py
+++ b/snovault/elasticsearch/indexer.py
@@ -323,10 +323,11 @@ class Indexer(object):
 
                 msg_telemetry = msg_body.get('telemetry_id')
                 msg_diff = msg_body.get('diff', None)
+                coalesced_message = bool(msg_body.get('coalesced'))
 
                 effective_sid = msg_sid
                 error = None
-                if msg_body.get('coalesced') and self.secondary_coalescer.enabled:
+                if coalesced_message and self.secondary_coalescer.enabled:
                     try:
                         claim = self.secondary_coalescer.claim(
                             msg_uuid,
@@ -383,6 +384,17 @@ class Indexer(object):
                         errors.append(error)
                 else:
                     # Sucessfully processed! (i.e. indexed or discarded conflict)
+                    if coalesced_message and not self.secondary_coalescer.enabled:
+                        try:
+                            self.secondary_coalescer.release(msg_uuid)
+                        except Exception as release_error:
+                            log.exception(
+                                'Secondary coalescing marker cleanup failed',
+                                coalescing_event='marker_cleanup_failure',
+                                item_uuid=msg_uuid,
+                                namespace=self.secondary_coalescer.namespace,
+                                error=repr(release_error),
+                            )
                     # if non-strict, adding will queue associated items to secondary
                     if msg_body['strict'] is False:
                         non_strict_uuids.add(msg_uuid)

--- a/snovault/elasticsearch/indexer.py
+++ b/snovault/elasticsearch/indexer.py
@@ -391,18 +391,15 @@ class Indexer(object):
                     if msg_body['strict'] is False:
                         non_strict_uuids.add(msg_uuid)
                     counter[0] += 1  # do not increment on error
-                    to_delete.append(msg)
-
-                # delete messages when we have the right number
-                if len(to_delete) == self.queue.delete_batch_size:
-                    self.queue.delete_messages(to_delete, target_queue=target_queue)
-                    to_delete = []
 
                 # CHANGE - this needs to happen PER MESSAGE now
                 # add to secondary queue, if applicable
                 # search for all items that linkTo the non-strict items or contain
                 # a rev_link to them
                 if non_strict_uuids or rev_linked_uuids:
+                    if to_delete and len(to_delete) + 1 >= self.queue.delete_batch_size:
+                        self.queue.delete_messages(to_delete, target_queue=target_queue)
+                        to_delete = []
                     queued, failed = self.find_and_queue_secondary_items(non_strict_uuids,  # THIS IS NOW A SINGLE UUID
                                                                          rev_linked_uuids,
                                                                          msg_sid,
@@ -414,6 +411,14 @@ class Indexer(object):
                         errors.append({'error_message': error_msg})
                     non_strict_uuids = set()
                     rev_linked_uuids = set()
+
+                if error is None:
+                    to_delete.append(msg)
+
+                # delete messages when we have the right number
+                if len(to_delete) == self.queue.delete_batch_size:
+                    self.queue.delete_messages(to_delete, target_queue=target_queue)
+                    to_delete = []
 
             # if we need to restart the worker, break out of while loop
             if deferred:

--- a/snovault/elasticsearch/indexer_queue.py
+++ b/snovault/elasticsearch/indexer_queue.py
@@ -606,14 +606,27 @@ class QueueManager(object):
                 to_retry = []
                 for fail_message in failed_messages:
                     fail_id = fail_message.get('Id')
-                    if not fail_id:
+                    if fail_id is None:
                         log.error('INDEXING: Non-retryable error sending message: %s' %
                                   str(fail_message), target_queue=target_queue)
                         continue  # cannot retry this message without an Id
                     to_retry.extend([json.loads(ent['MessageBody']) for ent in entries if ent['Id'] == fail_id])
                 if to_retry:
                     failed_messages = self.send_messages(to_retry, target_queue, retries=retries+1)
-            failed.extend(failed_messages)
+            for failed_message in failed_messages:
+                if (isinstance(failed_message, dict)
+                        and not failed_message.get('uuid')):
+                    fail_id = failed_message.get('Id')
+                    try:
+                        failed_index = int(fail_id)
+                    except (TypeError, ValueError):
+                        failed_index = None
+                    if (failed_index is not None and 0 <= failed_index < len(msg_batch)
+                            and isinstance(msg_batch[failed_index], dict)
+                            and msg_batch[failed_index].get('uuid')):
+                        failed_message = dict(failed_message)
+                        failed_message['uuid'] = msg_batch[failed_index]['uuid']
+                failed.append(failed_message)
         return failed
 
     def receive_messages(self, target_queue='primary', wait_time_seconds=2):

--- a/snovault/elasticsearch/indexer_queue.py
+++ b/snovault/elasticsearch/indexer_queue.py
@@ -17,7 +17,11 @@ from dcicutils.misc_utils import ignored, RateManager, LockoutManager
 from pyramid.view import view_config
 
 from .indexer_utils import get_uuids_for_types
-from .interfaces import INDEXER_QUEUE, INDEXER_QUEUE_MIRROR
+from .interfaces import (
+    INDEXER_QUEUE,
+    INDEXER_QUEUE_MIRROR,
+    SECONDARY_INDEXING_COALESCER,
+)
 from ..util import debug_log
 
 log = structlog.getLogger(__name__)
@@ -125,6 +129,17 @@ def indexing_status(context, request):
     else:
         for queue in numbers:
             response[queue] = numbers[queue]
+        coalescer = request.registry.get(SECONDARY_INDEXING_COALESCER)
+        if coalescer is not None and coalescer.enabled:
+            try:
+                response['secondary_coalescing'] = coalescer.status()
+            except Exception as error:
+                log.exception('Unable to read secondary coalescing status')
+                response['secondary_coalescing'] = {
+                    'mode': coalescer.mode,
+                    'namespace': coalescer.namespace,
+                    'status_error': repr(error),
+                }
         response['display_title'] = 'Indexing Status'
         response['status'] = 'Success'
     return response
@@ -301,7 +316,7 @@ class QueueManager(object):
         return namespace[:80].replace('.', '-').replace(' ', '').replace("’", '')
 
     def add_uuids(self, registry, uuids, strict=False, target_queue='primary',
-                  sid=None, telemetry_id=None):
+                  sid=None, telemetry_id=None, coalesced=False, origin=None):
         """
         Takes a list of string uuids queues them up. Also requires a registry,
         which is passed in automatically when using the /queue_indexing route.
@@ -322,6 +337,10 @@ class QueueManager(object):
             temp = {'uuid': uuid, 'sid': sid, 'strict': strict, 'timestamp': curr_time}
             if telemetry_id:
                 temp['telemetry_id'] = telemetry_id
+            if coalesced:
+                temp['coalesced'] = True
+            if origin:
+                temp['origin'] = origin
             items.append(temp)
         failed = self.send_messages(items, target_queue=target_queue)
         return uuids, failed
@@ -610,7 +629,8 @@ class QueueManager(object):
         response = self.client.receive_message(
             QueueUrl=queue_url,
             MaxNumberOfMessages=self.receive_batch_size,
-            WaitTimeSeconds=wait_time_seconds
+            WaitTimeSeconds=wait_time_seconds,
+            AttributeNames=['ApproximateReceiveCount', 'SentTimestamp'],
         )
         # messages in response include ReceiptHandle and Body, most importantly
         return response.get('Messages', [])
@@ -640,7 +660,15 @@ class QueueManager(object):
                 QueueUrl=queue_url,
                 Entries=batch
             )
-            failed.extend(response.get('Failed', []))
+            batch_failures = response.get('Failed', [])
+            if batch_failures:
+                log.error(
+                    'INDEXING: SQS message deletion failed',
+                    target_queue=target_queue,
+                    failure_count=len(batch_failures),
+                    failures=batch_failures,
+                )
+            failed.extend(batch_failures)
         return failed
 
     def replace_messages(self, messages, target_queue='primary', vis_timeout=5):

--- a/snovault/elasticsearch/indexer_queue.py
+++ b/snovault/elasticsearch/indexer_queue.py
@@ -223,6 +223,7 @@ class QueueManager(object):
         self.receive_batch_size = 10
         self.delete_batch_size = 10
         self.replace_batch_size = 10
+        self.registry = registry
         if self.USE_RATE_MANAGER:
             self.collision_manager = RateManager(action="purge_queue", interval_seconds=self.PURGE_QUEUE_LOCKOUT_SECONDS,
                                                  safety_seconds=self.PURGE_QUEUE_SAFETY_SECONDS,
@@ -511,6 +512,10 @@ class QueueManager(object):
             except self.client.exceptions.PurgeQueueInProgress:
                 log.warning('\n___QUEUE IS ALREADY BEING PURGED: %s___\n' % queue_url,
                             queue_url=queue_url)
+        coalescer = (self.registry.get(SECONDARY_INDEXING_COALESCER)
+                     if hasattr(self.registry, 'get') else None)
+        if coalescer is not None and coalescer.namespace == self.env_name:
+            coalescer.release_all()
 
     def clear_queue(self):
         """

--- a/snovault/elasticsearch/indexer_queue.py
+++ b/snovault/elasticsearch/indexer_queue.py
@@ -540,6 +540,8 @@ class QueueManager(object):
         response = self.client.delete_queue(
             QueueUrl=queue_url
         )
+        if queue_url in {self.second_queue_url, self.dlq_url}:
+            self._release_secondary_state()
         setattr(self, queue_url, None)
         return response
 

--- a/snovault/elasticsearch/indexer_queue.py
+++ b/snovault/elasticsearch/indexer_queue.py
@@ -512,6 +512,9 @@ class QueueManager(object):
             except self.client.exceptions.PurgeQueueInProgress:
                 log.warning('\n___QUEUE IS ALREADY BEING PURGED: %s___\n' % queue_url,
                             queue_url=queue_url)
+        self._release_secondary_state()
+
+    def _release_secondary_state(self):
         coalescer = (self.registry.get(SECONDARY_INDEXING_COALESCER)
                      if hasattr(self.registry, 'get') else None)
         if coalescer is not None and coalescer.namespace == self.env_name:
@@ -527,6 +530,7 @@ class QueueManager(object):
             while msgs:
                 self.delete_messages(msgs, target)
                 msgs = self.receive_messages(target)
+        self._release_secondary_state()
 
     def delete_queue(self, queue_url):
         """

--- a/snovault/elasticsearch/interfaces.py
+++ b/snovault/elasticsearch/interfaces.py
@@ -6,6 +6,7 @@ ELASTIC_SEARCH = 'elasticsearch'
 INDEXER = 'indexer'
 INDEXER_QUEUE = 'indexer_queue'
 INDEXER_QUEUE_MIRROR = 'indexer_queue_mirror'
+SECONDARY_INDEXING_COALESCER = 'secondary_indexing_coalescer'
 INVALIDATION_SCOPE_ENABLED = 'invalidation_scope.enabled'
 
 

--- a/snovault/elasticsearch/secondary_indexing.py
+++ b/snovault/elasticsearch/secondary_indexing.py
@@ -287,6 +287,14 @@ class PostgresSecondaryIndexingStore:
             return sum(1 for _ in connection.execute(
                 self.RELEASE_ALL, {'namespace': namespace}))
 
+    def release(self, rid, namespace):
+        rid = str(uuid.UUID(str(rid)))
+        with self._transaction() as connection:
+            return connection.execute(
+                self.RELEASE_TARGET,
+                {'rid': rid, 'namespace': namespace},
+            ).rowcount
+
     def rearm_stale(self, namespace, stale_seconds, row_limit):
         with self._transaction() as connection:
             return [
@@ -371,10 +379,24 @@ class SecondaryIndexingCoalescer:
         self.registry = registry
         self.queue = registry[INDEXER_QUEUE]
         self.store = store or PostgresSecondaryIndexingStore(registry)
+        self._observed_mode = coalescing_mode(self.registry.settings)
 
     @property
     def mode(self):
-        return coalescing_mode(self.registry.settings)
+        mode = coalescing_mode(self.registry.settings)
+        if mode != self._observed_mode and (mode == 'off' or self._observed_mode == 'off'):
+            try:
+                self.store.release_all(self.namespace)
+            except Exception:
+                log.exception(
+                    'Secondary coalescing mode transition cleanup failed',
+                    coalescing_event='mode_transition_cleanup_failure',
+                    from_mode=self._observed_mode,
+                    to_mode=mode,
+                    namespace=self.namespace,
+                )
+        self._observed_mode = mode
+        return mode
 
     @property
     def namespace(self):
@@ -490,6 +512,9 @@ class SecondaryIndexingCoalescer:
         if not self.enabled:
             return 0
         return self.store.release_all(self.namespace)
+
+    def release(self, rid):
+        return self.store.release(rid, self.namespace)
 
     @staticmethod
     def _messages(rows, origin):

--- a/snovault/elasticsearch/secondary_indexing.py
+++ b/snovault/elasticsearch/secondary_indexing.py
@@ -137,6 +137,14 @@ class PostgresSecondaryIndexingStore:
            SET pending = FALSE
          WHERE rid = CAST(:rid AS uuid) AND namespace = :namespace
     """)
+    RELEASE_TARGETS = psql_text("""
+        UPDATE secondary_indexing_pending
+           SET pending = FALSE
+         WHERE namespace = :namespace
+           AND rid = ANY(CAST(:rids AS uuid[]))
+           AND pending
+         RETURNING rid
+    """)
     RELEASE_ALL = psql_text("""
         UPDATE secondary_indexing_pending
            SET pending = FALSE
@@ -156,6 +164,24 @@ class PostgresSecondaryIndexingStore:
         )
         UPDATE secondary_indexing_pending AS work
            SET queued_at = CURRENT_TIMESTAMP
+          FROM candidates
+         WHERE work.rid = candidates.rid
+           AND work.namespace = candidates.namespace
+        RETURNING work.rid, work.queued_sid, work.queued_at
+    """)
+    REARM_PENDING = psql_text("""
+        WITH candidates AS (
+            SELECT rid, namespace
+             FROM secondary_indexing_pending
+             WHERE namespace = :namespace
+               AND pending
+               AND queued_at < :before
+             ORDER BY queued_at, rid
+             LIMIT :row_limit
+             FOR UPDATE SKIP LOCKED
+        )
+        UPDATE secondary_indexing_pending AS work
+           SET queued_at = :before
           FROM candidates
          WHERE work.rid = candidates.rid
            AND work.namespace = candidates.namespace
@@ -295,6 +321,17 @@ class PostgresSecondaryIndexingStore:
                 {'rid': rid, 'namespace': namespace},
             ).rowcount
 
+    def release_targets(self, target_uuids, namespace):
+        targets = sorted({str(uuid.UUID(str(target))) for target in target_uuids})
+        released = 0
+        for batch in self._chunks(targets):
+            with self._transaction() as connection:
+                released += sum(1 for _ in connection.execute(
+                    self.RELEASE_TARGETS,
+                    {'rids': batch, 'namespace': namespace},
+                ))
+        return released
+
     def rearm_stale(self, namespace, stale_seconds, row_limit):
         with self._transaction() as connection:
             return [
@@ -304,6 +341,20 @@ class PostgresSecondaryIndexingStore:
                     {
                         'namespace': namespace,
                         'stale_seconds': max(int(stale_seconds), 0),
+                        'row_limit': min(max(int(row_limit), 1), MAX_OPERATION_ROWS),
+                    },
+                ).mappings()
+            ]
+
+    def rearm_pending(self, namespace, before, row_limit=MAX_OPERATION_ROWS):
+        with self._transaction() as connection:
+            return [
+                dict(row)
+                for row in connection.execute(
+                    self.REARM_PENDING,
+                    {
+                        'namespace': namespace,
+                        'before': before,
                         'row_limit': min(max(int(row_limit), 1), MAX_OPERATION_ROWS),
                     },
                 ).mappings()
@@ -379,23 +430,13 @@ class SecondaryIndexingCoalescer:
         self.registry = registry
         self.queue = registry[INDEXER_QUEUE]
         self.store = store or PostgresSecondaryIndexingStore(registry)
-        self._observed_mode = coalescing_mode(self.registry.settings)
+        self._repair_on_enable = coalescing_mode(self.registry.settings) in {'shadow', 'on'}
 
     @property
     def mode(self):
         mode = coalescing_mode(self.registry.settings)
-        if mode != self._observed_mode and (mode == 'off' or self._observed_mode == 'off'):
-            try:
-                self.store.release_all(self.namespace)
-            except Exception:
-                log.exception(
-                    'Secondary coalescing mode transition cleanup failed',
-                    coalescing_event='mode_transition_cleanup_failure',
-                    from_mode=self._observed_mode,
-                    to_mode=mode,
-                    namespace=self.namespace,
-                )
-        self._observed_mode = mode
+        if mode == 'off':
+            self._repair_on_enable = True
         return mode
 
     @property
@@ -404,7 +445,11 @@ class SecondaryIndexingCoalescer:
 
     @property
     def enabled(self):
-        return self.mode in {'shadow', 'on'}
+        mode = self.mode
+        if mode in {'shadow', 'on'} and self._repair_on_enable:
+            self._repair_pending()
+            self._repair_on_enable = False
+        return mode in {'shadow', 'on'}
 
     def enqueue(self, target_uuids, sid=None, telemetry_id=None):
         started = time.monotonic()
@@ -509,12 +554,17 @@ class SecondaryIndexingCoalescer:
         return result
 
     def release_all(self):
-        if not self.enabled:
+        if self.mode not in {'shadow', 'on'}:
             return 0
         return self.store.release_all(self.namespace)
 
     def release(self, rid):
         return self.store.release(rid, self.namespace)
+
+    def release_targets(self, target_uuids):
+        if self.mode not in {'shadow', 'on'}:
+            return 0
+        return self.store.release_targets(target_uuids, self.namespace)
 
     @staticmethod
     def _messages(rows, origin):
@@ -530,6 +580,45 @@ class SecondaryIndexingCoalescer:
             }
             for row in rows
         ]
+
+    def _repair_pending(self):
+        cutoff = datetime.datetime.now(datetime.timezone.utc)
+        rearmed = 0
+        failed_count = 0
+        while True:
+            try:
+                rows = self.store.rearm_pending(self.namespace, cutoff)
+            except Exception as error:
+                log.exception(
+                    'Secondary coalescing startup repair failed',
+                    coalescing_event='startup_repair_failure',
+                    namespace=self.namespace,
+                    error=repr(error),
+                )
+                return
+            if not rows:
+                break
+            messages = self._messages(rows, 'startup_repair')
+            rearmed += len(rows)
+            try:
+                failed = self.queue.send_messages(messages, target_queue='secondary')
+            except Exception as error:
+                log.exception(
+                    'Secondary coalescing startup repair send failed',
+                    coalescing_event='startup_repair_send_failure',
+                    namespace=self.namespace,
+                    rearmed=len(rows),
+                    error=repr(error),
+                )
+                break
+            failed_count += len(failed)
+        log.info(
+            'Secondary coalescing startup repair completed',
+            coalescing_event='startup_repair',
+            namespace=self.namespace,
+            rearmed=rearmed,
+            send_failures=failed_count,
+        )
 
     def sweep(self):
         if not self.enabled:

--- a/snovault/elasticsearch/secondary_indexing.py
+++ b/snovault/elasticsearch/secondary_indexing.py
@@ -190,7 +190,6 @@ class PostgresSecondaryIndexingStore:
         targets = sorted({str(uuid.UUID(str(target))) for target in target_uuids})
         queued_sid = int(queued_sid or 0)
         suppressed = set()
-        tracked = set()
         for batch in self._chunks(targets):
             params = {'rids': batch, 'namespace': namespace, 'queued_sid': queued_sid}
             with self._transaction() as connection:
@@ -199,7 +198,6 @@ class PostgresSecondaryIndexingStore:
                     for row in connection.execute(self.INSERT_MISSING, params)
                 }
                 locked = connection.execute(self.LOCK_TARGETS, params).mappings().all()
-                tracked.update(str(row['rid']) for row in locked)
                 suppressed.update(
                     str(row['rid']) for row in locked
                     if row['pending'] and str(row['rid']) not in inserted
@@ -209,7 +207,6 @@ class PostgresSecondaryIndexingStore:
         # it preserves the pre-feature behavior and lets normal missing-item handling run.
         return {
             'targets': targets,
-            'tracked': tracked,
             'suppressed': suppressed,
             'send': set(targets) - suppressed,
         }

--- a/snovault/elasticsearch/secondary_indexing.py
+++ b/snovault/elasticsearch/secondary_indexing.py
@@ -36,6 +36,40 @@ MAX_OPERATION_ROWS = 1000
 TARGET_BATCH_SIZE = 500
 
 
+def _bounded_setting(settings, key, default, minimum, maximum=None):
+    value = settings.get(key, default)
+    try:
+        value = int(value)
+    except (TypeError, ValueError, OverflowError):
+        log.error(
+            'Invalid secondary coalescing setting; using default',
+            setting=key,
+            configured_value=value,
+            default_value=default,
+        )
+        value = default
+    value = max(value, minimum)
+    return min(value, maximum) if maximum is not None else value
+
+
+def coalescing_repair_settings(settings):
+    return (
+        _bounded_setting(
+            settings,
+            COALESCING_STALE_SECONDS_SETTING,
+            DEFAULT_STALE_SECONDS,
+            minimum=0,
+        ),
+        _bounded_setting(
+            settings,
+            COALESCING_SWEEP_LIMIT_SETTING,
+            DEFAULT_SWEEP_LIMIT,
+            minimum=1,
+            maximum=MAX_OPERATION_ROWS,
+        ),
+    )
+
+
 def includeme(config):
     config.add_route('reset_secondary_coalescing', '/reset_secondary_coalescing')
     config.add_route('secondary_coalescing_status', '/secondary_coalescing_status')
@@ -476,10 +510,7 @@ class SecondaryIndexingCoalescer:
         if not self.enabled:
             return {'rearmed': 0, 'sent': 0, 'failed': 0}
         started = time.monotonic()
-        stale_seconds = max(0, int(self.registry.settings.get(
-            COALESCING_STALE_SECONDS_SETTING, DEFAULT_STALE_SECONDS)))
-        row_limit = min(MAX_OPERATION_ROWS, max(1, int(self.registry.settings.get(
-            COALESCING_SWEEP_LIMIT_SETTING, DEFAULT_SWEEP_LIMIT))))
+        stale_seconds, row_limit = coalescing_repair_settings(self.registry.settings)
         rows = self.store.rearm_stale(self.namespace, stale_seconds, row_limit)
         messages = self._messages(rows, 'sweeper')
         try:

--- a/snovault/elasticsearch/secondary_indexing.py
+++ b/snovault/elasticsearch/secondary_indexing.py
@@ -137,13 +137,25 @@ class PostgresSecondaryIndexingStore:
            SET pending = FALSE
          WHERE rid = CAST(:rid AS uuid) AND namespace = :namespace
     """)
-    RELEASE_TARGETS = psql_text("""
-        UPDATE secondary_indexing_pending
-           SET pending = FALSE
+    CAPTURE_TARGETS = psql_text("""
+        SELECT rid, queued_sid
+          FROM secondary_indexing_pending
          WHERE namespace = :namespace
            AND rid = ANY(CAST(:rids AS uuid[]))
            AND pending
-         RETURNING rid
+    """)
+    RELEASE_TARGETS = psql_text("""
+        UPDATE secondary_indexing_pending AS work
+           SET pending = FALSE
+          FROM unnest(
+              CAST(:rids AS uuid[]),
+              CAST(:queued_sids AS integer[])
+          ) AS target(rid, queued_sid)
+         WHERE work.namespace = :namespace
+           AND work.rid = target.rid
+           AND work.pending
+           AND work.queued_sid = target.queued_sid
+         RETURNING work.rid
     """)
     RELEASE_ALL = psql_text("""
         UPDATE secondary_indexing_pending
@@ -164,24 +176,6 @@ class PostgresSecondaryIndexingStore:
         )
         UPDATE secondary_indexing_pending AS work
            SET queued_at = CURRENT_TIMESTAMP
-          FROM candidates
-         WHERE work.rid = candidates.rid
-           AND work.namespace = candidates.namespace
-        RETURNING work.rid, work.queued_sid, work.queued_at
-    """)
-    REARM_PENDING = psql_text("""
-        WITH candidates AS (
-            SELECT rid, namespace
-             FROM secondary_indexing_pending
-             WHERE namespace = :namespace
-               AND pending
-               AND queued_at < :before
-             ORDER BY queued_at, rid
-             LIMIT :row_limit
-             FOR UPDATE SKIP LOCKED
-        )
-        UPDATE secondary_indexing_pending AS work
-           SET queued_at = :before
           FROM candidates
          WHERE work.rid = candidates.rid
            AND work.namespace = candidates.namespace
@@ -321,14 +315,35 @@ class PostgresSecondaryIndexingStore:
                 {'rid': rid, 'namespace': namespace},
             ).rowcount
 
-    def release_targets(self, target_uuids, namespace):
+    def capture_targets(self, target_uuids, namespace):
         targets = sorted({str(uuid.UUID(str(target))) for target in target_uuids})
-        released = 0
+        captured = {}
         for batch in self._chunks(targets):
+            with self._connection() as connection:
+                captured.update({
+                    str(row['rid']): int(row['queued_sid'])
+                    for row in connection.execute(
+                        self.CAPTURE_TARGETS,
+                        {'rids': batch, 'namespace': namespace},
+                    ).mappings()
+                })
+        return captured
+
+    def release_targets(self, target_states, namespace):
+        states = sorted(
+            (str(uuid.UUID(str(target))), int(queued_sid))
+            for target, queued_sid in target_states.items()
+        )
+        released = 0
+        for batch in self._chunks(states):
             with self._transaction() as connection:
                 released += sum(1 for _ in connection.execute(
                     self.RELEASE_TARGETS,
-                    {'rids': batch, 'namespace': namespace},
+                    {
+                        'rids': [target for target, queued_sid in batch],
+                        'queued_sids': [queued_sid for target, queued_sid in batch],
+                        'namespace': namespace,
+                    },
                 ))
         return released
 
@@ -341,20 +356,6 @@ class PostgresSecondaryIndexingStore:
                     {
                         'namespace': namespace,
                         'stale_seconds': max(int(stale_seconds), 0),
-                        'row_limit': min(max(int(row_limit), 1), MAX_OPERATION_ROWS),
-                    },
-                ).mappings()
-            ]
-
-    def rearm_pending(self, namespace, before, row_limit=MAX_OPERATION_ROWS):
-        with self._transaction() as connection:
-            return [
-                dict(row)
-                for row in connection.execute(
-                    self.REARM_PENDING,
-                    {
-                        'namespace': namespace,
-                        'before': before,
                         'row_limit': min(max(int(row_limit), 1), MAX_OPERATION_ROWS),
                     },
                 ).mappings()
@@ -430,14 +431,10 @@ class SecondaryIndexingCoalescer:
         self.registry = registry
         self.queue = registry[INDEXER_QUEUE]
         self.store = store or PostgresSecondaryIndexingStore(registry)
-        self._repair_on_enable = coalescing_mode(self.registry.settings) in {'shadow', 'on'}
 
     @property
     def mode(self):
-        mode = coalescing_mode(self.registry.settings)
-        if mode == 'off':
-            self._repair_on_enable = True
-        return mode
+        return coalescing_mode(self.registry.settings)
 
     @property
     def namespace(self):
@@ -445,11 +442,7 @@ class SecondaryIndexingCoalescer:
 
     @property
     def enabled(self):
-        mode = self.mode
-        if mode in {'shadow', 'on'} and self._repair_on_enable:
-            self._repair_pending()
-            self._repair_on_enable = False
-        return mode in {'shadow', 'on'}
+        return self.mode in {'shadow', 'on'}
 
     def enqueue(self, target_uuids, sid=None, telemetry_id=None):
         started = time.monotonic()
@@ -561,10 +554,15 @@ class SecondaryIndexingCoalescer:
     def release(self, rid):
         return self.store.release(rid, self.namespace)
 
-    def release_targets(self, target_uuids):
+    def snapshot_targets(self, target_uuids):
+        if self.mode not in {'shadow', 'on'}:
+            return {}
+        return self.store.capture_targets(target_uuids, self.namespace)
+
+    def release_targets(self, target_states):
         if self.mode not in {'shadow', 'on'}:
             return 0
-        return self.store.release_targets(target_uuids, self.namespace)
+        return self.store.release_targets(target_states, self.namespace)
 
     @staticmethod
     def _messages(rows, origin):
@@ -580,45 +578,6 @@ class SecondaryIndexingCoalescer:
             }
             for row in rows
         ]
-
-    def _repair_pending(self):
-        cutoff = datetime.datetime.now(datetime.timezone.utc)
-        rearmed = 0
-        failed_count = 0
-        while True:
-            try:
-                rows = self.store.rearm_pending(self.namespace, cutoff)
-            except Exception as error:
-                log.exception(
-                    'Secondary coalescing startup repair failed',
-                    coalescing_event='startup_repair_failure',
-                    namespace=self.namespace,
-                    error=repr(error),
-                )
-                return
-            if not rows:
-                break
-            messages = self._messages(rows, 'startup_repair')
-            rearmed += len(rows)
-            try:
-                failed = self.queue.send_messages(messages, target_queue='secondary')
-            except Exception as error:
-                log.exception(
-                    'Secondary coalescing startup repair send failed',
-                    coalescing_event='startup_repair_send_failure',
-                    namespace=self.namespace,
-                    rearmed=len(rows),
-                    error=repr(error),
-                )
-                break
-            failed_count += len(failed)
-        log.info(
-            'Secondary coalescing startup repair completed',
-            coalescing_event='startup_repair',
-            namespace=self.namespace,
-            rearmed=rearmed,
-            send_failures=failed_count,
-        )
 
     def sweep(self):
         if not self.enabled:

--- a/snovault/elasticsearch/secondary_indexing.py
+++ b/snovault/elasticsearch/secondary_indexing.py
@@ -103,6 +103,12 @@ class PostgresSecondaryIndexingStore:
            SET pending = FALSE
          WHERE rid = CAST(:rid AS uuid) AND namespace = :namespace
     """)
+    RELEASE_ALL = psql_text("""
+        UPDATE secondary_indexing_pending
+           SET pending = FALSE
+         WHERE namespace = :namespace AND pending
+         RETURNING rid
+    """)
     REARM_STALE = psql_text("""
         WITH candidates AS (
             SELECT rid, namespace
@@ -241,6 +247,11 @@ class PostgresSecondaryIndexingStore:
             except Exception:
                 transaction.rollback()
                 raise
+
+    def release_all(self, namespace):
+        with self._transaction() as connection:
+            return sum(1 for _ in connection.execute(
+                self.RELEASE_ALL, {'namespace': namespace}))
 
     def rearm_stale(self, namespace, stale_seconds, row_limit):
         with self._transaction() as connection:
@@ -440,6 +451,9 @@ class SecondaryIndexingCoalescer:
             duration_ms=round((time.monotonic() - started) * 1000, 3),
         )
         return result
+
+    def release_all(self):
+        return self.store.release_all(self.namespace)
 
     @staticmethod
     def _messages(rows, origin):

--- a/snovault/elasticsearch/secondary_indexing.py
+++ b/snovault/elasticsearch/secondary_indexing.py
@@ -1,0 +1,628 @@
+"""PostgreSQL coalescing state for secondary invalidation fan-out.
+
+SQS remains the work transport.  PostgreSQL arbitrates only whether a strict,
+full-render secondary job for a target is already outstanding in this queue
+namespace.  Primary edit events never enter this module.
+"""
+
+import datetime
+import time
+import uuid
+from contextlib import contextmanager
+
+import structlog
+from dcicutils.misc_utils import ignored
+from pyramid.httpexceptions import HTTPBadRequest
+from pyramid.settings import asbool
+from pyramid.view import view_config
+from sqlalchemy import text as psql_text
+
+from ..interfaces import DBSESSION
+from .interfaces import INDEXER_QUEUE, SECONDARY_INDEXING_COALESCER
+
+
+log = structlog.getLogger(__name__)
+
+COALESCING_MODE_SETTING = 'indexer.coalesce_secondary'
+COALESCING_MODES = frozenset({'off', 'shadow', 'on'})
+COALESCING_STALE_SECONDS_SETTING = 'indexer.coalesce_secondary.stale_seconds'
+COALESCING_SWEEP_INTERVAL_SETTING = 'indexer.coalesce_secondary.sweep_interval'
+COALESCING_SWEEP_LIMIT_SETTING = 'indexer.coalesce_secondary.sweep_limit'
+
+DEFAULT_STALE_SECONDS = 1800
+DEFAULT_SWEEP_INTERVAL = 300
+DEFAULT_SWEEP_LIMIT = 500
+MAX_OPERATION_ROWS = 1000
+TARGET_BATCH_SIZE = 500
+
+
+def includeme(config):
+    config.add_route('reset_secondary_coalescing', '/reset_secondary_coalescing')
+    config.add_route('secondary_coalescing_status', '/secondary_coalescing_status')
+    config.registry[SECONDARY_INDEXING_COALESCER] = SecondaryIndexingCoalescer(config.registry)
+    config.scan(__name__)
+
+
+def coalescing_mode(settings):
+    """Return a safe rollout mode; an invalid value fails open to normal SQS sends."""
+    mode = str(settings.get(COALESCING_MODE_SETTING, 'off')).strip().lower()
+    if mode not in COALESCING_MODES:
+        log.error(
+            'Invalid secondary coalescing mode; treating it as off',
+            configured_mode=mode,
+            allowed_modes=sorted(COALESCING_MODES),
+        )
+        return 'off'
+    return mode
+
+
+class PostgresSecondaryIndexingStore:
+    """Short READ COMMITTED transactions on connections separate from index snapshots."""
+
+    INSERT_MISSING = psql_text("""
+        INSERT INTO secondary_indexing_pending
+            (rid, namespace, pending, queued_sid, queued_at)
+        SELECT target.rid, :namespace, TRUE, :queued_sid, CURRENT_TIMESTAMP
+          FROM unnest(CAST(:rids AS uuid[])) AS target(rid)
+          JOIN resources ON resources.rid = target.rid
+         ORDER BY target.rid
+        ON CONFLICT (rid, namespace) DO NOTHING
+        RETURNING rid
+    """)
+    LOCK_TARGETS = psql_text("""
+        SELECT rid, pending
+          FROM secondary_indexing_pending
+         WHERE namespace = :namespace
+           AND rid = ANY(CAST(:rids AS uuid[]))
+         ORDER BY rid
+         FOR UPDATE
+    """)
+    ARM_TARGETS = psql_text("""
+        UPDATE secondary_indexing_pending AS work
+           SET pending = TRUE,
+               queued_sid = CASE
+                   WHEN work.pending THEN GREATEST(work.queued_sid, :queued_sid)
+                   ELSE :queued_sid
+               END,
+               queued_at = CASE
+                   WHEN work.pending THEN work.queued_at
+                   ELSE CURRENT_TIMESTAMP
+               END
+         WHERE work.namespace = :namespace
+           AND work.rid = ANY(CAST(:rids AS uuid[]))
+           AND (NOT work.pending OR work.queued_sid < :queued_sid)
+    """)
+    CLAIM_TARGET = psql_text("""
+        SELECT pending, queued_sid
+          FROM secondary_indexing_pending
+         WHERE rid = CAST(:rid AS uuid) AND namespace = :namespace
+         FOR UPDATE
+    """)
+    RELEASE_TARGET = psql_text("""
+        UPDATE secondary_indexing_pending
+           SET pending = FALSE
+         WHERE rid = CAST(:rid AS uuid) AND namespace = :namespace
+    """)
+    REARM_STALE = psql_text("""
+        WITH candidates AS (
+            SELECT rid, namespace
+              FROM secondary_indexing_pending
+             WHERE namespace = :namespace
+               AND pending
+               AND queued_at < CURRENT_TIMESTAMP - make_interval(secs => :stale_seconds)
+             ORDER BY queued_at, rid
+             LIMIT :row_limit
+             FOR UPDATE SKIP LOCKED
+        )
+        UPDATE secondary_indexing_pending AS work
+           SET queued_at = CURRENT_TIMESTAMP
+          FROM candidates
+         WHERE work.rid = candidates.rid
+           AND work.namespace = candidates.namespace
+        RETURNING work.rid, work.queued_sid, work.queued_at
+    """)
+    STATUS = psql_text("""
+        SELECT COUNT(*) AS table_rows,
+               COUNT(*) FILTER (WHERE pending) AS pending_count,
+               EXTRACT(EPOCH FROM (
+                   CURRENT_TIMESTAMP - MIN(queued_at) FILTER (WHERE pending)
+               )) AS oldest_pending_age_seconds
+          FROM secondary_indexing_pending
+         WHERE namespace = :namespace
+    """)
+    INSPECT_ALL_NAMESPACES = psql_text("""
+        SELECT namespace, pending, queued_sid, queued_at
+          FROM secondary_indexing_pending
+         WHERE rid = CAST(:rid AS uuid)
+         ORDER BY namespace
+    """)
+    INSPECT_NAMESPACE = psql_text("""
+        SELECT namespace, pending, queued_sid, queued_at
+          FROM secondary_indexing_pending
+         WHERE rid = CAST(:rid AS uuid) AND namespace = :namespace
+    """)
+
+    def __init__(self, registry, batch_size=TARGET_BATCH_SIZE):
+        self.registry = registry
+        self.batch_size = batch_size
+
+    def _engine(self):
+        # MPIndexer replaces registry[DBSESSION] inside each worker, so resolve it
+        # lazily rather than retaining the parent process's session factory.
+        bind = self.registry[DBSESSION]().get_bind()
+        return getattr(bind, 'engine', bind)
+
+    @contextmanager
+    def _connection(self):
+        connection = self._engine().connect()
+        try:
+            # Index renders intentionally use REPEATABLE READ READ ONLY.  State
+            # transitions need a separate, short write transaction whose locking
+            # decisions can observe a waiter that committed while it was blocked.
+            yield connection.execution_options(isolation_level='READ COMMITTED')
+        finally:
+            connection.close()
+
+    @contextmanager
+    def _transaction(self):
+        with self._connection() as connection:
+            transaction = connection.begin()
+            try:
+                yield connection
+            except Exception:
+                transaction.rollback()
+                raise
+            else:
+                transaction.commit()
+
+    def _chunks(self, values):
+        for start in range(0, len(values), self.batch_size):
+            yield values[start:start + self.batch_size]
+
+    def prepare_targets(self, target_uuids, namespace, queued_sid):
+        """Arm targets under unconditional locks and return already-covered UUIDs.
+
+        Missing rows are inserted pending before all rows are selected FOR UPDATE.
+        Consequently two producers racing on a previously absent or released target
+        serialize before either decides whether to suppress its SQS send.  Each batch
+        commits before this method returns and therefore before the caller contacts SQS.
+        """
+        targets = sorted({str(uuid.UUID(str(target))) for target in target_uuids})
+        queued_sid = int(queued_sid or 0)
+        suppressed = set()
+        tracked = set()
+        for batch in self._chunks(targets):
+            params = {'rids': batch, 'namespace': namespace, 'queued_sid': queued_sid}
+            with self._transaction() as connection:
+                inserted = {
+                    str(row.rid)
+                    for row in connection.execute(self.INSERT_MISSING, params)
+                }
+                locked = connection.execute(self.LOCK_TARGETS, params).mappings().all()
+                tracked.update(str(row['rid']) for row in locked)
+                suppressed.update(
+                    str(row['rid']) for row in locked
+                    if row['pending'] and str(row['rid']) not in inserted
+                )
+                connection.execute(self.ARM_TARGETS, params)
+        # A target deleted before the state transaction cannot be tracked, but sending
+        # it preserves the pre-feature behavior and lets normal missing-item handling run.
+        return {
+            'targets': targets,
+            'tracked': tracked,
+            'suppressed': suppressed,
+            'send': set(targets) - suppressed,
+        }
+
+    def claim(self, rid, namespace, message_sid, max_sid):
+        rid = str(uuid.UUID(str(rid)))
+        message_sid = int(message_sid or 0)
+        max_sid = int(max_sid)
+        with self._connection() as connection:
+            transaction = connection.begin()
+            try:
+                row = connection.execute(
+                    self.CLAIM_TARGET,
+                    {'rid': rid, 'namespace': namespace},
+                ).mappings().first()
+                if row is None:
+                    transaction.commit()
+                    return {'outcome': 'noop_row_absent', 'effective_sid': message_sid}
+                if not row['pending']:
+                    transaction.commit()
+                    return {'outcome': 'noop_not_pending', 'effective_sid': message_sid}
+                effective_sid = max(message_sid, int(row['queued_sid']))
+                if effective_sid > max_sid:
+                    transaction.rollback()
+                    return {'outcome': 'deferred_stale', 'effective_sid': effective_sid}
+                connection.execute(
+                    self.RELEASE_TARGET,
+                    {'rid': rid, 'namespace': namespace},
+                )
+                transaction.commit()
+                return {'outcome': 'claimed', 'effective_sid': effective_sid}
+            except Exception:
+                transaction.rollback()
+                raise
+
+    def rearm_stale(self, namespace, stale_seconds, row_limit):
+        with self._transaction() as connection:
+            return [
+                dict(row)
+                for row in connection.execute(
+                    self.REARM_STALE,
+                    {
+                        'namespace': namespace,
+                        'stale_seconds': max(int(stale_seconds), 0),
+                        'row_limit': min(max(int(row_limit), 1), MAX_OPERATION_ROWS),
+                    },
+                ).mappings()
+            ]
+
+    def status(self, namespace):
+        with self._connection() as connection:
+            row = connection.execute(self.STATUS, {'namespace': namespace}).mappings().one()
+        return {
+            'namespace': namespace,
+            'table_rows': int(row['table_rows']),
+            'pending_count': int(row['pending_count']),
+            'oldest_pending_age_seconds': (
+                float(row['oldest_pending_age_seconds'])
+                if row['oldest_pending_age_seconds'] is not None else None
+            ),
+        }
+
+    def inspect(self, rid, namespace=None):
+        params = {'rid': str(uuid.UUID(str(rid)))}
+        statement = self.INSPECT_ALL_NAMESPACES
+        if namespace is not None:
+            params['namespace'] = namespace
+            statement = self.INSPECT_NAMESPACE
+        with self._connection() as connection:
+            rows = connection.execute(statement, params).mappings().all()
+        return [dict(row) for row in rows]
+
+    def reset(self, namespace, target_uuids=None, all_targets=False, dry_run=True,
+              requeue=False, row_limit=MAX_OPERATION_ROWS):
+        row_limit = min(max(int(row_limit), 1), MAX_OPERATION_ROWS)
+        params = {'namespace': namespace, 'row_limit': row_limit}
+        target_filter = ''
+        if not all_targets:
+            params['rids'] = sorted({str(uuid.UUID(str(rid))) for rid in target_uuids})
+            target_filter = 'AND rid = ANY(CAST(:rids AS uuid[]))'
+        select_sql = """
+            SELECT rid, queued_sid, queued_at
+              FROM secondary_indexing_pending
+             WHERE namespace = :namespace AND pending {target_filter}
+             ORDER BY queued_at, rid
+             LIMIT :row_limit
+        """.format(target_filter=target_filter)
+        with self._transaction() as connection:
+            rows = connection.execute(psql_text(select_sql + ' FOR UPDATE SKIP LOCKED'), params).mappings().all()
+            result = [dict(row) for row in rows]
+            if dry_run or not result:
+                return result
+            rids = [str(row['rid']) for row in rows]
+            if requeue:
+                connection.execute(psql_text("""
+                    UPDATE secondary_indexing_pending
+                       SET queued_at = CURRENT_TIMESTAMP
+                     WHERE namespace = :namespace
+                       AND rid = ANY(CAST(:rids AS uuid[]))
+                       AND pending
+                """), {'namespace': namespace, 'rids': rids})
+            else:
+                connection.execute(psql_text("""
+                    UPDATE secondary_indexing_pending
+                       SET pending = FALSE
+                     WHERE namespace = :namespace
+                       AND rid = ANY(CAST(:rids AS uuid[]))
+                       AND pending
+                """), {'namespace': namespace, 'rids': rids})
+            return result
+
+
+class SecondaryIndexingCoalescer:
+    """Rollout gating, SQS transport, metrics, and operational orchestration."""
+
+    def __init__(self, registry, store=None):
+        self.registry = registry
+        self.queue = registry[INDEXER_QUEUE]
+        self.store = store or PostgresSecondaryIndexingStore(registry)
+
+    @property
+    def mode(self):
+        return coalescing_mode(self.registry.settings)
+
+    @property
+    def namespace(self):
+        return self.queue.env_name
+
+    @property
+    def enabled(self):
+        return self.mode in {'shadow', 'on'}
+
+    def enqueue(self, target_uuids, sid=None, telemetry_id=None):
+        started = time.monotonic()
+        targets = list(target_uuids)
+        if not self.enabled:
+            # The caller normally takes the original path directly in off mode.  Keep
+            # this fallback behavior-compatible for direct users of the service too.
+            return self.queue.add_uuids(
+                self.registry, targets, strict=True,
+                target_queue='secondary', sid=sid, telemetry_id=telemetry_id,
+            )
+        state_ready = True
+        try:
+            prepared = self.store.prepare_targets(targets, self.namespace, sid)
+        except Exception as error:
+            # Failure-open preserves current indexing behavior.  Earlier committed
+            # batches, if any, remain pending and are repaired by the sweeper.
+            log.exception(
+                'Secondary coalescing state enqueue failed; sending all targets',
+                coalescing_event='enqueue_db_failure',
+                namespace=self.namespace,
+                target_count=len(targets),
+                error=repr(error),
+            )
+            state_ready = False
+            prepared = {'targets': targets, 'suppressed': set(), 'send': set(targets)}
+        send_targets = prepared['targets'] if self.mode == 'shadow' else sorted(prepared['send'])
+        try:
+            queued, failed = self.queue.add_uuids(
+                self.registry,
+                send_targets,
+                strict=True,
+                target_queue='secondary',
+                sid=sid,
+                telemetry_id=telemetry_id,
+                coalesced=state_ready,
+                origin='fanout' if state_ready else None,
+            )
+        except Exception as error:
+            if not state_ready:
+                # With neither durable state nor a successful SQS send there is no
+                # recovery record. Propagate so the causing primary message remains
+                # undeleted and can retry after its visibility timeout.
+                log.exception(
+                    'Secondary state and SQS send both unavailable; retaining cause message',
+                    coalescing_event='unrecoverable_enqueue_failure',
+                    namespace=self.namespace,
+                    target_count=len(send_targets),
+                    error=repr(error),
+                )
+                raise
+            queued = []
+            failed = [{'uuid': target, 'error': repr(error)} for target in send_targets]
+            log.exception(
+                'Secondary coalescing SQS send failed; sweeper will repair',
+                coalescing_event='send_failure',
+                namespace=self.namespace,
+                target_count=len(send_targets),
+                error=repr(error),
+            )
+        if failed and not state_ready:
+            log.error(
+                'Secondary state unavailable and SQS reported failed sends; retaining cause message',
+                coalescing_event='unrecoverable_enqueue_failure',
+                namespace=self.namespace,
+                target_count=len(send_targets),
+                send_failures=len(failed),
+            )
+            raise RuntimeError(
+                'Secondary state was unavailable and %s SQS sends failed; '
+                'the causing message must retry.' % len(failed))
+        log.info(
+            'Secondary fan-out coalescing decision',
+            coalescing_event='fanout',
+            mode=self.mode,
+            namespace=self.namespace,
+            targets=len(prepared['targets']),
+            suppressed=len(prepared['suppressed']),
+            send_attempted=len(send_targets),
+            sent=max(0, len(send_targets) - len(failed)),
+            send_failures=len(failed),
+            state_ready=state_ready,
+            telemetry_id=telemetry_id,
+            duration_ms=round((time.monotonic() - started) * 1000, 3),
+        )
+        return queued, failed
+
+    def claim(self, rid, message_sid, max_sid, origin=None, receive_count=None):
+        started = time.monotonic()
+        result = self.store.claim(rid, self.namespace, message_sid, max_sid)
+        log.info(
+            'Secondary coalescing consumer claim',
+            coalescing_event='claim',
+            claim=result['outcome'],
+            item_uuid=str(rid),
+            namespace=self.namespace,
+            origin=origin,
+            approximate_receive_count=receive_count,
+            effective_sid=result['effective_sid'],
+            duration_ms=round((time.monotonic() - started) * 1000, 3),
+        )
+        return result
+
+    @staticmethod
+    def _messages(rows, origin):
+        timestamp = datetime.datetime.utcnow().isoformat()
+        return [
+            {
+                'uuid': str(row['rid']),
+                'sid': int(row['queued_sid']),
+                'strict': True,
+                'timestamp': timestamp,
+                'coalesced': True,
+                'origin': origin,
+            }
+            for row in rows
+        ]
+
+    def sweep(self):
+        if not self.enabled:
+            return {'rearmed': 0, 'sent': 0, 'failed': 0}
+        started = time.monotonic()
+        stale_seconds = max(0, int(self.registry.settings.get(
+            COALESCING_STALE_SECONDS_SETTING, DEFAULT_STALE_SECONDS)))
+        row_limit = min(MAX_OPERATION_ROWS, max(1, int(self.registry.settings.get(
+            COALESCING_SWEEP_LIMIT_SETTING, DEFAULT_SWEEP_LIMIT))))
+        rows = self.store.rearm_stale(self.namespace, stale_seconds, row_limit)
+        messages = self._messages(rows, 'sweeper')
+        try:
+            failed = self.queue.send_messages(messages, target_queue='secondary') if messages else []
+        except Exception as error:
+            failed = [{'error': repr(error)} for _ in messages]
+            log.exception(
+                'Secondary coalescing sweeper SQS send failed',
+                coalescing_event='sweeper_send_failure',
+                namespace=self.namespace,
+                rearmed=len(rows),
+                error=repr(error),
+            )
+        result = {'rearmed': len(rows), 'sent': len(messages) - len(failed), 'failed': len(failed)}
+        log.info(
+            'Secondary coalescing sweep complete',
+            coalescing_event='sweeper',
+            namespace=self.namespace,
+            stale_seconds=stale_seconds,
+            duration_ms=round((time.monotonic() - started) * 1000, 3),
+            **result,
+        )
+        return result
+
+    def status(self):
+        status = self.store.status(self.namespace)
+        status['mode'] = self.mode
+        return status
+
+    def inspect(self, rid, all_namespaces=True):
+        return self.store.inspect(rid, None if all_namespaces else self.namespace)
+
+    def reset(self, target_uuids=None, all_targets=False, dry_run=True,
+              requeue=False, row_limit=MAX_OPERATION_ROWS):
+        rows = self.store.reset(
+            self.namespace,
+            target_uuids=target_uuids,
+            all_targets=all_targets,
+            dry_run=dry_run,
+            requeue=requeue,
+            row_limit=row_limit,
+        )
+        failed = []
+        if requeue and not dry_run and rows:
+            # reset(requeue=True) commits queued_at before this send, so a failed
+            # operator resend remains pending and is eligible for a later sweep.
+            try:
+                failed = self.queue.send_messages(
+                    self._messages(rows, 'admin_requeue'), target_queue='secondary')
+            except Exception as error:
+                failed = [{'error': repr(error)} for _ in rows]
+                log.exception(
+                    'Secondary coalescing admin requeue failed; sweeper will repair',
+                    coalescing_event='admin_send_failure',
+                    namespace=self.namespace,
+                    error=repr(error),
+                )
+        return {
+            'matched': len(rows),
+            'released': len(rows) if not dry_run and not requeue else 0,
+            'requeued': len(rows) - len(failed) if not dry_run and requeue else 0,
+            'send_failures': len(failed),
+            'dry_run': dry_run,
+            'namespace': self.namespace,
+            'row_limit': min(int(row_limit), MAX_OPERATION_ROWS),
+        }
+
+
+@view_config(
+    route_name='reset_secondary_coalescing',
+    request_method='POST',
+    permission='index',
+)
+def reset_secondary_coalescing(context, request):
+    """Release or safely requeue a bounded set of pending rows for this environment."""
+    ignored(context)
+    body = request.json
+    all_targets = body.get('all') is True
+    target_uuids = body.get('uuids')
+    if all_targets == bool(target_uuids):
+        raise HTTPBadRequest('Provide exactly one of a non-empty uuids list or all=true.')
+    if target_uuids is not None and not isinstance(target_uuids, list):
+        raise HTTPBadRequest('uuids must be a list.')
+    try:
+        if target_uuids:
+            target_uuids = [str(uuid.UUID(str(rid))) for rid in target_uuids]
+        row_limit = int(body.get('limit', MAX_OPERATION_ROWS))
+    except (TypeError, ValueError, AttributeError):
+        raise HTTPBadRequest('Every uuid and limit must be valid.')
+    if row_limit < 1 or row_limit > MAX_OPERATION_ROWS:
+        raise HTTPBadRequest('limit must be between 1 and %s.' % MAX_OPERATION_ROWS)
+    try:
+        dry_run = asbool(body.get('dry_run', True))
+        requeue = asbool(body.get('requeue', False))
+    except ValueError:
+        raise HTTPBadRequest('dry_run and requeue must be booleans.')
+    coalescer = request.registry[SECONDARY_INDEXING_COALESCER]
+    result = coalescer.reset(
+        target_uuids=target_uuids,
+        all_targets=all_targets,
+        dry_run=dry_run,
+        requeue=requeue,
+        row_limit=row_limit,
+    )
+    log.warning(
+        'Secondary coalescing administrative action',
+        coalescing_event='admin_reset',
+        authenticated_userid=request.authenticated_userid,
+        requested_all=all_targets,
+        requested_uuids=len(target_uuids or []),
+        requeue=requeue,
+        **result,
+    )
+    return result
+
+
+@view_config(
+    route_name='secondary_coalescing_status',
+    request_method='GET',
+    permission='index',
+)
+def secondary_coalescing_status(context, request):
+    """Inspect aggregate or per-target state without changing rollout mode."""
+    ignored(context)
+    coalescer = request.registry[SECONDARY_INDEXING_COALESCER]
+    target_uuid = request.params.get('uuid')
+    if target_uuid:
+        try:
+            target_uuid = str(uuid.UUID(str(target_uuid)))
+        except (TypeError, ValueError, AttributeError):
+            raise HTTPBadRequest('uuid must be valid.')
+        try:
+            states = coalescer.inspect(target_uuid)
+        except Exception as error:
+            log.exception('Unable to inspect secondary coalescing target state')
+            return {
+                'mode': coalescer.mode,
+                'target_uuid': target_uuid,
+                'status': 'Failure',
+                'detail': repr(error),
+            }
+        return {
+            'mode': coalescer.mode,
+            'target_uuid': target_uuid,
+            'states': states,
+            'status': 'Success',
+        }
+    try:
+        response = coalescer.status()
+    except Exception as error:
+        log.exception('Unable to inspect secondary coalescing aggregate state')
+        return {
+            'mode': coalescer.mode,
+            'namespace': coalescer.namespace,
+            'status': 'Failure',
+            'detail': repr(error),
+        }
+    response['status'] = 'Success'
+    return response

--- a/snovault/elasticsearch/secondary_indexing.py
+++ b/snovault/elasticsearch/secondary_indexing.py
@@ -453,6 +453,8 @@ class SecondaryIndexingCoalescer:
         return result
 
     def release_all(self):
+        if not self.enabled:
+            return 0
         return self.store.release_all(self.namespace)
 
     @staticmethod

--- a/snovault/indexing_views.py
+++ b/snovault/indexing_views.py
@@ -8,6 +8,7 @@ from pyramid.settings import asbool
 from timeit import default_timer as timer
 
 from .elasticsearch.indexer_utils import find_uuids_for_indexing
+from .elasticsearch.interfaces import SECONDARY_INDEXING_COALESCER
 from .embed import make_subrequest
 from .interfaces import CONNECTION, STORAGE
 from .resources import Item
@@ -271,6 +272,12 @@ def indexing_info(context, request):
     es_model = request.registry[STORAGE].read.get_by_uuid(uuid)
     es_sid = es_model.sid if es_model is not None else None
     response = {'sid_db': db_sid, 'sid_es': es_sid, 'title': 'Indexing Info for %s' % uuid}
+    coalescer = request.registry.get(SECONDARY_INDEXING_COALESCER)
+    if coalescer is not None and coalescer.enabled:
+        try:
+            response['secondary_coalescing'] = coalescer.inspect(uuid)
+        except Exception as error:
+            response['secondary_coalescing_error'] = repr(error)
     if asbool(request.params.get('run', True)):
         request._indexing_view = True
         request.datastore = 'database'

--- a/snovault/storage.py
+++ b/snovault/storage.py
@@ -8,7 +8,7 @@ from botocore.client import Config
 from dcicutils.misc_utils import ignored, get_error_message
 from pyramid.httpexceptions import HTTPConflict, HTTPLocked, HTTPInternalServerError
 from pyramid.threadlocal import get_current_request
-from sqlalchemy import Column, ForeignKey, bindparam, func, orm, schema, types
+from sqlalchemy import Column, DDL, ForeignKey, bindparam, event, func, orm, schema, types
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import JSONB as JSON
 from sqlalchemy.exc import IntegrityError
@@ -988,6 +988,50 @@ class Resource(Base):
 
     def used_for(self, item):
         pass
+
+
+class SecondaryIndexingPending(Base):
+    """Single-slot secondary indexing work state, isolated by queue namespace.
+
+    SQS remains the transport.  This narrow row only records whether a full-render
+    secondary job is already outstanding and the newest source sid it must cover.
+    """
+
+    __tablename__ = 'secondary_indexing_pending'
+
+    rid = Column(
+        UUID,
+        ForeignKey('resources.rid', ondelete='CASCADE'),
+        nullable=False,
+        primary_key=True,
+    )
+    namespace = Column(types.String, nullable=False, primary_key=True)
+    pending = Column(types.Boolean, nullable=False, default=False, server_default='false')
+    queued_sid = Column(types.Integer, nullable=False, default=0, server_default='0')
+    queued_at = Column(types.DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (
+        schema.Index(
+            'secondary_indexing_pending_sweep_idx',
+            namespace,
+            queued_at,
+            postgresql_where=pending,
+            postgresql_include=['rid', 'queued_sid'],
+        ),
+    )
+
+
+event.listen(
+    SecondaryIndexingPending.__table__,
+    'after_create',
+    DDL("""
+        ALTER TABLE secondary_indexing_pending SET (
+            fillfactor = 70,
+            autovacuum_vacuum_scale_factor = 0.02,
+            autovacuum_analyze_scale_factor = 0.05
+        )
+    """).execute_if(dialect='postgresql'),
+)
 
 
 class Blob(Base):

--- a/snovault/storage.py
+++ b/snovault/storage.py
@@ -1011,12 +1011,14 @@ class SecondaryIndexingPending(Base):
     queued_at = Column(types.DateTime(timezone=True), nullable=False)
 
     __table_args__ = (
+        # No INCLUDE columns: the sweep locks rows FOR UPDATE (heap access either
+        # way), while keeping queued_sid out of every index leaves the common
+        # suppression update (newer sid on an already-pending row) HOT-eligible.
         schema.Index(
             'secondary_indexing_pending_sweep_idx',
             namespace,
             queued_at,
             postgresql_where=pending,
-            postgresql_include=['rid', 'queued_sid'],
         ),
     )
 

--- a/snovault/tests/test_indexer_queue.py
+++ b/snovault/tests/test_indexer_queue.py
@@ -159,6 +159,16 @@ def test_send_messages_retries_failed_entries_by_id():
     assert retried_bodies == [{'uuid': 'b'}]
 
 
+def test_send_messages_correlates_final_batch_failures_to_uuids():
+    manager, mock_boto3_client = make_queue_manager(env_name="some-env")
+    mock_client = mock_boto3_client.return_value
+    mock_client.send_message_batch.return_value = {'Failed': [{'Id': '1'}]}
+
+    failed = manager.send_messages([{'uuid': 'a'}, {'uuid': 'b'}], target_queue='secondary')
+
+    assert failed == [{'Id': '1', 'uuid': 'b'}]
+
+
 class FakeQueue:
     """ Minimal stand-in exposing just receive_messages/delete_messages, for testing the
     receive_n_messages test helper's surplus-handling logic in isolation from real SQS. """

--- a/snovault/tests/test_indexer_queue.py
+++ b/snovault/tests/test_indexer_queue.py
@@ -106,6 +106,7 @@ def test_receive_messages_passes_wait_time_seconds():
         QueueUrl=manager.queue_url,
         MaxNumberOfMessages=manager.receive_batch_size,
         WaitTimeSeconds=2,
+        AttributeNames=['ApproximateReceiveCount', 'SentTimestamp'],
     )
 
     mock_client.receive_message.reset_mock()
@@ -114,6 +115,7 @@ def test_receive_messages_passes_wait_time_seconds():
         QueueUrl=manager.queue_url,
         MaxNumberOfMessages=manager.receive_batch_size,
         WaitTimeSeconds=20,
+        AttributeNames=['ApproximateReceiveCount', 'SentTimestamp'],
     )
 
 

--- a/snovault/tests/test_secondary_indexing.py
+++ b/snovault/tests/test_secondary_indexing.py
@@ -180,6 +180,11 @@ class FailingPrepareStore(MemoryStore):
         raise RuntimeError('injected PostgreSQL state failure')
 
 
+class FailingReleaseStore(MemoryStore):
+    def release_all(self, namespace):
+        raise AssertionError('off-mode cleanup must not access PostgreSQL state')
+
+
 class FakeQueue:
     def __init__(self, namespace='env-a'):
         self.env_name = namespace
@@ -289,6 +294,12 @@ def test_release_all_clears_pending_state_for_queue_purges():
 
     assert coalescer.release_all() == 1
     assert store.rows[(rid, 'env-a')]['pending'] is False
+
+
+def test_off_mode_release_all_does_not_access_optional_state():
+    coalescer, _, _, _ = make_coalescer(mode='off', store=FailingReleaseStore())
+
+    assert coalescer.release_all() == 0
 
 
 def test_purge_queue_releases_matching_coalescing_namespace():

--- a/snovault/tests/test_secondary_indexing.py
+++ b/snovault/tests/test_secondary_indexing.py
@@ -85,7 +85,6 @@ class MemoryStore:
             self.events.append(('commit', namespace, tuple(targets)))
             return {
                 'targets': targets,
-                'tracked': set(targets),
                 'suppressed': suppressed,
                 'send': set(targets) - suppressed,
             }
@@ -216,7 +215,7 @@ def make_coalescer(mode='on', namespace='env-a', store=None):
     return coalescer, queue, store, registry
 
 
-def test_table_is_narrow_namespace_keyed_and_sweeper_index_is_covering():
+def test_table_is_narrow_namespace_keyed_and_sweeper_index_allows_hot_suppression():
     table = SecondaryIndexingPending.__table__
     assert list(table.columns.keys()) == ['rid', 'namespace', 'pending', 'queued_sid', 'queued_at']
     assert [column.name for column in table.primary_key.columns] == ['rid', 'namespace']
@@ -225,8 +224,11 @@ def test_table_is_narrow_namespace_keyed_and_sweeper_index_is_covering():
     index = next(iter(table.indexes))
     ddl = str(CreateIndex(index).compile(dialect=postgresql.dialect()))
     assert '(namespace, queued_at)' in ddl
-    assert 'INCLUDE (rid, queued_sid)' in ddl
     assert 'WHERE pending' in ddl
+    # queued_sid must stay out of every index (keys and INCLUDE lists alike) so
+    # that merging a newer sid into an already-pending row stays a HOT update.
+    assert 'INCLUDE' not in ddl
+    assert 'queued_sid' not in ddl
     statements = []
 
     def capture(statement, *args, **kwargs):

--- a/snovault/tests/test_secondary_indexing.py
+++ b/snovault/tests/test_secondary_indexing.py
@@ -345,6 +345,23 @@ def test_clear_queue_releases_matching_coalescing_namespace():
     assert store.rows[(rid, 'env-a')]['pending'] is False
 
 
+def test_delete_secondary_queue_releases_matching_coalescing_namespace():
+    rid = str(uuid.uuid4())
+    coalescer, _, store, _ = make_coalescer()
+    coalescer.enqueue([rid], sid=10)
+    manager = object.__new__(QueueManager)
+    manager.registry = {SECONDARY_INDEXING_COALESCER: coalescer}
+    manager.env_name = 'env-a'
+    manager.queue_url = 'primary'
+    manager.second_queue_url = 'secondary'
+    manager.dlq_url = 'dlq'
+    manager.client = SimpleNamespace(delete_queue=mock.Mock())
+
+    manager.delete_queue('secondary')
+
+    assert store.rows[(rid, 'env-a')]['pending'] is False
+
+
 def test_invalid_sweep_interval_uses_safe_default_and_zero_disables_sweeping():
     assert coalescing_sweep_interval({
         'indexer.coalesce_secondary.sweep_interval': 'invalid'

--- a/snovault/tests/test_secondary_indexing.py
+++ b/snovault/tests/test_secondary_indexing.py
@@ -30,6 +30,7 @@ from ..elasticsearch.secondary_indexing import (
     PostgresSecondaryIndexingStore,
     SecondaryIndexingCoalescer,
     coalescing_mode,
+    coalescing_repair_settings,
     reset_secondary_coalescing,
     secondary_coalescing_status,
 )
@@ -326,6 +327,24 @@ def test_purge_queue_releases_matching_coalescing_namespace():
     assert store.rows[(rid, 'env-a')]['pending'] is False
 
 
+def test_clear_queue_releases_matching_coalescing_namespace():
+    rid = str(uuid.uuid4())
+    coalescer, _, store, _ = make_coalescer()
+    coalescer.enqueue([rid], sid=10)
+    message = {'MessageId': 'one', 'ReceiptHandle': 'receipt'}
+    manager = object.__new__(QueueManager)
+    manager.registry = {SECONDARY_INDEXING_COALESCER: coalescer}
+    manager.env_name = 'env-a'
+    manager.queue_targets = ['primary', 'secondary', 'dlq']
+    manager.receive_messages = mock.Mock(side_effect=[[message], [], [], []])
+    manager.delete_messages = mock.Mock()
+
+    manager.clear_queue()
+
+    manager.delete_messages.assert_called_once_with([message], 'primary')
+    assert store.rows[(rid, 'env-a')]['pending'] is False
+
+
 def test_invalid_sweep_interval_uses_safe_default_and_zero_disables_sweeping():
     assert coalescing_sweep_interval({
         'indexer.coalesce_secondary.sweep_interval': 'invalid'
@@ -333,6 +352,27 @@ def test_invalid_sweep_interval_uses_safe_default_and_zero_disables_sweeping():
     assert coalescing_sweep_interval({
         'indexer.coalesce_secondary.sweep_interval': '-1'
     }) == 0
+
+
+def test_invalid_repair_settings_use_safe_bounded_defaults():
+    assert coalescing_repair_settings({
+        'indexer.coalesce_secondary.stale_seconds': 'invalid',
+        'indexer.coalesce_secondary.sweep_limit': 'invalid',
+    }) == (1800, 500)
+    assert coalescing_repair_settings({
+        'indexer.coalesce_secondary.stale_seconds': '-1',
+        'indexer.coalesce_secondary.sweep_limit': '0',
+    }) == (0, 1)
+    coalescer, _, store, registry = make_coalescer()
+    registry.settings.update({
+        'indexer.coalesce_secondary.stale_seconds': 'invalid',
+        'indexer.coalesce_secondary.sweep_limit': 'invalid',
+    })
+    store.rearm_stale = mock.Mock(return_value=[])
+
+    coalescer.sweep()
+
+    store.rearm_stale.assert_called_once_with('env-a', 1800, 500)
 
 
 def test_shadow_runs_state_machine_but_sends_would_be_suppressed_targets():
@@ -768,3 +808,35 @@ def test_secondary_enqueue_failure_retains_cause_message_at_delete_batch_boundar
         raise AssertionError('secondary enqueue failure must retain the cause message')
 
     indexer.queue.delete_messages.assert_not_called()
+
+
+def test_claim_failure_falls_back_to_strict_rendering():
+    rid = str(uuid.uuid4())
+    message = {
+        'MessageId': 'one', 'ReceiptHandle': 'receipt',
+        'Body': json.dumps({
+            'uuid': rid, 'sid': 140, 'strict': True,
+            'timestamp': datetime.datetime.utcnow().isoformat(),
+            'coalesced': True, 'origin': 'fanout',
+        }),
+        'Attributes': {},
+    }
+    coalescer = mock.Mock(enabled=True, namespace='env-a')
+    coalescer.claim.side_effect = RuntimeError('state table unavailable')
+    indexer = object.__new__(Indexer)
+    indexer.secondary_coalescer = coalescer
+    indexer.queue = mock.Mock(delete_batch_size=10)
+    indexer.get_messages_from_queue = mock.Mock(side_effect=[([message], 'secondary'), ([], None)])
+    indexer.update_object = mock.Mock(return_value=None)
+    request = SimpleNamespace(registry={
+        STORAGE: SimpleNamespace(write=SimpleNamespace(get_max_sid=lambda: 140)),
+    })
+
+    errors, deferred = indexer.update_objects_queue(request, [0])
+
+    assert errors == [] and deferred is False
+    indexer.update_object.assert_called_once_with(
+        request, rid, add_to_secondary=None, sid=140, max_sid=140,
+        curr_time=mock.ANY, telemetry_id=None)
+    indexer.queue.delete_messages.assert_called_once_with(
+        [message], target_queue='secondary')

--- a/snovault/tests/test_secondary_indexing.py
+++ b/snovault/tests/test_secondary_indexing.py
@@ -20,7 +20,10 @@ from ..elasticsearch.es_index_listener import (
     coalescing_sweep_configuration,
     coalescing_sweep_interval,
 )
-from ..elasticsearch.create_mapping import _release_secondary_coalescing_targets
+from ..elasticsearch.create_mapping import (
+    _release_secondary_coalescing_targets,
+    _successful_secondary_targets,
+)
 from ..elasticsearch.indexer import Indexer
 from ..elasticsearch.indexer_queue import QueueManager, dlq_to_primary, queue_indexing
 from ..elasticsearch.interfaces import (
@@ -131,22 +134,6 @@ class MemoryStore:
         self.events.append(('sweep_commit', namespace, len(candidates)))
         return candidates
 
-    def rearm_pending(self, namespace, before, row_limit=1000):
-        candidates = []
-        for (rid, row_namespace), row in sorted(self.rows.items()):
-            if (row_namespace != namespace or not row['pending']
-                    or row['queued_at'] >= before):
-                continue
-            row['queued_at'] = datetime.datetime.now(datetime.timezone.utc)
-            candidates.append({
-                'rid': rid,
-                'queued_sid': row['queued_sid'],
-                'queued_at': row['queued_at'],
-            })
-            if len(candidates) == row_limit:
-                break
-        return candidates
-
     def status(self, namespace):
         matching = [row for (rid, ns), row in self.rows.items() if ns == namespace]
         pending = [row for row in matching if row['pending']]
@@ -204,8 +191,21 @@ class MemoryStore:
             return 1
         return 0
 
-    def release_targets(self, target_uuids, namespace):
-        return sum(self.release(rid, namespace) for rid in target_uuids)
+    def capture_targets(self, target_uuids, namespace):
+        return {
+            rid: self.rows[(rid, namespace)]['queued_sid']
+            for rid in {str(uuid.UUID(str(target))) for target in target_uuids}
+            if self.rows.get((rid, namespace), {}).get('pending')
+        }
+
+    def release_targets(self, target_states, namespace):
+        released = 0
+        for rid, queued_sid in target_states.items():
+            row = self.rows.get((rid, namespace))
+            if row is not None and row['pending'] and row['queued_sid'] == queued_sid:
+                row['pending'] = False
+                released += 1
+        return released
 
 
 class FailingPrepareStore(MemoryStore):
@@ -335,7 +335,7 @@ def test_off_mode_release_all_does_not_access_optional_state():
     assert coalescer.release_all() == 0
 
 
-def test_rollout_disable_repairs_state_before_reenable():
+def test_rollout_disable_preserves_state_for_reenable():
     for initial_mode in ('shadow', 'on'):
         rid = str(uuid.uuid4())
         coalescer, queue, store, registry = make_coalescer(mode=initial_mode)
@@ -347,7 +347,7 @@ def test_rollout_disable_repairs_state_before_reenable():
 
         registry.settings['indexer.coalesce_secondary'] = 'on'
         assert coalescer.enabled is True
-        assert queue.send_calls[-1][0][0]['origin'] == 'startup_repair'
+        assert queue.send_calls == []
         coalescer.enqueue([rid], sid=11)
         assert queue.add_calls[-1][0] == []
         assert store.rows[(rid, 'env-a')]['pending'] is True
@@ -367,25 +367,43 @@ def test_bulk_reindex_cleanup_releases_only_selected_state():
     coalescer, _, store, registry = make_coalescer()
     coalescer.enqueue([rid, unrelated], sid=10)
 
-    _release_secondary_coalescing_targets(registry, [rid])
+    target_states = coalescer.snapshot_targets([rid])
+    _release_secondary_coalescing_targets(registry, target_states)
 
     assert store.rows[(rid, 'env-a')]['pending'] is False
     assert store.rows[(unrelated, 'env-a')]['pending'] is True
 
 
-def test_restart_rearms_pending_state_before_enabled_consumption():
+def test_bulk_reindex_cleanup_does_not_release_newer_fanout():
+    rid = str(uuid.uuid4())
+    store = MemoryStore()
+    coalescer, _, _, _ = make_coalescer(mode='on', store=store)
+    coalescer.enqueue([rid], sid=10)
+    target_states = coalescer.snapshot_targets([rid])
+    coalescer.enqueue([rid], sid=11)
+
+    _release_secondary_coalescing_targets(coalescer.registry, target_states)
+
+    assert store.rows[(rid, 'env-a')]['pending'] is True
+    assert store.rows[(rid, 'env-a')]['queued_sid'] == 11
+
+
+def test_bulk_cleanup_releases_only_correlated_successful_sends():
+    assert _successful_secondary_targets(['a', 'b'], [{'Id': '1', 'uuid': 'b'}]) == ['a']
+    assert _successful_secondary_targets(['a', 'b'], [{'Id': '1'}]) == []
+
+
+def test_restart_does_not_duplicate_live_pending_marker():
     rid = str(uuid.uuid4())
     store = MemoryStore()
     first, _, _, _ = make_coalescer(mode='on', store=store)
     first.enqueue([rid], sid=10)
 
-    off, _, _, _ = make_coalescer(mode='off', store=store)
-    assert off.enabled is False
-
     restarted, queue, _, _ = make_coalescer(mode='on', store=store)
     assert restarted.enabled is True
-    assert queue.send_calls[-1][0][0]['origin'] == 'startup_repair'
-    assert store.rows[(rid, 'env-a')]['pending'] is True
+    assert queue.send_calls == []
+    restarted.enqueue([rid], sid=11)
+    assert queue.add_calls[-1][0] == []
 
 
 def test_listener_rechecks_coalescing_mode_and_interval():

--- a/snovault/tests/test_secondary_indexing.py
+++ b/snovault/tests/test_secondary_indexing.py
@@ -16,6 +16,7 @@ from sqlalchemy import create_mock_engine
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.schema import CreateIndex
 
+from ..elasticsearch.es_index_listener import coalescing_sweep_interval
 from ..elasticsearch.indexer import Indexer
 from ..elasticsearch.indexer_queue import QueueManager, dlq_to_primary, queue_indexing
 from ..elasticsearch.interfaces import (
@@ -164,6 +165,15 @@ class MemoryStore:
             self.events.append(('reset_commit', namespace, requeue, len(selected)))
         return selected
 
+    def release_all(self, namespace):
+        released = 0
+        for (rid, row_namespace), row in self.rows.items():
+            if row_namespace == namespace and row['pending']:
+                row['pending'] = False
+                released += 1
+        self.events.append(('release_all', namespace, released))
+        return released
+
 
 class FailingPrepareStore(MemoryStore):
     def prepare_targets(self, target_uuids, namespace, queued_sid):
@@ -270,6 +280,48 @@ def test_on_mode_suppresses_only_after_state_commit_and_merges_sid():
     assert store.rows[(rid, 'env-a')]['queued_sid'] == 12
     assert store.events[0][0] == 'commit'
     assert store.events[1][0] == 'send'
+
+
+def test_release_all_clears_pending_state_for_queue_purges():
+    rid = str(uuid.uuid4())
+    coalescer, _, store, _ = make_coalescer()
+    coalescer.enqueue([rid], sid=10)
+
+    assert coalescer.release_all() == 1
+    assert store.rows[(rid, 'env-a')]['pending'] is False
+
+
+def test_purge_queue_releases_matching_coalescing_namespace():
+    rid = str(uuid.uuid4())
+    coalescer, _, store, _ = make_coalescer()
+    coalescer.enqueue([rid], sid=10)
+    manager = object.__new__(QueueManager)
+    manager.registry = {SECONDARY_INDEXING_COALESCER: coalescer}
+    manager.env_name = 'env-a'
+    manager.queue_url = 'primary'
+    manager.second_queue_url = 'secondary'
+    manager.dlq_url = 'dlq'
+    manager._wait_until_purge_queue_allowed = mock.Mock()
+
+    class PurgeExceptions:
+        PurgeQueueInProgress = type('PurgeQueueInProgress', (Exception,), {})
+
+    manager.client = SimpleNamespace(
+        purge_queue=mock.Mock(), exceptions=PurgeExceptions)
+
+    manager.purge_queue()
+
+    assert manager.client.purge_queue.call_count == 3
+    assert store.rows[(rid, 'env-a')]['pending'] is False
+
+
+def test_invalid_sweep_interval_uses_safe_default_and_zero_disables_sweeping():
+    assert coalescing_sweep_interval({
+        'indexer.coalesce_secondary.sweep_interval': 'invalid'
+    }) == 300
+    assert coalescing_sweep_interval({
+        'indexer.coalesce_secondary.sweep_interval': '-1'
+    }) == 0
 
 
 def test_shadow_runs_state_machine_but_sends_would_be_suppressed_targets():
@@ -671,3 +723,37 @@ def test_failed_render_releases_no_sqs_message_and_redelivery_can_retry():
     # redeliver and safely take the no-op claim path.
     assert store.rows[(rid, 'env-a')]['pending'] is False
     assert coalescer.claim(rid, 120, 120)['outcome'] == 'noop_not_pending'
+
+
+def test_secondary_enqueue_failure_retains_cause_message_at_delete_batch_boundary():
+    rid = str(uuid.uuid4())
+    coalescer, secondary_queue, _, _ = make_coalescer(store=FailingPrepareStore())
+    secondary_queue.fail_next_add = True
+    message = {
+        'MessageId': 'one', 'ReceiptHandle': 'receipt',
+        'Body': json.dumps({
+            'uuid': rid, 'sid': 130, 'strict': False,
+            'timestamp': datetime.datetime.utcnow().isoformat(),
+        }),
+        'Attributes': {},
+    }
+    indexer = object.__new__(Indexer)
+    indexer.secondary_coalescer = coalescer
+    indexer.queue = mock.Mock(delete_batch_size=1)
+    indexer.get_messages_from_queue = mock.Mock(side_effect=[([message], 'primary')])
+    indexer.update_object = mock.Mock(return_value=None)
+    indexer.find_and_queue_secondary_items = mock.Mock(
+        side_effect=lambda source, reverse, sid, telemetry_id, diff=None:
+        coalescer.enqueue(source | reverse, sid=sid, telemetry_id=telemetry_id))
+    request = SimpleNamespace(registry={
+        STORAGE: SimpleNamespace(write=SimpleNamespace(get_max_sid=lambda: 130)),
+    })
+
+    try:
+        indexer.update_objects_queue(request, [0])
+    except RuntimeError as error:
+        assert 'injected SQS add failure' in str(error)
+    else:
+        raise AssertionError('secondary enqueue failure must retain the cause message')
+
+    indexer.queue.delete_messages.assert_not_called()

--- a/snovault/tests/test_secondary_indexing.py
+++ b/snovault/tests/test_secondary_indexing.py
@@ -335,32 +335,6 @@ def test_off_mode_release_all_does_not_access_optional_state():
     assert coalescer.release_all() == 0
 
 
-def test_rollout_disable_preserves_state_for_reenable():
-    for initial_mode in ('shadow', 'on'):
-        rid = str(uuid.uuid4())
-        coalescer, queue, store, registry = make_coalescer(mode=initial_mode)
-        coalescer.enqueue([rid], sid=10)
-
-        registry.settings['indexer.coalesce_secondary'] = 'off'
-        assert coalescer.enabled is False
-        assert store.rows[(rid, 'env-a')]['pending'] is True
-
-        registry.settings['indexer.coalesce_secondary'] = 'on'
-        assert coalescer.enabled is True
-        assert queue.send_calls == []
-        coalescer.enqueue([rid], sid=11)
-        assert queue.add_calls[-1][0] == []
-        assert store.rows[(rid, 'env-a')]['pending'] is True
-
-
-def test_rollout_disable_cleanup_failure_keeps_off_mode_available():
-    coalescer, _, _, registry = make_coalescer(mode='on', store=FailingReleaseStore())
-
-    registry.settings['indexer.coalesce_secondary'] = 'off'
-
-    assert coalescer.enabled is False
-
-
 def test_bulk_reindex_cleanup_releases_only_selected_state():
     rid = str(uuid.uuid4())
     unrelated = str(uuid.uuid4())
@@ -406,11 +380,8 @@ def test_restart_does_not_duplicate_live_pending_marker():
     assert queue.add_calls[-1][0] == []
 
 
-def test_listener_rechecks_coalescing_mode_and_interval():
-    coalescer, _, _, registry = make_coalescer(mode='off')
-    assert coalescing_sweep_configuration(coalescer, registry.settings) == (False, 0)
-
-    registry.settings['indexer.coalesce_secondary'] = 'on'
+def test_listener_uses_enabled_coalescing_interval():
+    coalescer, _, _, registry = make_coalescer(mode='on')
     registry.settings['indexer.coalesce_secondary.sweep_interval'] = '17'
     assert coalescing_sweep_configuration(coalescer, registry.settings) == (True, 17)
 

--- a/snovault/tests/test_secondary_indexing.py
+++ b/snovault/tests/test_secondary_indexing.py
@@ -17,6 +17,7 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.schema import CreateIndex
 
 from ..elasticsearch.es_index_listener import coalescing_sweep_interval
+from ..elasticsearch.create_mapping import _release_secondary_coalescing
 from ..elasticsearch.indexer import Indexer
 from ..elasticsearch.indexer_queue import QueueManager, dlq_to_primary, queue_indexing
 from ..elasticsearch.interfaces import (
@@ -175,6 +176,15 @@ class MemoryStore:
         self.events.append(('release_all', namespace, released))
         return released
 
+    def release(self, rid, namespace):
+        rid = str(uuid.UUID(str(rid)))
+        row = self.rows.get((rid, namespace))
+        if row is not None and row['pending']:
+            row['pending'] = False
+            self.events.append(('release', namespace, rid))
+            return 1
+        return 0
+
 
 class FailingPrepareStore(MemoryStore):
     def prepare_targets(self, target_uuids, namespace, queued_sid):
@@ -301,6 +311,41 @@ def test_off_mode_release_all_does_not_access_optional_state():
     coalescer, _, _, _ = make_coalescer(mode='off', store=FailingReleaseStore())
 
     assert coalescer.release_all() == 0
+
+
+def test_rollout_disable_releases_state_before_reenable():
+    for initial_mode in ('shadow', 'on'):
+        rid = str(uuid.uuid4())
+        coalescer, queue, store, registry = make_coalescer(mode=initial_mode)
+        coalescer.enqueue([rid], sid=10)
+
+        registry.settings['indexer.coalesce_secondary'] = 'off'
+        assert coalescer.enabled is False
+        assert store.rows[(rid, 'env-a')]['pending'] is False
+
+        registry.settings['indexer.coalesce_secondary'] = 'on'
+        assert coalescer.enabled is True
+        coalescer.enqueue([rid], sid=11)
+        assert queue.add_calls[-1][0] == [rid]
+        assert store.rows[(rid, 'env-a')]['pending'] is True
+
+
+def test_rollout_disable_cleanup_failure_keeps_off_mode_available():
+    coalescer, _, _, registry = make_coalescer(mode='on', store=FailingReleaseStore())
+
+    registry.settings['indexer.coalesce_secondary'] = 'off'
+
+    assert coalescer.enabled is False
+
+
+def test_bulk_reindex_cleanup_releases_pending_state():
+    rid = str(uuid.uuid4())
+    coalescer, _, store, registry = make_coalescer()
+    coalescer.enqueue([rid], sid=10)
+
+    _release_secondary_coalescing(registry)
+
+    assert store.rows[(rid, 'env-a')]['pending'] is False
 
 
 def test_purge_queue_releases_matching_coalescing_namespace():
@@ -857,3 +902,36 @@ def test_claim_failure_falls_back_to_strict_rendering():
         curr_time=mock.ANY, telemetry_id=None)
     indexer.queue.delete_messages.assert_called_once_with(
         [message], target_queue='secondary')
+
+
+def test_off_mode_coalesced_marker_releases_state_after_render():
+    rid = str(uuid.uuid4())
+    coalescer, _, store, _ = make_coalescer(mode='off')
+    store.rows[(rid, 'env-a')] = {
+        'pending': True,
+        'queued_sid': 150,
+        'queued_at': datetime.datetime.now(datetime.timezone.utc),
+    }
+    message = {
+        'MessageId': 'one', 'ReceiptHandle': 'receipt',
+        'Body': json.dumps({
+            'uuid': rid, 'sid': 150, 'strict': True,
+            'timestamp': datetime.datetime.utcnow().isoformat(),
+            'coalesced': True, 'origin': 'fanout',
+        }),
+        'Attributes': {},
+    }
+    indexer = object.__new__(Indexer)
+    indexer.secondary_coalescer = coalescer
+    indexer.queue = mock.Mock(delete_batch_size=10)
+    indexer.get_messages_from_queue = mock.Mock(side_effect=[([message], 'secondary'), ([], None)])
+    indexer.update_object = mock.Mock(return_value=None)
+    request = SimpleNamespace(registry={
+        STORAGE: SimpleNamespace(write=SimpleNamespace(get_max_sid=lambda: 150)),
+    })
+
+    errors, deferred = indexer.update_objects_queue(request, [0])
+
+    assert errors == [] and deferred is False
+    assert store.rows[(rid, 'env-a')]['pending'] is False
+    indexer.queue.delete_messages.assert_called_once_with([message], target_queue='secondary')

--- a/snovault/tests/test_secondary_indexing.py
+++ b/snovault/tests/test_secondary_indexing.py
@@ -16,8 +16,11 @@ from sqlalchemy import create_mock_engine
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.schema import CreateIndex
 
-from ..elasticsearch.es_index_listener import coalescing_sweep_interval
-from ..elasticsearch.create_mapping import _release_secondary_coalescing
+from ..elasticsearch.es_index_listener import (
+    coalescing_sweep_configuration,
+    coalescing_sweep_interval,
+)
+from ..elasticsearch.create_mapping import _release_secondary_coalescing_targets
 from ..elasticsearch.indexer import Indexer
 from ..elasticsearch.indexer_queue import QueueManager, dlq_to_primary, queue_indexing
 from ..elasticsearch.interfaces import (
@@ -128,6 +131,22 @@ class MemoryStore:
         self.events.append(('sweep_commit', namespace, len(candidates)))
         return candidates
 
+    def rearm_pending(self, namespace, before, row_limit=1000):
+        candidates = []
+        for (rid, row_namespace), row in sorted(self.rows.items()):
+            if (row_namespace != namespace or not row['pending']
+                    or row['queued_at'] >= before):
+                continue
+            row['queued_at'] = datetime.datetime.now(datetime.timezone.utc)
+            candidates.append({
+                'rid': rid,
+                'queued_sid': row['queued_sid'],
+                'queued_at': row['queued_at'],
+            })
+            if len(candidates) == row_limit:
+                break
+        return candidates
+
     def status(self, namespace):
         matching = [row for (rid, ns), row in self.rows.items() if ns == namespace]
         pending = [row for row in matching if row['pending']]
@@ -184,6 +203,9 @@ class MemoryStore:
             self.events.append(('release', namespace, rid))
             return 1
         return 0
+
+    def release_targets(self, target_uuids, namespace):
+        return sum(self.release(rid, namespace) for rid in target_uuids)
 
 
 class FailingPrepareStore(MemoryStore):
@@ -313,7 +335,7 @@ def test_off_mode_release_all_does_not_access_optional_state():
     assert coalescer.release_all() == 0
 
 
-def test_rollout_disable_releases_state_before_reenable():
+def test_rollout_disable_repairs_state_before_reenable():
     for initial_mode in ('shadow', 'on'):
         rid = str(uuid.uuid4())
         coalescer, queue, store, registry = make_coalescer(mode=initial_mode)
@@ -321,12 +343,13 @@ def test_rollout_disable_releases_state_before_reenable():
 
         registry.settings['indexer.coalesce_secondary'] = 'off'
         assert coalescer.enabled is False
-        assert store.rows[(rid, 'env-a')]['pending'] is False
+        assert store.rows[(rid, 'env-a')]['pending'] is True
 
         registry.settings['indexer.coalesce_secondary'] = 'on'
         assert coalescer.enabled is True
+        assert queue.send_calls[-1][0][0]['origin'] == 'startup_repair'
         coalescer.enqueue([rid], sid=11)
-        assert queue.add_calls[-1][0] == [rid]
+        assert queue.add_calls[-1][0] == []
         assert store.rows[(rid, 'env-a')]['pending'] is True
 
 
@@ -338,14 +361,40 @@ def test_rollout_disable_cleanup_failure_keeps_off_mode_available():
     assert coalescer.enabled is False
 
 
-def test_bulk_reindex_cleanup_releases_pending_state():
+def test_bulk_reindex_cleanup_releases_only_selected_state():
     rid = str(uuid.uuid4())
+    unrelated = str(uuid.uuid4())
     coalescer, _, store, registry = make_coalescer()
-    coalescer.enqueue([rid], sid=10)
+    coalescer.enqueue([rid, unrelated], sid=10)
 
-    _release_secondary_coalescing(registry)
+    _release_secondary_coalescing_targets(registry, [rid])
 
     assert store.rows[(rid, 'env-a')]['pending'] is False
+    assert store.rows[(unrelated, 'env-a')]['pending'] is True
+
+
+def test_restart_rearms_pending_state_before_enabled_consumption():
+    rid = str(uuid.uuid4())
+    store = MemoryStore()
+    first, _, _, _ = make_coalescer(mode='on', store=store)
+    first.enqueue([rid], sid=10)
+
+    off, _, _, _ = make_coalescer(mode='off', store=store)
+    assert off.enabled is False
+
+    restarted, queue, _, _ = make_coalescer(mode='on', store=store)
+    assert restarted.enabled is True
+    assert queue.send_calls[-1][0][0]['origin'] == 'startup_repair'
+    assert store.rows[(rid, 'env-a')]['pending'] is True
+
+
+def test_listener_rechecks_coalescing_mode_and_interval():
+    coalescer, _, _, registry = make_coalescer(mode='off')
+    assert coalescing_sweep_configuration(coalescer, registry.settings) == (False, 0)
+
+    registry.settings['indexer.coalesce_secondary'] = 'on'
+    registry.settings['indexer.coalesce_secondary.sweep_interval'] = '17'
+    assert coalescing_sweep_configuration(coalescer, registry.settings) == (True, 17)
 
 
 def test_purge_queue_releases_matching_coalescing_namespace():

--- a/snovault/tests/test_secondary_indexing.py
+++ b/snovault/tests/test_secondary_indexing.py
@@ -1,0 +1,671 @@
+"""Local-only tests for secondary PostgreSQL/SQS coalescing.
+
+These use deterministic in-memory state and mocked queue clients.  They make no
+connections to PostgreSQL, SQS, Elasticsearch, Redis, or other live services.
+"""
+
+import datetime
+import json
+import threading
+import time
+import uuid
+from types import SimpleNamespace
+from unittest import mock
+
+from sqlalchemy import create_mock_engine
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.schema import CreateIndex
+
+from ..elasticsearch.indexer import Indexer
+from ..elasticsearch.indexer_queue import QueueManager, dlq_to_primary, queue_indexing
+from ..elasticsearch.interfaces import (
+    ELASTIC_SEARCH,
+    INDEXER_QUEUE,
+    INDEXER_QUEUE_MIRROR,
+    INVALIDATION_SCOPE_ENABLED,
+    SECONDARY_INDEXING_COALESCER,
+)
+from ..elasticsearch.secondary_indexing import (
+    PostgresSecondaryIndexingStore,
+    SecondaryIndexingCoalescer,
+    coalescing_mode,
+    reset_secondary_coalescing,
+    secondary_coalescing_status,
+)
+from ..interfaces import STORAGE
+from ..invalidation import add_to_indexing_queue
+from ..storage import SecondaryIndexingPending
+
+
+class MemoryStore:
+    """Locking stand-in for the PostgreSQL protocol, shared by fake connections."""
+
+    def __init__(self):
+        self.rows = {}
+        self.locks = {}
+        self.meta_lock = threading.Lock()
+        self.events = []
+        self.pause_first_prepare = False
+        self.first_prepare_locked = threading.Event()
+        self.release_first_prepare = threading.Event()
+        self.prepare_calls = 0
+
+    def _lock(self, key):
+        with self.meta_lock:
+            return self.locks.setdefault(key, threading.Lock())
+
+    def prepare_targets(self, target_uuids, namespace, queued_sid):
+        targets = sorted({str(uuid.UUID(str(target))) for target in target_uuids})
+        keys = [(target, namespace) for target in targets]
+        locks = [self._lock(key) for key in keys]
+        for lock in locks:
+            lock.acquire()
+        try:
+            with self.meta_lock:
+                self.prepare_calls += 1
+                call_number = self.prepare_calls
+            if self.pause_first_prepare and call_number == 1:
+                self.first_prepare_locked.set()
+                assert self.release_first_prepare.wait(timeout=2)
+            suppressed = {
+                target for target, key in zip(targets, keys)
+                if self.rows.get(key, {}).get('pending')
+            }
+            now = datetime.datetime.now(datetime.timezone.utc)
+            for target, key in zip(targets, keys):
+                row = self.rows.get(key)
+                if row is None or not row['pending']:
+                    self.rows[key] = {
+                        'pending': True,
+                        'queued_sid': int(queued_sid or 0),
+                        'queued_at': now,
+                    }
+                else:
+                    row['queued_sid'] = max(row['queued_sid'], int(queued_sid or 0))
+            self.events.append(('commit', namespace, tuple(targets)))
+            return {
+                'targets': targets,
+                'tracked': set(targets),
+                'suppressed': suppressed,
+                'send': set(targets) - suppressed,
+            }
+        finally:
+            for lock in reversed(locks):
+                lock.release()
+
+    def claim(self, rid, namespace, message_sid, max_sid):
+        rid = str(uuid.UUID(str(rid)))
+        key = (rid, namespace)
+        with self._lock(key):
+            row = self.rows.get(key)
+            message_sid = int(message_sid or 0)
+            if row is None:
+                return {'outcome': 'noop_row_absent', 'effective_sid': message_sid}
+            if not row['pending']:
+                return {'outcome': 'noop_not_pending', 'effective_sid': message_sid}
+            effective_sid = max(message_sid, row['queued_sid'])
+            if effective_sid > int(max_sid):
+                return {'outcome': 'deferred_stale', 'effective_sid': effective_sid}
+            row['pending'] = False
+            return {'outcome': 'claimed', 'effective_sid': effective_sid}
+
+    def rearm_stale(self, namespace, stale_seconds, row_limit):
+        cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=stale_seconds)
+        candidates = []
+        for (rid, row_namespace), row in sorted(self.rows.items()):
+            if (row_namespace == namespace and row['pending']
+                    and row['queued_at'] < cutoff):
+                row['queued_at'] = datetime.datetime.now(datetime.timezone.utc)
+                candidates.append({
+                    'rid': rid,
+                    'queued_sid': row['queued_sid'],
+                    'queued_at': row['queued_at'],
+                })
+                if len(candidates) == row_limit:
+                    break
+        self.events.append(('sweep_commit', namespace, len(candidates)))
+        return candidates
+
+    def status(self, namespace):
+        matching = [row for (rid, ns), row in self.rows.items() if ns == namespace]
+        pending = [row for row in matching if row['pending']]
+        return {
+            'namespace': namespace,
+            'table_rows': len(matching),
+            'pending_count': len(pending),
+            'oldest_pending_age_seconds': 0 if pending else None,
+        }
+
+    def inspect(self, rid, namespace=None):
+        rid = str(uuid.UUID(str(rid)))
+        return [
+            {'namespace': ns, **row}
+            for (row_rid, ns), row in sorted(self.rows.items())
+            if row_rid == rid and (namespace is None or namespace == ns)
+        ]
+
+    def reset(self, namespace, target_uuids=None, all_targets=False, dry_run=True,
+              requeue=False, row_limit=1000):
+        selected = []
+        allowed = set(target_uuids or [])
+        for (rid, ns), row in sorted(self.rows.items()):
+            if ns != namespace or not row['pending']:
+                continue
+            if not all_targets and rid not in allowed:
+                continue
+            selected.append({'rid': rid, 'queued_sid': row['queued_sid'], 'queued_at': row['queued_at']})
+            if not dry_run:
+                if requeue:
+                    row['queued_at'] = datetime.datetime.now(datetime.timezone.utc)
+                else:
+                    row['pending'] = False
+            if len(selected) == row_limit:
+                break
+        if not dry_run:
+            self.events.append(('reset_commit', namespace, requeue, len(selected)))
+        return selected
+
+
+class FailingPrepareStore(MemoryStore):
+    def prepare_targets(self, target_uuids, namespace, queued_sid):
+        raise RuntimeError('injected PostgreSQL state failure')
+
+
+class FakeQueue:
+    def __init__(self, namespace='env-a'):
+        self.env_name = namespace
+        self.add_calls = []
+        self.send_calls = []
+        self.fail_next_add = False
+        self.fail_next_send = False
+
+    def add_uuids(self, registry, uuids, **kwargs):
+        uuids = list(uuids)
+        self.add_calls.append((uuids, kwargs))
+        registry[SECONDARY_INDEXING_COALESCER].store.events.append(
+            ('send', self.env_name, tuple(uuids)))
+        if self.fail_next_add:
+            self.fail_next_add = False
+            raise RuntimeError('injected SQS add failure')
+        return uuids, []
+
+    def send_messages(self, messages, target_queue='primary'):
+        messages = list(messages)
+        self.send_calls.append((messages, target_queue))
+        if self.fail_next_send:
+            self.fail_next_send = False
+            raise RuntimeError('injected SQS send failure')
+        return []
+
+
+class FakeRegistry(dict):
+    def __init__(self, settings=None, **values):
+        super().__init__(values)
+        self.settings = settings or {}
+
+
+def make_coalescer(mode='on', namespace='env-a', store=None):
+    store = store or MemoryStore()
+    queue = FakeQueue(namespace)
+    registry = FakeRegistry(
+        settings={'indexer.coalesce_secondary': mode},
+        **{INDEXER_QUEUE: queue},
+    )
+    coalescer = SecondaryIndexingCoalescer(registry, store=store)
+    registry[SECONDARY_INDEXING_COALESCER] = coalescer
+    return coalescer, queue, store, registry
+
+
+def test_table_is_narrow_namespace_keyed_and_sweeper_index_is_covering():
+    table = SecondaryIndexingPending.__table__
+    assert list(table.columns.keys()) == ['rid', 'namespace', 'pending', 'queued_sid', 'queued_at']
+    assert [column.name for column in table.primary_key.columns] == ['rid', 'namespace']
+    assert table.columns.queued_at.nullable is False
+    assert next(iter(table.foreign_keys)).ondelete == 'CASCADE'
+    index = next(iter(table.indexes))
+    ddl = str(CreateIndex(index).compile(dialect=postgresql.dialect()))
+    assert '(namespace, queued_at)' in ddl
+    assert 'INCLUDE (rid, queued_sid)' in ddl
+    assert 'WHERE pending' in ddl
+    statements = []
+
+    def capture(statement, *args, **kwargs):
+        statements.append(str(statement.compile(dialect=engine.dialect)))
+
+    engine = create_mock_engine('postgresql://', capture)
+    table.create(engine)
+    emitted_ddl = '\n'.join(statements)
+    assert 'fillfactor = 70' in emitted_ddl
+    assert 'autovacuum_vacuum_scale_factor = 0.02' in emitted_ddl
+
+
+def test_postgres_protocol_uses_ordered_unconditional_locks_and_skip_locked_sweep():
+    assert 'ON CONFLICT (rid, namespace) DO NOTHING' in str(PostgresSecondaryIndexingStore.INSERT_MISSING)
+    assert 'ORDER BY target.rid' in str(PostgresSecondaryIndexingStore.INSERT_MISSING)
+    assert 'FOR UPDATE' in str(PostgresSecondaryIndexingStore.LOCK_TARGETS)
+    assert 'ORDER BY rid' in str(PostgresSecondaryIndexingStore.LOCK_TARGETS)
+    assert 'FOR UPDATE SKIP LOCKED' in str(PostgresSecondaryIndexingStore.REARM_STALE)
+
+
+def test_rollout_mode_defaults_and_invalid_values_fail_open():
+    assert coalescing_mode({}) == 'off'
+    assert coalescing_mode({'indexer.coalesce_secondary': 'shadow'}) == 'shadow'
+    assert coalescing_mode({'indexer.coalesce_secondary': 'on'}) == 'on'
+    assert coalescing_mode({'indexer.coalesce_secondary': 'typo'}) == 'off'
+
+
+def test_on_mode_suppresses_only_after_state_commit_and_merges_sid():
+    rid = str(uuid.uuid4())
+    coalescer, queue, store, _ = make_coalescer()
+
+    assert coalescer.enqueue([rid], sid=10) == ([rid], [])
+    assert coalescer.enqueue([rid], sid=12) == ([], [])
+
+    assert len(queue.add_calls) == 2
+    assert queue.add_calls[0][1]['coalesced'] is True
+    assert queue.add_calls[0][1]['origin'] == 'fanout'
+    assert queue.add_calls[1][0] == []
+    assert store.rows[(rid, 'env-a')]['queued_sid'] == 12
+    assert store.events[0][0] == 'commit'
+    assert store.events[1][0] == 'send'
+
+
+def test_shadow_runs_state_machine_but_sends_would_be_suppressed_targets():
+    rid = str(uuid.uuid4())
+    coalescer, queue, store, _ = make_coalescer(mode='shadow')
+    coalescer.enqueue([rid], sid=10)
+    coalescer.enqueue([rid], sid=11)
+    assert [call[0] for call in queue.add_calls] == [[rid], [rid]]
+    assert store.rows[(rid, 'env-a')]['queued_sid'] == 11
+
+
+def test_two_connection_race_serializes_and_sends_once():
+    rid = str(uuid.uuid4())
+    store = MemoryStore()
+    store.pause_first_prepare = True
+    coalescer, queue, _, _ = make_coalescer(store=store)
+    results = []
+
+    first = threading.Thread(target=lambda: results.append(coalescer.enqueue([rid], sid=20)))
+    second = threading.Thread(target=lambda: results.append(coalescer.enqueue([rid], sid=21)))
+    first.start()
+    assert store.first_prepare_locked.wait(timeout=1)
+    second.start()
+    time.sleep(0.02)
+    assert second.is_alive()  # second fake connection is waiting for the target lock
+    store.release_first_prepare.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive() and not second.is_alive()
+    assert sum(len(call[0]) for call in queue.add_calls) == 1
+    assert store.rows[(rid, 'env-a')]['queued_sid'] == 21
+
+
+def test_namespace_isolation_prevents_blue_green_starvation():
+    rid = str(uuid.uuid4())
+    store = MemoryStore()
+    env_a, queue_a, _, _ = make_coalescer(namespace='env-a', store=store)
+    env_b, queue_b, _, _ = make_coalescer(namespace='env-b', store=store)
+    env_a.enqueue([rid], sid=30)
+    env_b.enqueue([rid], sid=30)
+    assert queue_a.add_calls[0][0] == [rid]
+    assert queue_b.add_calls[0][0] == [rid]
+    assert store.rows[(rid, 'env-a')]['pending'] is True
+    assert store.rows[(rid, 'env-b')]['pending'] is True
+
+
+def test_send_failure_remains_pending_and_sweeper_recovers_after_commit():
+    rid = str(uuid.uuid4())
+    coalescer, queue, store, _ = make_coalescer()
+    queue.fail_next_add = True
+    queued, failed = coalescer.enqueue([rid], sid=40)
+    assert queued == [] and len(failed) == 1
+    row = store.rows[(rid, 'env-a')]
+    assert row['pending'] is True
+    row['queued_at'] -= datetime.timedelta(hours=1)
+
+    result = coalescer.sweep()
+    assert result == {'rearmed': 1, 'sent': 1, 'failed': 0}
+    message = queue.send_calls[-1][0][0]
+    assert message['uuid'] == rid
+    assert message['sid'] == 40
+    assert message['coalesced'] is True
+    assert message['origin'] == 'sweeper'
+    assert store.events[-1][0] == 'sweep_commit'
+
+
+def test_state_failure_fails_open_with_legacy_unmarked_secondary_message():
+    rid = str(uuid.uuid4())
+    coalescer, queue, _, _ = make_coalescer(store=FailingPrepareStore())
+
+    queued, failed = coalescer.enqueue([rid], sid=41)
+
+    assert queued == [rid] and failed == []
+    assert queue.add_calls == [([rid], {
+        'strict': True,
+        'target_queue': 'secondary',
+        'sid': 41,
+        'telemetry_id': None,
+        'coalesced': False,
+        'origin': None,
+    })]
+
+
+def test_state_and_send_failure_propagates_so_cause_message_is_not_deleted():
+    rid = str(uuid.uuid4())
+    coalescer, queue, _, _ = make_coalescer(store=FailingPrepareStore())
+    queue.fail_next_add = True
+
+    try:
+        coalescer.enqueue([rid], sid=42)
+    except RuntimeError as error:
+        assert 'injected SQS add failure' in str(error)
+    else:
+        raise AssertionError('combined PostgreSQL/SQS failure must propagate')
+
+
+def test_stale_snapshot_defers_without_releasing_pending():
+    rid = str(uuid.uuid4())
+    coalescer, _, store, _ = make_coalescer()
+    coalescer.enqueue([rid], sid=50)
+    result = coalescer.claim(rid, message_sid=45, max_sid=49)
+    assert result == {'outcome': 'deferred_stale', 'effective_sid': 50}
+    assert store.rows[(rid, 'env-a')]['pending'] is True
+
+
+def test_claim_then_redelivery_is_a_safe_noop_claim():
+    rid = str(uuid.uuid4())
+    coalescer, _, store, _ = make_coalescer()
+    coalescer.enqueue([rid], sid=60)
+    assert coalescer.claim(rid, 60, 60)['outcome'] == 'claimed'
+    assert coalescer.claim(rid, 60, 60)['outcome'] == 'noop_not_pending'
+    assert store.rows[(rid, 'env-a')]['pending'] is False
+
+
+def test_reset_dry_run_release_and_safe_requeue():
+    rid = str(uuid.uuid4())
+    coalescer, queue, store, _ = make_coalescer()
+    coalescer.enqueue([rid], sid=70)
+    assert coalescer.status()['pending_count'] == 1
+    assert coalescer.inspect(rid)[0]['namespace'] == 'env-a'
+
+    dry_run = coalescer.reset(target_uuids=[rid], dry_run=True)
+    assert dry_run['matched'] == 1
+    assert store.rows[(rid, 'env-a')]['pending'] is True
+
+    requeued = coalescer.reset(target_uuids=[rid], dry_run=False, requeue=True)
+    assert requeued['requeued'] == 1
+    assert store.rows[(rid, 'env-a')]['pending'] is True
+    assert queue.send_calls[-1][0][0]['origin'] == 'admin_requeue'
+
+    released = coalescer.reset(target_uuids=[rid], dry_run=False, requeue=False)
+    assert released['released'] == 1
+    assert store.rows[(rid, 'env-a')]['pending'] is False
+
+
+def test_reset_view_is_bounded_authorized_surface_with_audited_principal():
+    rid = str(uuid.uuid4())
+    service = mock.Mock()
+    service.reset.return_value = {
+        'matched': 1, 'released': 1, 'requeued': 0, 'send_failures': 0,
+        'dry_run': False, 'namespace': 'env-a', 'row_limit': 1,
+    }
+    request = SimpleNamespace(
+        json={'uuids': [rid], 'dry_run': False, 'requeue': False, 'limit': 1},
+        registry={SECONDARY_INDEXING_COALESCER: service},
+        authenticated_userid='mailto.operator@example.org',
+    )
+    with mock.patch('snovault.elasticsearch.secondary_indexing.log.warning') as audit:
+        response = reset_secondary_coalescing(None, request)
+    assert response['released'] == 1
+    service.reset.assert_called_once_with(
+        target_uuids=[rid], all_targets=False, dry_run=False,
+        requeue=False, row_limit=1,
+    )
+    assert audit.call_args.kwargs['authenticated_userid'] == 'mailto.operator@example.org'
+
+
+def test_status_view_supports_per_target_and_aggregate_queries_even_when_off():
+    rid = str(uuid.uuid4())
+    service = mock.Mock(mode='off')
+    service.inspect.return_value = [{'namespace': 'env-a', 'pending': True}]
+    service.status.return_value = {'mode': 'off', 'namespace': 'env-a', 'pending_count': 1}
+    registry = {SECONDARY_INDEXING_COALESCER: service}
+
+    target_response = secondary_coalescing_status(
+        None, SimpleNamespace(registry=registry, params={'uuid': rid}))
+    assert target_response['states'] == [{'namespace': 'env-a', 'pending': True}]
+    service.inspect.assert_called_once_with(rid)
+
+    aggregate_response = secondary_coalescing_status(
+        None, SimpleNamespace(registry=registry, params={}))
+    assert aggregate_response['pending_count'] == 1
+
+
+def test_queue_indexing_remains_an_explicit_flag_blind_force_bypass():
+    rid = str(uuid.uuid4())
+    queue = mock.Mock()
+    queue.add_uuids.return_value = ([rid], [])
+    request = SimpleNamespace(
+        json={'uuids': [rid], 'target_queue': 'secondary', 'strict': True},
+        registry={INDEXER_QUEUE: queue},
+        params={},
+    )
+    response = queue_indexing(None, request)
+    assert response['number_queued'] == 1
+    queue.add_uuids.assert_called_once_with(
+        request.registry, [rid], strict=True, target_queue='secondary', telemetry_id=None)
+
+
+def test_dlq_replay_preserves_coalescing_marker_for_a_safe_claim():
+    rid = str(uuid.uuid4())
+    body = json.dumps({
+        'uuid': rid, 'sid': 75, 'strict': True,
+        'timestamp': datetime.datetime.utcnow().isoformat(),
+        'coalesced': True, 'origin': 'fanout',
+    })
+    queue = mock.Mock()
+    queue.receive_messages.return_value = [{'Body': body}]
+    queue.send_messages.return_value = []
+    request = SimpleNamespace(registry={INDEXER_QUEUE: queue})
+
+    response = dlq_to_primary(None, request)
+
+    assert response == {'number_failed': 0, 'number_migrated': 1}
+    queue.send_messages.assert_called_once_with([body])
+    assert json.loads(queue.send_messages.call_args.args[0][0])['coalesced'] is True
+
+
+def test_final_target_selection_consumes_diff_before_secondary_coalescing():
+    source = str(uuid.uuid4())
+    removed_by_scope = str(uuid.uuid4())
+    retained = str(uuid.uuid4())
+    new_rev = str(uuid.uuid4())
+    coalescer = mock.Mock(enabled=True)
+    coalescer.enqueue.return_value = ([retained, new_rev], [])
+    indexer = object.__new__(Indexer)
+    indexer.registry = SimpleNamespace(settings={INVALIDATION_SCOPE_ENABLED: True})
+    indexer.secondary_coalescer = coalescer
+    indexer.queue = mock.Mock()
+    invalidated_with_type = {(removed_by_scope, 'TypeA'), (retained, 'TypeB')}
+
+    def filter_scope(registry, diff, typed, secondary):
+        assert diff == ['Source.field']
+        secondary.discard(removed_by_scope)
+
+    with mock.patch('snovault.elasticsearch.indexer.find_uuids_for_indexing', return_value=(
+            {source, removed_by_scope, retained}, invalidated_with_type)), \
+            mock.patch('snovault.elasticsearch.indexer.filter_invalidation_scope', side_effect=filter_scope):
+        indexer.find_and_queue_secondary_items(
+            {source}, {new_rev}, sid=80, telemetry_id='telemetry', diff=['Source.field'])
+
+    coalescer.enqueue.assert_called_once_with(
+        {retained, new_rev}, sid=80, telemetry_id='telemetry')
+    assert 'diff' not in coalescer.enqueue.call_args.kwargs
+
+
+def test_off_mode_uses_original_secondary_queue_call_exactly():
+    source = str(uuid.uuid4())
+    target = str(uuid.uuid4())
+    indexer = object.__new__(Indexer)
+    indexer.registry = SimpleNamespace(settings={})
+    indexer.secondary_coalescer = mock.Mock(enabled=False)
+    indexer.queue = mock.Mock()
+    indexer.queue.add_uuids.return_value = ([target], [])
+    with mock.patch('snovault.elasticsearch.indexer.find_uuids_for_indexing', return_value=(
+            {source, target}, {(target, 'Type')})):
+        result = indexer.find_and_queue_secondary_items({source}, set(), sid=90, telemetry_id='t')
+    assert result == ([target], [])
+    indexer.queue.add_uuids.assert_called_once_with(
+        indexer.registry, [target], strict=True,
+        target_queue='secondary', sid=90, telemetry_id='t')
+
+
+def test_primary_edit_queue_payload_and_mirror_behavior_are_unchanged():
+    rid = str(uuid.uuid4())
+    primary = mock.Mock()
+    mirror = mock.Mock()
+    request = SimpleNamespace(
+        params={},
+        registry={INDEXER_QUEUE: primary, INDEXER_QUEUE_MIRROR: mirror, ELASTIC_SEARCH: None},
+    )
+    item = {'uuid': rid, 'sid': 100, 'diff': ['Type.field'], 'telemetry_id': 'trace'}
+    add_to_indexing_queue(True, request, item, 'edit')
+
+    for queue in (primary, mirror):
+        queue.send_messages.assert_called_once()
+        payload = queue.send_messages.call_args.args[0][0]
+        assert payload == item
+        assert set(payload) == {
+            'uuid', 'sid', 'diff', 'telemetry_id', 'strict', 'method', 'timestamp'}
+        assert payload['strict'] is False
+        assert payload['method'] == 'PATCH'
+        assert queue.send_messages.call_args.kwargs == {'target_queue': 'primary'}
+
+
+def test_primary_render_does_not_claim_interleaved_secondary_state():
+    rid = str(uuid.uuid4())
+    coalescer, _, store, _ = make_coalescer()
+    coalescer.enqueue([rid], sid=100)
+    primary_body = {
+        'uuid': rid, 'sid': 101, 'strict': False,
+        'timestamp': datetime.datetime.utcnow().isoformat(),
+        'method': 'PATCH', 'diff': ['Type.field'],
+    }
+    message = {
+        'MessageId': 'primary', 'ReceiptHandle': 'receipt',
+        'Body': json.dumps(primary_body), 'Attributes': {},
+    }
+    indexer = object.__new__(Indexer)
+    indexer.secondary_coalescer = coalescer
+    indexer.queue = mock.Mock(delete_batch_size=10)
+    indexer.get_messages_from_queue = mock.Mock(side_effect=[([message], 'primary'), ([], None)])
+    indexer.update_object = mock.Mock(return_value=None)
+    indexer.find_and_queue_secondary_items = mock.Mock(return_value=([], []))
+    request = SimpleNamespace(registry={
+        STORAGE: SimpleNamespace(write=SimpleNamespace(get_max_sid=lambda: 101)),
+    })
+
+    errors, deferred = indexer.update_objects_queue(request, [0])
+
+    assert errors == [] and deferred is False
+    assert store.rows[(rid, 'env-a')]['pending'] is True
+    indexer.find_and_queue_secondary_items.assert_called_once()
+
+
+def test_queue_manager_default_payload_has_no_coalescing_fields_and_receives_attributes():
+    manager = object.__new__(QueueManager)
+    manager.send_messages = mock.Mock(return_value=[])
+    manager.client = mock.Mock()
+    manager.client.receive_message.return_value = {'Messages': []}
+    manager.queue_url = 'primary-url'
+    manager.receive_batch_size = 10
+    manager.queue_targets = {'primary': 'primary-url'}
+    rid = str(uuid.uuid4())
+
+    manager.add_uuids({}, [rid], strict=False, target_queue='primary', sid=101)
+    body = manager.send_messages.call_args.args[0][0]
+    assert set(body) == {'uuid', 'sid', 'strict', 'timestamp'}
+    manager.receive_messages()
+    manager.client.receive_message.assert_called_once_with(
+        QueueUrl='primary-url',
+        MaxNumberOfMessages=10,
+        WaitTimeSeconds=2,
+        AttributeNames=['ApproximateReceiveCount', 'SentTimestamp'],
+    )
+
+
+def test_redelivered_marker_is_rendered_again_but_deleted_only_after_success():
+    rid = str(uuid.uuid4())
+    coalescer, _, store, _ = make_coalescer()
+    coalescer.enqueue([rid], sid=110)
+    message_body = {
+        'uuid': rid, 'sid': 110, 'strict': True,
+        'timestamp': datetime.datetime.utcnow().isoformat(),
+        'coalesced': True, 'origin': 'fanout',
+    }
+    messages = [
+        {
+            'MessageId': str(number), 'ReceiptHandle': 'receipt-%s' % number,
+            'Body': json.dumps(message_body),
+            'Attributes': {'ApproximateReceiveCount': str(number)},
+        }
+        for number in (1, 2)
+    ]
+    indexer = object.__new__(Indexer)
+    indexer.secondary_coalescer = coalescer
+    indexer.queue = mock.Mock(delete_batch_size=10)
+    indexer.get_messages_from_queue = mock.Mock(side_effect=[(messages, 'secondary'), ([], None)])
+
+    def render(*args, **kwargs):
+        assert store.rows[(rid, 'env-a')]['pending'] is False
+
+    indexer.update_object = mock.Mock(side_effect=render)
+    request = SimpleNamespace(registry={
+        STORAGE: SimpleNamespace(write=SimpleNamespace(get_max_sid=lambda: 110)),
+    })
+    counter = [0]
+
+    errors, deferred = indexer.update_objects_queue(request, counter)
+
+    assert errors == [] and deferred is False
+    assert indexer.update_object.call_count == 2
+    assert counter == [2]
+    indexer.queue.delete_messages.assert_called_once_with(messages, target_queue='secondary')
+    assert store.rows[(rid, 'env-a')]['pending'] is False
+
+
+def test_failed_render_releases_no_sqs_message_and_redelivery_can_retry():
+    rid = str(uuid.uuid4())
+    coalescer, _, store, _ = make_coalescer()
+    coalescer.enqueue([rid], sid=120)
+    message = {
+        'MessageId': 'one', 'ReceiptHandle': 'receipt',
+        'Body': json.dumps({
+            'uuid': rid, 'sid': 120, 'strict': True,
+            'timestamp': datetime.datetime.utcnow().isoformat(),
+            'coalesced': True, 'origin': 'fanout',
+        }),
+        'Attributes': {'ApproximateReceiveCount': '1'},
+    }
+    indexer = object.__new__(Indexer)
+    indexer.secondary_coalescer = coalescer
+    indexer.queue = mock.Mock(delete_batch_size=10)
+    indexer.get_messages_from_queue = mock.Mock(side_effect=[([message], 'secondary'), ([], None)])
+    indexer.update_object = mock.Mock(return_value={'error_message': 'injected render failure'})
+    request = SimpleNamespace(registry={
+        STORAGE: SimpleNamespace(write=SimpleNamespace(get_max_sid=lambda: 120)),
+    })
+
+    errors, deferred = indexer.update_objects_queue(request, [0])
+
+    assert errors == [{'error_message': 'injected render failure'}]
+    assert deferred is False
+    indexer.queue.delete_messages.assert_not_called()
+    indexer.queue.replace_messages.assert_called_once_with(
+        [message], target_queue='secondary', vis_timeout=180)
+    # Claim-before-render released the row; the still-undelivered SQS message can
+    # redeliver and safely take the no-op claim path.
+    assert store.rows[(rid, 'env-a')]['pending'] is False
+    assert coalescer.claim(rid, 120, 120)['outcome'] == 'noop_not_pending'

--- a/snovault/tests/test_selective_reindex.py
+++ b/snovault/tests/test_selective_reindex.py
@@ -751,6 +751,7 @@ class RunQueue:
 
     def add_uuids(self, registry, uuids, **kwargs):
         self.added.append((uuids, kwargs))
+        return uuids, []
 
 
 class RunIndices:


### PR DESCRIPTION
## Intent

Validate the existing Snovault PR 330: secondary-only PostgreSQL indexing coalescing must be correct, efficient, simple, tested, and safe; preserve primary SQS behavior, use PostgreSQL state with SQS transport, avoid production side effects, and keep PR 330 as the only PR.

## What Changed

- Add PostgreSQL-backed coalescing for secondary-only indexing invalidations, using SQS markers for transport while preserving primary indexing behavior.
- Integrate safe state handling across queue drains, purges, deletes, bulk reindexing, retries, rollout transitions, and bounded startup repair, with off-mode compatibility.
- Document the operational contract and add changelog entries plus comprehensive PostgreSQL/SQS and queue coverage.

## Risk Assessment

⚠️ Medium: No material defects were substantiated in the current diff; the stateful PostgreSQL/SQS feature is bounded by its documented one-way rollout contract but remains operationally complex.

## Testing

Focused tests and a real PostgreSQL-backed SQS-boundary rehearsal completed successfully. The default Poetry runner and local PostgreSQL setup were unavailable, so an existing Python environment and temporary in-worktree wrappers were used; all transient wrappers, databases, and caches were removed. No linters, formatters, static analysis, or no-mistakes gate were run.

<details>
<summary>Evidence: PostgreSQL + SQS E2E</summary>

`Real PostgreSQL-backed coalescing rehearsal transcript showing commit-before-SQS, duplicate suppression, SID merge, claim, and persisted release.`

```text
{
  "database": "temporary PostgreSQL server",
  "transport": "recording SQS boundary",
  "target_uuid": "00000000-0000-0000-0000-000000000330",
  "first_enqueue": [
    ["00000000-0000-0000-0000-000000000330"],
    []
  ],
  "second_enqueue_duplicate": [[], []],
  "sqs_calls_observed_after_db_commit": [
    {
      "db_state_visible_at_send": {"pending": true, "queued_sid": 100},
      "kwargs": {
        "coalesced": true,
        "origin": "fanout",
        "sid": 100,
        "strict": true,
        "target_queue": "secondary",
        "telemetry_id": null
      },
      "uuids": ["00000000-0000-0000-0000-000000000330"]
    },
    {
      "db_state_visible_at_send": {"pending": true, "queued_sid": 105},
      "kwargs": {
        "coalesced": true,
        "origin": "fanout",
        "sid": 105,
        "strict": true,
        "target_queue": "secondary",
        "telemetry_id": null
      },
      "uuids": []
    }
  ],
  "consumer_claim": {"effective_sid": 105, "outcome": "claimed"},
  "final_persisted_state": {
    "namespace": "env-a",
    "pending": false,
    "queued_sid": 105
  }
}
```
</details>
<details>
<summary>Evidence: Coalescing E2E</summary>

`State/transport rehearsal including unchanged primary and mirror payload behavior.`

```text
{
  "scenario": "secondary fan-out coalescing with SQS transport",
  "target_uuid": "00000000-0000-0000-0000-000000000330",
  "first_enqueue": [["00000000-0000-0000-0000-000000000330"], []],
  "second_enqueue_same_target": [[], []],
  "state_after_duplicate_enqueue": {
    "namespace": "env-a",
    "pending": true,
    "queued_sid": 105
  },
  "consumer_claim_of_old_message": {
    "outcome": "claimed",
    "effective_sid": 105
  },
  "state_after_claim": {
    "pending": false,
    "queued_sid": 105
  },
  "enqueue_after_claim": [["00000000-0000-0000-0000-000000000330"], []],
  "coalescing_transport_calls": [
    {
      "uuids": ["00000000-0000-0000-0000-000000000330"],
      "strict": true,
      "target_queue": "secondary",
      "sid": 100,
      "coalesced": true,
      "origin": "fanout"
    },
    {
      "uuids": [],
      "strict": true,
      "target_queue": "secondary",
      "sid": 105,
      "coalesced": true,
      "origin": "fanout"
    },
    {
      "uuids": ["00000000-0000-0000-0000-000000000330"],
      "strict": true,
      "target_queue": "secondary",
      "sid": 106,
      "coalesced": true,
      "origin": "fanout"
    }
  ],
  "state_and_transport_order": [
    ["commit", "env-a", ["00000000-0000-0000-0000-000000000330"]],
    ["send", "env-a", ["00000000-0000-0000-0000-000000000330"]],
    ["commit", "env-a", ["00000000-0000-0000-0000-000000000330"]],
    ["send", "env-a", []],
    ["commit", "env-a", ["00000000-0000-0000-0000-000000000330"]],
    ["send", "env-a", ["00000000-0000-0000-0000-000000000330"]]
  ],
  "primary_edit_payload_keys": [
    "diff", "method", "sid", "strict", "telemetry_id", "timestamp", "uuid"
  ],
  "primary_edit_strict": false,
  "mirror_edit_payload_matches_primary": true,
  "postgres_table_contract": {
    "columns": ["rid", "namespace", "pending", "queued_sid", "queued_at"],
    "primary_key": ["rid", "namespace"],
    "partial_index": "CREATE INDEX secondary_indexing_pending_sweep_idx ON secondary_indexing_pending (namespace, queued_at) WHERE pending"
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (8) ✅</summary>

- 🚨 `/Users/willronchetti/.no-mistakes/worktrees/c79a0abd23c3/01KXNWQZTBC2909KD9TMYNADF9/snovault/elasticsearch/secondary_indexing.py:354` - When `on` arms a row, `QueueManager.purge_queue()` used by `create_mapping` removes its SQS marker but never clears `secondary_indexing_pending`; bulk reindex then bypasses this coalescer, leaving the row pending and suppressing later fan-out until the stale sweep (default 30 minutes). Release/reset state whenever queues are purged or bulk reindexing begins.
- 🚨 `/Users/willronchetti/.no-mistakes/worktrees/c79a0abd23c3/01KXNWQZTBC2909KD9TMYNADF9/snovault/elasticsearch/secondary_indexing.py:401` - This branch raises when PostgreSQL state is unavailable and the fallback SQS send reports failures so the causing primary message can retry. However, `update_objects_queue` may flush `to_delete` before calling secondary fan-out; when this message fills the batch, it is already deleted, so failed targets have neither a primary retry nor durable coalescing state. Defer deletion until fan-out succeeds or otherwise retain the cause message.
- ⚠️ `/Users/willronchetti/.no-mistakes/worktrees/c79a0abd23c3/01KXNWQZTBC2909KD9TMYNADF9/snovault/elasticsearch/es_index_listener.py:64` - The new sweep interval is parsed with `int()` on every listener loop without validation, even when coalescing is disabled. A non-numeric configuration raises out of the listener and the generic handler terminates the process; invalid values should fail closed to a safe default or disable sweeping.

🔧 Fix: Fixed purge recovery, retry retention, and interval validation
1 error still open:
- 🚨 `/Users/willronchetti/.no-mistakes/worktrees/c79a0abd23c3/01KXNWQZTBC2909KD9TMYNADF9/snovault/elasticsearch/indexer_queue.py:517` - The stated intent requires “avoid production side effects,” but this cleanup runs whenever the coalescer object exists, even in default `off` mode: `QueueManager.purge_queue()` now unconditionally calls `release_all()`. That adds a PostgreSQL write/query to legacy purge flows and fails deployments where the optional state table has not been installed. Gate cleanup on enabled mode or otherwise preserve the off-mode path; cover all queue-clearing paths consistently.

🔧 Fix: Guarded off-mode cleanup and added compatibility coverage
3 issues (1 error, 2 warnings) still open:
- 🚨 `/Users/willronchetti/.no-mistakes/worktrees/c79a0abd23c3/01KXNWQZTBC2909KD9TMYNADF9/snovault/elasticsearch/indexer_queue.py:520` - With coalescing enabled, `clear_queue()` deletes secondary marker messages without releasing matching PostgreSQL rows, suppressing later fan-out until the stale sweep. Release the current namespace&#39;s state when draining this queue.
- ⚠️ `/Users/willronchetti/.no-mistakes/worktrees/c79a0abd23c3/01KXNWQZTBC2909KD9TMYNADF9/snovault/elasticsearch/secondary_indexing.py:479` - `stale_seconds` and `sweep_limit` use unvalidated `int()` conversions. Malformed settings make every sweep fail inside the listener&#39;s catch-and-log wrapper, leaving stranded rows unrepaired indefinitely. Apply safe defaults and validation like the sweep interval.
- ⚠️ `/Users/willronchetti/.no-mistakes/worktrees/c79a0abd23c3/01KXNWQZTBC2909KD9TMYNADF9/snovault/elasticsearch/indexer.py:338` - The producer fails open when PostgreSQL state is unavailable, but existing `coalesced` markers do not: claim failures only visibility-replace the message, so a state-table outage can repeatedly retry and eventually DLQ valid secondary work. Fall back to ordinary strict rendering or provide equivalent durable retry handling.

🔧 Fix: Repaired queue drains, settings fallback, and claim outage handling
1 warning still open:
- ⚠️ `/Users/willronchetti/.no-mistakes/worktrees/c79a0abd23c3/01KXNWQZTBC2909KD9TMYNADF9/snovault/elasticsearch/indexer_queue.py:535` - `delete_queue()` is another destructive queue-clearing path, but unlike purge/clear it never releases coalescing state. Deleting and recreating the secondary queue while coalescing is enabled leaves rows armed and suppresses later fan-out until the sweep; release matching namespace state when deleting the secondary queue, preserving the off-mode guard.

🔧 Fix: Released state when deleting secondary queues
2 warnings still open:
- ⚠️ `/Users/willronchetti/.no-mistakes/worktrees/c79a0abd23c3/01KXNWQZTBC2909KD9TMYNADF9/snovault/elasticsearch/create_mapping.py:1322` - Cleanup only runs in the total-reindex/purge block. Other bulk paths, including staggered and non-purging reindexes, bypass coalescing without releasing pending rows; lost markers can leave `pending=TRUE` and suppress later fan-out until the default 30-minute sweep. Release/reset state before every bulk reindex.
- ⚠️ `/Users/willronchetti/.no-mistakes/worktrees/c79a0abd23c3/01KXNWQZTBC2909KD9TMYNADF9/snovault/elasticsearch/indexer.py:329` - The intent requires secondary coalescing to be “correct ... and safe.” Switching from `on`/`shadow` to `off` makes existing coalesced markers skip `claim`; successful renders delete them while leaving PostgreSQL rows pending, and off mode disables sweeping. Re-enabling can therefore suppress fresh fan-out until reset or stale repair; release existing marker state during rollback or enforce cleanup.

🔧 Fix: Release coalescing state across bulk and rollout transitions
3 issues (2 errors, 1 warning) still open:
- 🚨 `/Users/willronchetti/.no-mistakes/worktrees/c79a0abd23c3/01KXNWQZTBC2909KD9TMYNADF9/snovault/elasticsearch/create_mapping.py:1393` - Conflicts with the required intent that secondary-only coalescing be “correct ... and safe”: this namespace-wide `release_all()` before partial/selective/type-only bulk reindexes can discard an unrelated target’s only recovery row when its prior SQS send failed, leaving Elasticsearch stale. Preserve pending state outside the actual reindex target set.
- 🚨 `/Users/willronchetti/.no-mistakes/worktrees/c79a0abd23c3/01KXNWQZTBC2909KD9TMYNADF9/snovault/elasticsearch/secondary_indexing.py:382` - Conflicts with the required intent that coalescing be “correct ... and safe”: `_observed_mode` is initialized from the current setting, so normal process restarts across `on`/`shadow` ↔ `off` perform no cleanup. Re-enabling can therefore suppress fresh fan-out behind stranded rows whose markers were purged or never sent; persist or enforce transition cleanup across restarts and mixed-worker rollouts.
- ⚠️ `/Users/willronchetti/.no-mistakes/worktrees/c79a0abd23c3/01KXNWQZTBC2909KD9TMYNADF9/snovault/elasticsearch/es_index_listener.py:71` - The listener snapshots `coalescing_enabled` at startup. Enabling coalescing in a running process that started with it off arms PostgreSQL state but never runs the sweeper, so failed secondary sends are not repaired; re-evaluate the mode and sweep interval in the loop or require a listener restart for the rollout.

🔧 Fix: Scope bulk cleanup and repair rollout restarts dynamically
3 issues (1 error, 2 warnings) still open:
- 🚨 `/Users/willronchetti/.no-mistakes/worktrees/c79a0abd23c3/01KXNWQZTBC2909KD9TMYNADF9/snovault/elasticsearch/create_mapping.py:1465` - This conflicts with the required intent that coalescing be “correct ... and safe”: `QueueManager.add_uuids()` returns the original UUID list even when SQS reports failures, and those failure records contain batch `Id` values rather than `uuid`. `failed_uuids` therefore stays empty and this releases every target, including failed sends; the synchronous path also ignores indexing errors before releasing state. Correlate failures correctly and release only confirmed successful targets.
- ⚠️ `/Users/willronchetti/.no-mistakes/worktrees/c79a0abd23c3/01KXNWQZTBC2909KD9TMYNADF9/snovault/elasticsearch/secondary_indexing.py:433` - This conflicts with the required intent that coalescing be “efficient”: every new coalescer starts with `_repair_on_enable=True`, so the first `enabled` check re-arms and sends duplicate markers for every currently pending row, even when existing SQS markers are valid. The unbounded loop can block startup and flood SQS/Elasticsearch, especially across multiple indexing workers. Restrict repair to a proven off-to-on transition or make it bounded and sweep-driven.
- ⚠️ `/Users/willronchetti/.no-mistakes/worktrees/c79a0abd23c3/01KXNWQZTBC2909KD9TMYNADF9/snovault/elasticsearch/create_mapping.py:1465` - The target-state release occurs after the bulk message is accepted. A concurrent primary edit can arm the same target between enqueue and `release_targets()`; if the bulk worker indexed before that edit and the newer fan-out send then fails, this late release clears the only recovery row and loses the invalidation. Synchronize the cleanup with the bulk snapshot/queueing boundary or preserve newer state.

🔧 Fix: Hardened bulk cleanup and bounded startup repair
1 error still open:
- 🚨 `/Users/willronchetti/.no-mistakes/worktrees/c79a0abd23c3/01KXNWQZTBC2909KD9TMYNADF9/snovault/elasticsearch/secondary_indexing.py:550` - The intent requires secondary-only PostgreSQL indexing coalescing to be “correct ... and safe.” `release_all()` is disabled in `off` mode, and the coalescer does not persist the prior rollout mode or repair state on startup; switching from `on`/`shadow` to `off` after a failed or purged SQS marker can leave `pending=TRUE`, and a later restart with coalescing enabled suppresses fresh fan-out until the stale sweep (or indefinitely when sweeping is disabled). Add durable transition cleanup or an equivalent safe reset across restarts and mixed-worker rollouts.

🔧 Fix: Scoped rollout contract to one-way deployment
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `NO_SERVER_FIXTURES=TRUE PYENV_VERSION=snovault311 python -m pytest snovault/tests/test_secondary_indexing.py snovault/tests/test_indexer_queue.py -q`
- <code>`PATH=&#34;$PWD/test-bin:$PATH&#34; LANG=C LC_ALL=C PYENV_VERSION=snovault311 python -m pytest snovault/tests/test_secondary_indexing.py snovault/tests/test_indexer_queue.py -q` (real temporary PostgreSQL)</code>
- <code>Manual real-PostgreSQL `PostgresSecondaryIndexingStore` plus recording-SQS rehearsal</code>
- `gh-axi pr checks 330`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
