### PR TITLE
Security (AccessKey reset-secret ACL), ingestion poison-message isolation, unused-dep cleanup, and timing-log/observability fix [T0/T8/T7/T4]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,16 @@ Change Log
   as their declared ``numpy`` provider and do not declare it themselves, so removing it would
   break their transitive provision.
 
+* Observability (audit finding T4): fix the per-request "Request timings" structured log so its
+  environment field (``ff_env``) is populated. ``stats_tween`` read the setting from a mistyped
+  key ``env_name`` (underscore) that no code ever sets, instead of the dotted ``env.name`` used
+  everywhere else in the framework, so ``ff_env`` -- the primary environment filter for log
+  aggregation and for any consumer Sentry ``LoggingIntegration`` that captures this event -- was
+  silently always absent. Snovault deliberately does NOT initialize Sentry or depend on
+  ``sentry-sdk``: Sentry is initialized consumer-side (via the ``SENTRY_DSN`` deployment setting,
+  see ``dcicutils`` deployment support), and consumers capture snovault's request/DB timing
+  telemetry by pointing a Sentry (or other) log integration at this now-correct structured event.
+
 11.33.1
 =======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,38 @@ snovault
 Change Log
 ----------
 
+11.34.0
+=======
+
+* Security (audit finding T0): fix a broken-object-level-authorization flaw in the
+  ``AccessKey`` ``reset-secret`` view (``snovault/types/access_key.py``). The view was gated
+  on ``permission='add'``; on an ``AccessKey`` *item* context that permission has no matching
+  ACE (the item ACL's terminal deny covers only ``view``/``edit``), so it fell through to the
+  access-keys collection's ``(Allow, Authenticated, 'add')`` -- letting any authenticated user
+  rotate and read any other user's access-key secret, then authenticate as that user. The view
+  is now gated on ``permission='edit'`` (item-scoped to ``role.owner`` + ``group.admin``).
+  Collection-level ``add`` (self-service key creation) is unchanged. Adds owner/admin/non-owner
+  regression tests.
+
+* Reliability (audit finding T8): a single malformed SQS ingestion message no longer
+  crash-loops the ingestion listener. ``IngestionListener.run`` now routes each message through
+  a new ``handle_one_message`` that isolates JSON/uuid parse failures and handler exceptions,
+  logs a body-free message identity for diagnosis, deletes unparseable (poison) messages so
+  they cannot redeliver-and-crash the listener every visibility-timeout window, and leaves
+  handler-errored (but structurally valid) messages for redelivery instead of acknowledging
+  them. Adds offline mocked tests for invalid JSON, missing ``uuid``, and handler
+  success/failure/raise. (The separate ES indexer dead-letter-queue policy question, audit
+  finding B-ES-1, is intentionally left unaddressed here.)
+
+* Dependencies (audit finding T7): remove the unused heavy direct dependencies ``pmdarima``
+  and ``xlrd`` (neither is imported anywhere in snovault; both were vestiges of an abandoned
+  Python-3.12 upgrade attempt). This drops the entire ``pmdarima`` scientific-computing closure
+  (``scikit-learn``, ``statsmodels``, ``patsy``, ``scipy``, ``joblib``, ``cython``, ``pandas``,
+  ...) from the lockfile, shrinking installs and CVE surface. ``numpy`` is deliberately
+  retained: consumer apps (fourfront/cgap/smaht-portal/encoded-core) rely on ``dcicsnovault``
+  as their declared ``numpy`` provider and do not declare it themselves, so removing it would
+  break their transitive provision.
+
 11.33.1
 =======
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -967,78 +967,6 @@ test = ["certifi", "cryptography-vectors (==43.0.3)", "pretend", "pytest (>=6.2.
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
-name = "cython"
-version = "3.1.2"
-description = "The Cython compiler for writing C extensions in the Python language."
-category = "main"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "cython-3.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0f2add8b23cb19da3f546a688cd8f9e0bfc2776715ebf5e283bc3113b03ff008"},
-    {file = "cython-3.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0d6248a2ae155ca4c42d7fa6a9a05154d62e695d7736bc17e1b85da6dcc361df"},
-    {file = "cython-3.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:262bf49d9da64e2a34c86cbf8de4aa37daffb0f602396f116cca1ed47dc4b9f2"},
-    {file = "cython-3.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae53ae93c699d5f113953a9869df2fc269d8e173f9aa0616c6d8d6e12b4e9827"},
-    {file = "cython-3.1.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b417c5d046ce676ee595ec7955ed47a68ad6f419cbf8c2a8708e55a3b38dfa35"},
-    {file = "cython-3.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:af127da4b956e0e906e552fad838dc3fb6b6384164070ceebb0d90982a8ae25a"},
-    {file = "cython-3.1.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:9be3d4954b46fd0f2dceac011d470f658eaf819132db52fbd1cf226ee60348db"},
-    {file = "cython-3.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:63da49672c4bb022b4de9d37bab6c29953dbf5a31a2f40dffd0cf0915dcd7a17"},
-    {file = "cython-3.1.2-cp310-cp310-win32.whl", hash = "sha256:2d8291dbbc1cb86b8d60c86fe9cbf99ec72de28cb157cbe869c95df4d32efa96"},
-    {file = "cython-3.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:e1f30a1339e03c80968a371ef76bf27a6648c5646cccd14a97e731b6957db97a"},
-    {file = "cython-3.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5548573e0912d7dc80579827493315384c462e2f15797b91a8ed177686d31eb9"},
-    {file = "cython-3.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bf3ea5bc50d80762c490f42846820a868a6406fdb5878ae9e4cc2f11b50228a"},
-    {file = "cython-3.1.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20ce53951d06ab2bca39f153d9c5add1d631c2a44d58bf67288c9d631be9724e"},
-    {file = "cython-3.1.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e05a36224e3002d48c7c1c695b3771343bd16bc57eab60d6c5d5e08f3cbbafd8"},
-    {file = "cython-3.1.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dbc0fc0777c7ab82297c01c61a1161093a22a41714f62e8c35188a309bd5db8e"},
-    {file = "cython-3.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:18161ef3dd0e90a944daa2be468dd27696712a5f792d6289e97d2a31298ad688"},
-    {file = "cython-3.1.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ca45020950cd52d82189d6dfb6225737586be6fe7b0b9d3fadd7daca62eff531"},
-    {file = "cython-3.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:aaae97d6d07610224be2b73a93e9e3dd85c09aedfd8e47054e3ef5a863387dae"},
-    {file = "cython-3.1.2-cp311-cp311-win32.whl", hash = "sha256:3d439d9b19e7e70f6ff745602906d282a853dd5219d8e7abbf355de680c9d120"},
-    {file = "cython-3.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:8efa44ee2f1876e40eb5e45f6513a19758077c56bf140623ccab43d31f873b61"},
-    {file = "cython-3.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9c2c4b6f9a941c857b40168b3f3c81d514e509d985c2dcd12e1a4fea9734192e"},
-    {file = "cython-3.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bdbc115bbe1b8c1dcbcd1b03748ea87fa967eb8dfc3a1a9bb243d4a382efcff4"},
-    {file = "cython-3.1.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c05111f89db1ca98edc0675cfaa62be47b3ff519a29876eb095532a9f9e052b8"},
-    {file = "cython-3.1.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6e7188df8709be32cfdfadc7c3782e361c929df9132f95e1bbc90a340dca3c7"},
-    {file = "cython-3.1.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1c0ecc71e60a051732c2607b8eb8f2a03a5dac09b28e52b8af323c329db9987b"},
-    {file = "cython-3.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f27143cf88835c8bcc9bf3304953f23f377d1d991e8942982fe7be344c7cfce3"},
-    {file = "cython-3.1.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d8c43566701133f53bf13485839d8f3f309095fe0d3b9d0cd5873073394d2edc"},
-    {file = "cython-3.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a3bb893e85f027a929c1764bb14db4c31cbdf8a96f59a78f608f2ba7cfbbce95"},
-    {file = "cython-3.1.2-cp312-cp312-win32.whl", hash = "sha256:12c5902f105e43ca9af7874cdf87a23627f98c15d5a4f6d38bc9d334845145c0"},
-    {file = "cython-3.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:06789eb7bd2e55b38b9dd349e9309f794aee0fed99c26ea5c9562d463877763f"},
-    {file = "cython-3.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:cc22e5f18af436c894b90c257130346930fdc860d7f42b924548c591672beeef"},
-    {file = "cython-3.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42c7bffb0fe9898996c7eef9eb74ce3654553c7a3a3f3da66e5a49f801904ce0"},
-    {file = "cython-3.1.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88dc7fd54bfae78c366c6106a759f389000ea4dfe8ed9568af9d2f612825a164"},
-    {file = "cython-3.1.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80d0ce057672ca50728153757d022842d5dcec536b50c79615a22dda2a874ea0"},
-    {file = "cython-3.1.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eda6a43f1b78eae0d841698916eef661d15f8bc8439c266a964ea4c504f05612"},
-    {file = "cython-3.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b4c516d103e87c2e9c1ab85227e4d91c7484c1ba29e25f8afbf67bae93fee164"},
-    {file = "cython-3.1.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7542f1d18ab2cd22debc72974ec9e53437a20623d47d6001466e430538d7df54"},
-    {file = "cython-3.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:63335513c06dcec4ecdaa8598f36c969032149ffd92a461f641ee363dc83c7ad"},
-    {file = "cython-3.1.2-cp313-cp313-win32.whl", hash = "sha256:b377d542299332bfeb61ec09c57821b10f1597304394ba76544f4d07780a16df"},
-    {file = "cython-3.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:8ab1319c77f15b0ae04b3fb03588df3afdec4cf79e90eeea5c961e0ebd8fdf72"},
-    {file = "cython-3.1.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:dbc1f225cb9f9be7a025589463507e10bb2d76a3258f8d308e0e2d0b966c556e"},
-    {file = "cython-3.1.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c1661c1701c96e1866f839e238570c96a97535a81da76a26f45f99ede18b3897"},
-    {file = "cython-3.1.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:955bc6032d89ce380458266e65dcf5ae0ed1e7c03a7a4457e3e4773e90ba7373"},
-    {file = "cython-3.1.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b58e859889dd0fc6c3a990445b930f692948b28328bb4f3ed84b51028b7e183"},
-    {file = "cython-3.1.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:992a6504aa3eed50dd1fc3d1fa998928b08c1188130bd526e177b6d7f3383ec4"},
-    {file = "cython-3.1.2-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:f3d03077938b02ec47a56aa156da7bfc2379193738397d4e88086db5b0a374e0"},
-    {file = "cython-3.1.2-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:b7e1d3c383a5f4ca5319248b9cb1b16a04fb36e153d651e558897171b7dbabb9"},
-    {file = "cython-3.1.2-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:58d4d45e40cadf4f602d96b7016cf24ccfe4d954c61fa30b79813db8ccb7818f"},
-    {file = "cython-3.1.2-cp38-cp38-win32.whl", hash = "sha256:919ff38a93f7c21829a519693b336979feb41a0f7ca35969402d7e211706100e"},
-    {file = "cython-3.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:aca994519645ba8fb5e99c0f9d4be28d61435775552aaf893a158c583cd218a5"},
-    {file = "cython-3.1.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fe7f1ee4c13f8a773bd6c66b3d25879f40596faeab49f97d28c39b16ace5fff9"},
-    {file = "cython-3.1.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c9ec7d2baea122d94790624f743ff5b78f4e777bf969384be65b69d92fa4bc3f"},
-    {file = "cython-3.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df57827185874f29240b02402e615547ab995d90182a852c6ec4f91bbae355a4"},
-    {file = "cython-3.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1a69b9b4fe0a48a8271027c0703c71ab1993c4caca01791c0fd2e2bd9031aa"},
-    {file = "cython-3.1.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:970cc1558519f0f108c3e2f4b3480de4945228d9292612d5b2bb687e36c646b8"},
-    {file = "cython-3.1.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:604c39cd6d152498a940aeae28b6fd44481a255a3fdf1b0051c30f3873c88b7f"},
-    {file = "cython-3.1.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:855f2ae06438c7405997cf0df42d5b508ec3248272bb39df4a7a4a82a5f7c8cb"},
-    {file = "cython-3.1.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:9e3016ca7a86728bfcbdd52449521e859a977451f296a7ae4967cefa2ec498f7"},
-    {file = "cython-3.1.2-cp39-cp39-win32.whl", hash = "sha256:4896fc2b0f90820ea6fcf79a07e30822f84630a404d4e075784124262f6d0adf"},
-    {file = "cython-3.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:a965b81eb4f5a5f3f6760b162cb4de3907c71a9ba25d74de1ad7a0e4856f0412"},
-    {file = "cython-3.1.2-py3-none-any.whl", hash = "sha256:d23fd7ffd7457205f08571a42b108a3cf993e83a59fe4d72b42e6fc592cf2639"},
-    {file = "cython-3.1.2.tar.gz", hash = "sha256:6bbf7a953fa6762dfecdec015e3b054ba51c0121a45ad851fa130f63f5331381"},
-]
-
-[[package]]
 name = "dcicutils"
 version = "8.18.3"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
@@ -1488,18 +1416,6 @@ files = [
 ]
 
 [[package]]
-name = "joblib"
-version = "1.5.1"
-description = "Lightweight pipelining with Python functions"
-category = "main"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "joblib-1.5.1-py3-none-any.whl", hash = "sha256:4719a31f054c7d766948dcd83e9613686b27114f190f717cec7eaa2084f8a74a"},
-    {file = "joblib-1.5.1.tar.gz", hash = "sha256:f4f86e351f39fe3d0d32a9f2c3d8af1ee4cec285aafcb27003dda5205576b444"},
-]
-
-[[package]]
 name = "jsonc-parser"
 version = "1.1.5"
 description = "A lightweight, native tool for parsing .jsonc files"
@@ -1819,100 +1735,13 @@ kerberos = ["requests_kerberos"]
 name = "packaging"
 version = "25.0"
 description = "Core utilities for Python packages"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
     {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
     {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
 ]
-
-[[package]]
-name = "pandas"
-version = "2.3.1"
-description = "Powerful data structures for data analysis, time series, and statistics"
-category = "main"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "pandas-2.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:22c2e866f7209ebc3a8f08d75766566aae02bcc91d196935a1d9e59c7b990ac9"},
-    {file = "pandas-2.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3583d348546201aff730c8c47e49bc159833f971c2899d6097bce68b9112a4f1"},
-    {file = "pandas-2.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f951fbb702dacd390561e0ea45cdd8ecfa7fb56935eb3dd78e306c19104b9b0"},
-    {file = "pandas-2.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd05b72ec02ebfb993569b4931b2e16fbb4d6ad6ce80224a3ee838387d83a191"},
-    {file = "pandas-2.3.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1b916a627919a247d865aed068eb65eb91a344b13f5b57ab9f610b7716c92de1"},
-    {file = "pandas-2.3.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:fe67dc676818c186d5a3d5425250e40f179c2a89145df477dd82945eaea89e97"},
-    {file = "pandas-2.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:2eb789ae0274672acbd3c575b0598d213345660120a257b47b5dafdc618aec83"},
-    {file = "pandas-2.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2b0540963d83431f5ce8870ea02a7430adca100cec8a050f0811f8e31035541b"},
-    {file = "pandas-2.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fe7317f578c6a153912bd2292f02e40c1d8f253e93c599e82620c7f69755c74f"},
-    {file = "pandas-2.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6723a27ad7b244c0c79d8e7007092d7c8f0f11305770e2f4cd778b3ad5f9f85"},
-    {file = "pandas-2.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3462c3735fe19f2638f2c3a40bd94ec2dc5ba13abbb032dd2fa1f540a075509d"},
-    {file = "pandas-2.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:98bcc8b5bf7afed22cc753a28bc4d9e26e078e777066bc53fac7904ddef9a678"},
-    {file = "pandas-2.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4d544806b485ddf29e52d75b1f559142514e60ef58a832f74fb38e48d757b299"},
-    {file = "pandas-2.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:b3cd4273d3cb3707b6fffd217204c52ed92859533e31dc03b7c5008aa933aaab"},
-    {file = "pandas-2.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:689968e841136f9e542020698ee1c4fbe9caa2ed2213ae2388dc7b81721510d3"},
-    {file = "pandas-2.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:025e92411c16cbe5bb2a4abc99732a6b132f439b8aab23a59fa593eb00704232"},
-    {file = "pandas-2.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b7ff55f31c4fcb3e316e8f7fa194566b286d6ac430afec0d461163312c5841e"},
-    {file = "pandas-2.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7dcb79bf373a47d2a40cf7232928eb7540155abbc460925c2c96d2d30b006eb4"},
-    {file = "pandas-2.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:56a342b231e8862c96bdb6ab97170e203ce511f4d0429589c8ede1ee8ece48b8"},
-    {file = "pandas-2.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ca7ed14832bce68baef331f4d7f294411bed8efd032f8109d690df45e00c4679"},
-    {file = "pandas-2.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ac942bfd0aca577bef61f2bc8da8147c4ef6879965ef883d8e8d5d2dc3e744b8"},
-    {file = "pandas-2.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9026bd4a80108fac2239294a15ef9003c4ee191a0f64b90f170b40cfb7cf2d22"},
-    {file = "pandas-2.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6de8547d4fdb12421e2d047a2c446c623ff4c11f47fddb6b9169eb98ffba485a"},
-    {file = "pandas-2.3.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:782647ddc63c83133b2506912cc6b108140a38a37292102aaa19c81c83db2928"},
-    {file = "pandas-2.3.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ba6aff74075311fc88504b1db890187a3cd0f887a5b10f5525f8e2ef55bfdb9"},
-    {file = "pandas-2.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e5635178b387bd2ba4ac040f82bc2ef6e6b500483975c4ebacd34bec945fda12"},
-    {file = "pandas-2.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f3bf5ec947526106399a9e1d26d40ee2b259c66422efdf4de63c848492d91bb"},
-    {file = "pandas-2.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:1c78cf43c8fde236342a1cb2c34bcff89564a7bfed7e474ed2fffa6aed03a956"},
-    {file = "pandas-2.3.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8dfc17328e8da77be3cf9f47509e5637ba8f137148ed0e9b5241e1baf526e20a"},
-    {file = "pandas-2.3.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ec6c851509364c59a5344458ab935e6451b31b818be467eb24b0fe89bd05b6b9"},
-    {file = "pandas-2.3.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:911580460fc4884d9b05254b38a6bfadddfcc6aaef856fb5859e7ca202e45275"},
-    {file = "pandas-2.3.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2f4d6feeba91744872a600e6edbbd5b033005b431d5ae8379abee5bcfa479fab"},
-    {file = "pandas-2.3.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fe37e757f462d31a9cd7580236a82f353f5713a80e059a29753cf938c6775d96"},
-    {file = "pandas-2.3.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5db9637dbc24b631ff3707269ae4559bce4b7fd75c1c4d7e13f40edc42df4444"},
-    {file = "pandas-2.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4645f770f98d656f11c69e81aeb21c6fca076a44bed3dcbb9396a4311bc7f6d8"},
-    {file = "pandas-2.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:342e59589cc454aaff7484d75b816a433350b3d7964d7847327edda4d532a2e3"},
-    {file = "pandas-2.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d12f618d80379fde6af007f65f0c25bd3e40251dbd1636480dfffce2cf1e6da"},
-    {file = "pandas-2.3.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd71c47a911da120d72ef173aeac0bf5241423f9bfea57320110a978457e069e"},
-    {file = "pandas-2.3.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:09e3b1587f0f3b0913e21e8b32c3119174551deb4a4eba4a89bc7377947977e7"},
-    {file = "pandas-2.3.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2323294c73ed50f612f67e2bf3ae45aea04dce5690778e08a09391897f35ff88"},
-    {file = "pandas-2.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:b4b0de34dc8499c2db34000ef8baad684cfa4cbd836ecee05f323ebfba348c7d"},
-    {file = "pandas-2.3.1.tar.gz", hash = "sha256:0a95b9ac964fe83ce317827f80304d37388ea77616b1425f0ae41c9d2d0d7bb2"},
-]
-
-[package.dependencies]
-numpy = [
-    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
-    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
-]
-python-dateutil = ">=2.8.2"
-pytz = ">=2020.1"
-tzdata = ">=2022.7"
-
-[package.extras]
-all = ["PyQt5 (>=5.15.9)", "SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)", "beautifulsoup4 (>=4.11.2)", "bottleneck (>=1.3.6)", "dataframe-api-compat (>=0.1.7)", "fastparquet (>=2022.12.0)", "fsspec (>=2022.11.0)", "gcsfs (>=2022.11.0)", "html5lib (>=1.1)", "hypothesis (>=6.46.1)", "jinja2 (>=3.1.2)", "lxml (>=4.9.2)", "matplotlib (>=3.6.3)", "numba (>=0.56.4)", "numexpr (>=2.8.4)", "odfpy (>=1.4.1)", "openpyxl (>=3.1.0)", "pandas-gbq (>=0.19.0)", "psycopg2 (>=2.9.6)", "pyarrow (>=10.0.1)", "pymysql (>=1.0.2)", "pyreadstat (>=1.2.0)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)", "python-calamine (>=0.1.7)", "pyxlsb (>=1.0.10)", "qtpy (>=2.3.0)", "s3fs (>=2022.11.0)", "scipy (>=1.10.0)", "tables (>=3.8.0)", "tabulate (>=0.9.0)", "xarray (>=2022.12.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.5)", "zstandard (>=0.19.0)"]
-aws = ["s3fs (>=2022.11.0)"]
-clipboard = ["PyQt5 (>=5.15.9)", "qtpy (>=2.3.0)"]
-compression = ["zstandard (>=0.19.0)"]
-computation = ["scipy (>=1.10.0)", "xarray (>=2022.12.0)"]
-consortium-standard = ["dataframe-api-compat (>=0.1.7)"]
-excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.1.0)", "python-calamine (>=0.1.7)", "pyxlsb (>=1.0.10)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.5)"]
-feather = ["pyarrow (>=10.0.1)"]
-fss = ["fsspec (>=2022.11.0)"]
-gcp = ["gcsfs (>=2022.11.0)", "pandas-gbq (>=0.19.0)"]
-hdf5 = ["tables (>=3.8.0)"]
-html = ["beautifulsoup4 (>=4.11.2)", "html5lib (>=1.1)", "lxml (>=4.9.2)"]
-mysql = ["SQLAlchemy (>=2.0.0)", "pymysql (>=1.0.2)"]
-output-formatting = ["jinja2 (>=3.1.2)", "tabulate (>=0.9.0)"]
-parquet = ["pyarrow (>=10.0.1)"]
-performance = ["bottleneck (>=1.3.6)", "numba (>=0.56.4)", "numexpr (>=2.8.4)"]
-plot = ["matplotlib (>=3.6.3)"]
-postgresql = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "psycopg2 (>=2.9.6)"]
-pyarrow = ["pyarrow (>=10.0.1)"]
-spss = ["pyreadstat (>=1.2.0)"]
-sql-other = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)"]
-test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
-xml = ["lxml (>=4.9.2)"]
 
 [[package]]
 name = "passlib"
@@ -1946,24 +1775,6 @@ files = [
 
 [package.extras]
 paste = ["Paste"]
-
-[[package]]
-name = "patsy"
-version = "1.0.1"
-description = "A Python package for describing statistical models and for building design matrices."
-category = "main"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "patsy-1.0.1-py2.py3-none-any.whl", hash = "sha256:751fb38f9e97e62312e921a1954b81e1bb2bcda4f5eeabaf94db251ee791509c"},
-    {file = "patsy-1.0.1.tar.gz", hash = "sha256:e786a9391eec818c054e359b737bbce692f051aee4c661f4141cc88fb459c0c4"},
-]
-
-[package.dependencies]
-numpy = ">=1.4"
-
-[package.extras]
-test = ["pytest", "pytest-cov", "scipy"]
 
 [[package]]
 name = "pillow"
@@ -2175,58 +1986,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
-
-[[package]]
-name = "pmdarima"
-version = "2.0.4"
-description = "Python's forecast::auto.arima equivalent"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pmdarima-2.0.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8e6c16672e0f122e63ab1d7282a362c762783264a07636bbc9d4ae3d58ac7605"},
-    {file = "pmdarima-2.0.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c9a839a477100331c47aa8a841c198ecb0b3fab4aff958622d31fec86d2aea76"},
-    {file = "pmdarima-2.0.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ccd9e2186ba1ef45006f6c88dc9ecd6121ddb8914114bebcfa0d42899b40ced7"},
-    {file = "pmdarima-2.0.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:165bdf787f5dafd5faab543d20524413b765d9cb6f020f0e1846551e7678414a"},
-    {file = "pmdarima-2.0.4-cp310-cp310-win_amd64.whl", hash = "sha256:cbde33812c37f441ba70d9e7b0479c758d56ad77a8dcbdead1fb8baad9aee806"},
-    {file = "pmdarima-2.0.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8d961c99b445e53eadf6627c61bf800f403bd247b7ec2f62c6dfe8a0b1bcbf0b"},
-    {file = "pmdarima-2.0.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:78e815c51074411bbe8433a912af4cc8dac394d9330cfedf57dd5ce08efe4a65"},
-    {file = "pmdarima-2.0.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8022484256492bc425f0053b3a0346ab0a877f0f668664be738fe07f6b423c08"},
-    {file = "pmdarima-2.0.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46677b68efffde66aa1291799b39b91420961967fa2b6e041e26bb263782d38d"},
-    {file = "pmdarima-2.0.4-cp311-cp311-win_amd64.whl", hash = "sha256:bc594dd981bca5217b4448c96e82dbd60553b07263517a5cb0510b4bfe66ded1"},
-    {file = "pmdarima-2.0.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:62a4ff308fbb5074a66c0877ba6b472d0fc406cbc0b5a2dba7e8fa800c9dd8ca"},
-    {file = "pmdarima-2.0.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7e215ec6130b917843d26e0698637f976e4a6cc9dbd521bf44547668d08f058a"},
-    {file = "pmdarima-2.0.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d837bc00266a234d9292914f19a67e04ca8361d9c309b70fc8f16c1ed863551"},
-    {file = "pmdarima-2.0.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8790bff665a5ebaa36ddbbfd0e8ea51ad2e5809270dc74d462d5c2498b26220f"},
-    {file = "pmdarima-2.0.4-cp312-cp312-win_amd64.whl", hash = "sha256:a8bf7913bdbd0e286489b2111080a0f51f5d9d3ee5e05b7011a691207047ddcf"},
-    {file = "pmdarima-2.0.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5bce63dca165948a2311eff0c200e57370829855fce6e7d3fe930497f2f9fc04"},
-    {file = "pmdarima-2.0.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c1ed01cbb399d9cdbe3f12f2ef505a144826769ec3ad75f6075cadbe8447a13"},
-    {file = "pmdarima-2.0.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:73060d28ffabeae7374ab48ba7882b29ae6998de3e3e34f5484c64e0baefda0d"},
-    {file = "pmdarima-2.0.4-cp37-cp37m-win_amd64.whl", hash = "sha256:776e21e076393c6fe86895ffe71e6769c9b3fe0dffb92d6f6558657580cf0a42"},
-    {file = "pmdarima-2.0.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ec865e8fb07378c470f3e41a77d6705875a674cefbe6c0185e9bc070e642da5c"},
-    {file = "pmdarima-2.0.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:670ca1f93ed4f8239e7fbd7d1dd156108899e15e8fb0717b2b3fa605fa6ace35"},
-    {file = "pmdarima-2.0.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab1ee166f511d2497d6b357bf0cac84326efff25349eb777aea5b030ed6bf8bb"},
-    {file = "pmdarima-2.0.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d9ead43510adfe3c0d4000e37427bfcf11ba6cc3b26091368a847c5da010e052"},
-    {file = "pmdarima-2.0.4-cp38-cp38-win_amd64.whl", hash = "sha256:c1213f3fa1e3ced9796f4092f9bd4be1881205f77bc2f5a1494695134a92000e"},
-    {file = "pmdarima-2.0.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6e0e3c90e7a91b44599f08cd9c62880466860e76bd1b0ca2d2ff8e72834a1a7f"},
-    {file = "pmdarima-2.0.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8fe612384e4989f010dacdefbff874231f5b7351dfb84bcbfe9ed8d718fc4115"},
-    {file = "pmdarima-2.0.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db842d97905b171c867aae1a492b8c958ec1bae987c3ee41c561a06d99a19efd"},
-    {file = "pmdarima-2.0.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a03936d681c720b0e44565d099de2619b762cb9d443f3043de9a78888aff6bb2"},
-    {file = "pmdarima-2.0.4-cp39-cp39-win_amd64.whl", hash = "sha256:13ba7061d4e9d48f21e1c393bfaa3d6b31f60a8c97ddbe8d455fa675c594f9e4"},
-    {file = "pmdarima-2.0.4.tar.gz", hash = "sha256:b87f9d9f5b7dc2ddbd053687c2264e26ac98fd4118e843c7e9bc3dd7343e5c1a"},
-]
-
-[package.dependencies]
-Cython = ">=0.29,<0.29.18 || >0.29.18,<0.29.31 || >0.29.31"
-joblib = ">=0.11"
-numpy = ">=1.21.2"
-packaging = ">=17.1"
-pandas = ">=0.19"
-scikit-learn = ">=0.22"
-scipy = ">=1.3.2"
-setuptools = ">=38.6.0,<50.0.0 || >50.0.0"
-statsmodels = ">=0.13.2"
-urllib3 = "*"
 
 [[package]]
 name = "port-for"
@@ -3197,104 +2956,6 @@ botocore = ">=1.37.4,<2.0a.0"
 crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
 
 [[package]]
-name = "scikit-learn"
-version = "1.6.1"
-description = "A set of python modules for machine learning and data mining"
-category = "main"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "scikit_learn-1.6.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d056391530ccd1e501056160e3c9673b4da4805eb67eb2bdf4e983e1f9c9204e"},
-    {file = "scikit_learn-1.6.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:0c8d036eb937dbb568c6242fa598d551d88fb4399c0344d95c001980ec1c7d36"},
-    {file = "scikit_learn-1.6.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8634c4bd21a2a813e0a7e3900464e6d593162a29dd35d25bdf0103b3fce60ed5"},
-    {file = "scikit_learn-1.6.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:775da975a471c4f6f467725dff0ced5c7ac7bda5e9316b260225b48475279a1b"},
-    {file = "scikit_learn-1.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:8a600c31592bd7dab31e1c61b9bbd6dea1b3433e67d264d17ce1017dbdce8002"},
-    {file = "scikit_learn-1.6.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:72abc587c75234935e97d09aa4913a82f7b03ee0b74111dcc2881cba3c5a7b33"},
-    {file = "scikit_learn-1.6.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b3b00cdc8f1317b5f33191df1386c0befd16625f49d979fe77a8d44cae82410d"},
-    {file = "scikit_learn-1.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc4765af3386811c3ca21638f63b9cf5ecf66261cc4815c1db3f1e7dc7b79db2"},
-    {file = "scikit_learn-1.6.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25fc636bdaf1cc2f4a124a116312d837148b5e10872147bdaf4887926b8c03d8"},
-    {file = "scikit_learn-1.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:fa909b1a36e000a03c382aade0bd2063fd5680ff8b8e501660c0f59f021a6415"},
-    {file = "scikit_learn-1.6.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:926f207c804104677af4857b2c609940b743d04c4c35ce0ddc8ff4f053cddc1b"},
-    {file = "scikit_learn-1.6.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:2c2cae262064e6a9b77eee1c8e768fc46aa0b8338c6a8297b9b6759720ec0ff2"},
-    {file = "scikit_learn-1.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1061b7c028a8663fb9a1a1baf9317b64a257fcb036dae5c8752b2abef31d136f"},
-    {file = "scikit_learn-1.6.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e69fab4ebfc9c9b580a7a80111b43d214ab06250f8a7ef590a4edf72464dd86"},
-    {file = "scikit_learn-1.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:70b1d7e85b1c96383f872a519b3375f92f14731e279a7b4c6cfd650cf5dffc52"},
-    {file = "scikit_learn-1.6.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2ffa1e9e25b3d93990e74a4be2c2fc61ee5af85811562f1288d5d055880c4322"},
-    {file = "scikit_learn-1.6.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:dc5cf3d68c5a20ad6d571584c0750ec641cc46aeef1c1507be51300e6003a7e1"},
-    {file = "scikit_learn-1.6.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c06beb2e839ecc641366000ca84f3cf6fa9faa1777e29cf0c04be6e4d096a348"},
-    {file = "scikit_learn-1.6.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8ca8cb270fee8f1f76fa9bfd5c3507d60c6438bbee5687f81042e2bb98e5a97"},
-    {file = "scikit_learn-1.6.1-cp313-cp313-win_amd64.whl", hash = "sha256:7a1c43c8ec9fde528d664d947dc4c0789be4077a3647f232869f41d9bf50e0fb"},
-    {file = "scikit_learn-1.6.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a17c1dea1d56dcda2fac315712f3651a1fea86565b64b48fa1bc090249cbf236"},
-    {file = "scikit_learn-1.6.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:6a7aa5f9908f0f28f4edaa6963c0a6183f1911e63a69aa03782f0d924c830a35"},
-    {file = "scikit_learn-1.6.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0650e730afb87402baa88afbf31c07b84c98272622aaba002559b614600ca691"},
-    {file = "scikit_learn-1.6.1-cp313-cp313t-win_amd64.whl", hash = "sha256:3f59fe08dc03ea158605170eb52b22a105f238a5d512c4470ddeca71feae8e5f"},
-    {file = "scikit_learn-1.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6849dd3234e87f55dce1db34c89a810b489ead832aaf4d4550b7ea85628be6c1"},
-    {file = "scikit_learn-1.6.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:e7be3fa5d2eb9be7d77c3734ff1d599151bb523674be9b834e8da6abe132f44e"},
-    {file = "scikit_learn-1.6.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:44a17798172df1d3c1065e8fcf9019183f06c87609b49a124ebdf57ae6cb0107"},
-    {file = "scikit_learn-1.6.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8b7a3b86e411e4bce21186e1c180d792f3d99223dcfa3b4f597ecc92fa1a422"},
-    {file = "scikit_learn-1.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:7a73d457070e3318e32bdb3aa79a8d990474f19035464dfd8bede2883ab5dc3b"},
-    {file = "scikit_learn-1.6.1.tar.gz", hash = "sha256:b4fc2525eca2c69a59260f583c56a7557c6ccdf8deafdba6e060f94c1c59738e"},
-]
-
-[package.dependencies]
-joblib = ">=1.2.0"
-numpy = ">=1.19.5"
-scipy = ">=1.6.0"
-threadpoolctl = ">=3.1.0"
-
-[package.extras]
-benchmark = ["matplotlib (>=3.3.4)", "memory_profiler (>=0.57.0)", "pandas (>=1.1.5)"]
-build = ["cython (>=3.0.10)", "meson-python (>=0.16.0)", "numpy (>=1.19.5)", "scipy (>=1.6.0)"]
-docs = ["Pillow (>=7.1.2)", "matplotlib (>=3.3.4)", "memory_profiler (>=0.57.0)", "numpydoc (>=1.2.0)", "pandas (>=1.1.5)", "plotly (>=5.14.0)", "polars (>=0.20.30)", "pooch (>=1.6.0)", "pydata-sphinx-theme (>=0.15.3)", "scikit-image (>=0.17.2)", "seaborn (>=0.9.0)", "sphinx (>=7.3.7)", "sphinx-copybutton (>=0.5.2)", "sphinx-design (>=0.5.0)", "sphinx-design (>=0.6.0)", "sphinx-gallery (>=0.17.1)", "sphinx-prompt (>=1.4.0)", "sphinx-remove-toctrees (>=1.0.0.post1)", "sphinxcontrib-sass (>=0.3.4)", "sphinxext-opengraph (>=0.9.1)", "towncrier (>=24.8.0)"]
-examples = ["matplotlib (>=3.3.4)", "pandas (>=1.1.5)", "plotly (>=5.14.0)", "pooch (>=1.6.0)", "scikit-image (>=0.17.2)", "seaborn (>=0.9.0)"]
-install = ["joblib (>=1.2.0)", "numpy (>=1.19.5)", "scipy (>=1.6.0)", "threadpoolctl (>=3.1.0)"]
-maintenance = ["conda-lock (==2.5.6)"]
-tests = ["black (>=24.3.0)", "matplotlib (>=3.3.4)", "mypy (>=1.9)", "numpydoc (>=1.2.0)", "pandas (>=1.1.5)", "polars (>=0.20.30)", "pooch (>=1.6.0)", "pyamg (>=4.0.0)", "pyarrow (>=12.0.0)", "pytest (>=7.1.2)", "pytest-cov (>=2.9.0)", "ruff (>=0.5.1)", "scikit-image (>=0.17.2)"]
-
-[[package]]
-name = "scipy"
-version = "1.13.1"
-description = "Fundamental algorithms for scientific computing in Python"
-category = "main"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "scipy-1.13.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:20335853b85e9a49ff7572ab453794298bcf0354d8068c5f6775a0eabf350aca"},
-    {file = "scipy-1.13.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:d605e9c23906d1994f55ace80e0125c587f96c020037ea6aa98d01b4bd2e222f"},
-    {file = "scipy-1.13.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cfa31f1def5c819b19ecc3a8b52d28ffdcc7ed52bb20c9a7589669dd3c250989"},
-    {file = "scipy-1.13.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f26264b282b9da0952a024ae34710c2aff7d27480ee91a2e82b7b7073c24722f"},
-    {file = "scipy-1.13.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:eccfa1906eacc02de42d70ef4aecea45415f5be17e72b61bafcfd329bdc52e94"},
-    {file = "scipy-1.13.1-cp310-cp310-win_amd64.whl", hash = "sha256:2831f0dc9c5ea9edd6e51e6e769b655f08ec6db6e2e10f86ef39bd32eb11da54"},
-    {file = "scipy-1.13.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:27e52b09c0d3a1d5b63e1105f24177e544a222b43611aaf5bc44d4a0979e32f9"},
-    {file = "scipy-1.13.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:54f430b00f0133e2224c3ba42b805bfd0086fe488835effa33fa291561932326"},
-    {file = "scipy-1.13.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e89369d27f9e7b0884ae559a3a956e77c02114cc60a6058b4e5011572eea9299"},
-    {file = "scipy-1.13.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a78b4b3345f1b6f68a763c6e25c0c9a23a9fd0f39f5f3d200efe8feda560a5fa"},
-    {file = "scipy-1.13.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:45484bee6d65633752c490404513b9ef02475b4284c4cfab0ef946def50b3f59"},
-    {file = "scipy-1.13.1-cp311-cp311-win_amd64.whl", hash = "sha256:5713f62f781eebd8d597eb3f88b8bf9274e79eeabf63afb4a737abc6c84ad37b"},
-    {file = "scipy-1.13.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5d72782f39716b2b3509cd7c33cdc08c96f2f4d2b06d51e52fb45a19ca0c86a1"},
-    {file = "scipy-1.13.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:017367484ce5498445aade74b1d5ab377acdc65e27095155e448c88497755a5d"},
-    {file = "scipy-1.13.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:949ae67db5fa78a86e8fa644b9a6b07252f449dcf74247108c50e1d20d2b4627"},
-    {file = "scipy-1.13.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de3ade0e53bc1f21358aa74ff4830235d716211d7d077e340c7349bc3542e884"},
-    {file = "scipy-1.13.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2ac65fb503dad64218c228e2dc2d0a0193f7904747db43014645ae139c8fad16"},
-    {file = "scipy-1.13.1-cp312-cp312-win_amd64.whl", hash = "sha256:cdd7dacfb95fea358916410ec61bbc20440f7860333aee6d882bb8046264e949"},
-    {file = "scipy-1.13.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:436bbb42a94a8aeef855d755ce5a465479c721e9d684de76bf61a62e7c2b81d5"},
-    {file = "scipy-1.13.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:8335549ebbca860c52bf3d02f80784e91a004b71b059e3eea9678ba994796a24"},
-    {file = "scipy-1.13.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d533654b7d221a6a97304ab63c41c96473ff04459e404b83275b60aa8f4b7004"},
-    {file = "scipy-1.13.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:637e98dcf185ba7f8e663e122ebf908c4702420477ae52a04f9908707456ba4d"},
-    {file = "scipy-1.13.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a014c2b3697bde71724244f63de2476925596c24285c7a637364761f8710891c"},
-    {file = "scipy-1.13.1-cp39-cp39-win_amd64.whl", hash = "sha256:392e4ec766654852c25ebad4f64e4e584cf19820b980bc04960bca0b0cd6eaa2"},
-    {file = "scipy-1.13.1.tar.gz", hash = "sha256:095a87a0312b08dfd6a6155cbbd310a8c51800fc931b8c0b84003014b874ed3c"},
-]
-
-[package.dependencies]
-numpy = ">=1.22.4,<2.3"
-
-[package.extras]
-dev = ["cython-lint (>=0.12.2)", "doit (>=0.36.0)", "mypy", "pycodestyle", "pydevtool", "rich-click", "ruff", "types-psutil", "typing_extensions"]
-doc = ["jupyterlite-pyodide-kernel", "jupyterlite-sphinx (>=0.12.0)", "jupytext", "matplotlib (>=3.5)", "myst-nb", "numpydoc", "pooch", "pydata-sphinx-theme (>=0.15.2)", "sphinx (>=5.0.0)", "sphinx-design (>=0.4.0)"]
-test = ["array-api-strict", "asv", "gmpy2", "hypothesis (>=6.30)", "mpmath", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
-
-[[package]]
 name = "setuptools"
 version = "80.9.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -3581,58 +3242,6 @@ pymysql = ["pymysql", "pymysql (<1)"]
 sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
-name = "statsmodels"
-version = "0.14.5"
-description = "Statistical computations and models for Python"
-category = "main"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "statsmodels-0.14.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9fc2b5cdc0c95cba894849651fec1fa1511d365e3eb72b0cc75caac44077cd48"},
-    {file = "statsmodels-0.14.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b8d96b0bbaeabd3a557c35cc7249baa9cfbc6dd305c32a9f2cbdd7f46c037e7f"},
-    {file = "statsmodels-0.14.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:145bc39b2cb201efb6c83cc3f2163c269e63b0d4809801853dec6f440bd3bc37"},
-    {file = "statsmodels-0.14.5-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d7c14fb2617bb819fb2532e1424e1da2b98a3419a80e95f33365a72d437d474e"},
-    {file = "statsmodels-0.14.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1e9742d8a5ac38a3bfc4b7f4b0681903920f20cbbf466d72b1fd642033846108"},
-    {file = "statsmodels-0.14.5-cp310-cp310-win_amd64.whl", hash = "sha256:1cab9e6fce97caf4239cdb2df375806937da5d0b7ba2699b13af33a07f438464"},
-    {file = "statsmodels-0.14.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4b7091a8442076c708c926de3603653a160955e80a2b6d931475b7bb8ddc02e5"},
-    {file = "statsmodels-0.14.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:128872be8f3208f4446d91ea9e4261823902fc7997fee7e1a983eb62fd3b7c6e"},
-    {file = "statsmodels-0.14.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f2ad5aee04ae7196c429df2174df232c057e478c5fa63193d01c8ec9aae04d31"},
-    {file = "statsmodels-0.14.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f402fc793458dd6d96e099acb44cd1de1428565bf7ef3030878a8daff091f08a"},
-    {file = "statsmodels-0.14.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:26c028832730aebfbfd4e7501694e1f9ad31ec8536e776716673f4e7afd4059a"},
-    {file = "statsmodels-0.14.5-cp311-cp311-win_amd64.whl", hash = "sha256:ec56f771d9529cdc17ed2fb2a950d100b6e83a7c5372aae8ac5bb065c474b856"},
-    {file = "statsmodels-0.14.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:37e7364a39f9aa3b51d15a208c2868b90aadb8412f868530f5cba9197cb00eaa"},
-    {file = "statsmodels-0.14.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4263d7f4d0f1d5ac6eb4db22e1ee34264a14d634b9332c975c9d9109b6b46e12"},
-    {file = "statsmodels-0.14.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:86224f6e36f38486e471e75759d241fe2912d8bc25ab157d54ee074c6aedbf45"},
-    {file = "statsmodels-0.14.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c3dd760a6fa80cd5e0371685c697bb9c2c0e6e1f394d975e596a1e6d0bbb9372"},
-    {file = "statsmodels-0.14.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6264fb00e02f858b86bd01ef2dc05055a71d4a0cc7551b9976b07b0f0e6cf24f"},
-    {file = "statsmodels-0.14.5-cp312-cp312-win_amd64.whl", hash = "sha256:b2ed065bfbaf8bb214c7201656df840457c2c8c65e1689e3eb09dc7440f9c61c"},
-    {file = "statsmodels-0.14.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:906263134dd1a640e55ecb01fda4a9be7b9e08558dba9e4c4943a486fdb0c9c8"},
-    {file = "statsmodels-0.14.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9118f76344f77cffbb3a9cbcff8682b325be5eed54a4b3253e09da77a74263d3"},
-    {file = "statsmodels-0.14.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9dc4ee159070557c9a6c000625d85f653de437772fe7086857cff68f501afe45"},
-    {file = "statsmodels-0.14.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a085d47c8ef5387279a991633883d0e700de2b0acc812d7032d165888627bef"},
-    {file = "statsmodels-0.14.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f866b2ebb2904b47c342d00def83c526ef2eb1df6a9a3c94ba5fe63d0005aec"},
-    {file = "statsmodels-0.14.5-cp313-cp313-win_amd64.whl", hash = "sha256:2a06bca03b7a492f88c8106103ab75f1a5ced25de90103a89f3a287518017939"},
-    {file = "statsmodels-0.14.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b23b8f646dd78ef5e8d775d879208f8dc0a73418b41c16acac37361ff9ab7738"},
-    {file = "statsmodels-0.14.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4e5e26b21d2920905764fb0860957d08b5ba2fae4466ef41b1f7c53ecf9fc7fa"},
-    {file = "statsmodels-0.14.5-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a060c7e0841c549c8ce2825fd6687e6757e305d9c11c9a73f6c5a0ce849bb69"},
-    {file = "statsmodels-0.14.5-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56da20def5350d676388213a330fd40ed15d0e8dd0bb1b92c0e4b0f2a65d3ad2"},
-    {file = "statsmodels-0.14.5-cp39-cp39-win_amd64.whl", hash = "sha256:afb37ca1d70d99b5fd876e8574ea46372298ae0f0a8b17e4cf0a9afd2373ae62"},
-    {file = "statsmodels-0.14.5.tar.gz", hash = "sha256:de260e58cccfd2ceddf835b55a357233d6ca853a1aa4f90f7553a52cc71c6ddf"},
-]
-
-[package.dependencies]
-numpy = ">=1.22.3,<3"
-packaging = ">=21.3"
-pandas = ">=1.4,<2.1.0 || >2.1.0"
-patsy = ">=0.5.6"
-scipy = ">=1.8,<1.9.2 || >1.9.2"
-
-[package.extras]
-build = ["cython (>=3.0.10)"]
-develop = ["colorama", "cython (>=3.0.10)", "cython (>=3.0.10,<4)", "flake8", "isort", "jinja2", "joblib", "matplotlib (>=3)", "pytest (>=7.3.0,<8)", "pytest-cov", "pytest-randomly", "pytest-xdist", "pywinpty", "setuptools_scm[toml] (>=8.0,<9.0)"]
-docs = ["ipykernel", "jupyter_client", "matplotlib", "nbconvert", "nbformat", "numpydoc", "pandas-datareader", "sphinx"]
-
-[[package]]
 name = "structlog"
 version = "19.2.0"
 description = "Structured Logging for Python"
@@ -3669,18 +3278,6 @@ WebOb = "*"
 
 [package.extras]
 test = ["WebTest", "pyramid", "pytest"]
-
-[[package]]
-name = "threadpoolctl"
-version = "3.6.0"
-description = "threadpoolctl"
-category = "main"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb"},
-    {file = "threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e"},
-]
 
 [[package]]
 name = "toml"
@@ -3839,18 +3436,6 @@ python-versions = ">=3.9"
 files = [
     {file = "typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76"},
     {file = "typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36"},
-]
-
-[[package]]
-name = "tzdata"
-version = "2025.2"
-description = "Provider of IANA time zone data"
-category = "main"
-optional = false
-python-versions = ">=2"
-files = [
-    {file = "tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8"},
-    {file = "tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9"},
 ]
 
 [[package]]
@@ -4028,18 +3613,6 @@ six = "*"
 webob = "*"
 
 [[package]]
-name = "xlrd"
-version = "1.2.0"
-description = "Library for developers to extract data from Microsoft Excel (tm) spreadsheet files"
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "xlrd-1.2.0-py2.py3-none-any.whl", hash = "sha256:e551fb498759fa3a5384a94ccd4c3c02eb7c00ea424426e212ac0c57be9dfbde"},
-    {file = "xlrd-1.2.0.tar.gz", hash = "sha256:546eb36cee8db40c3eaa46c351e67ffee6eeb5fa2650b71bc4c758a29a1b29b2"},
-]
-
-[[package]]
 name = "xmltodict"
 version = "0.14.2"
 description = "Makes working with XML feel like you are working with JSON"
@@ -4148,4 +3721,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "5589391f0e3d72b32a1dc7dc7113d3a9e7928641064e45db5c56c6682055b019"
+content-hash = "e48f82db735f06e65bce944edff7cdbc9ce7e48ff0f56e25f479c580f5976477"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.33.1"
+version = "11.34.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -51,10 +51,13 @@ future = "^0.18.3"
 html5lib = ">=1.1"  # experimental, should be OK now that we're not using moto server
 humanfriendly = "^1.44.9"
 netaddr = ">=0.8.0,<1"
+# numpy is intentionally retained even though snovault itself does not import it: consumer
+# apps (fourfront/cgap/smaht-portal/encoded-core) rely on dcicsnovault as their *declared*
+# numpy provider and do not declare numpy themselves, so removing it here would break their
+# transitive provision. (pmdarima -- an unused time-series forecasting stack -- was removed.)
 numpy = "^1.26.4"
 passlib = "^1.7.4"
 pillow = "^11.1.0"
-pmdarima = "^2.0.4"
 psutil = "^5.9.0"
 psycopg2-binary = "^2.9.1"
 PyBrowserID = ">=0.10.0,<1"
@@ -86,7 +89,6 @@ venusian = "^3.1.0"
 WebOb = "^1.8.7"
 WebTest = "^2.0.35"
 WSGIProxy2 = "0.4.2"
-xlrd = "^1.0.0"
 "zope.deprecation" = "^4.4.0"
 "zope.interface" = ">=4.7.2,<6"
 "zope.sqlalchemy" = "1.6"

--- a/snovault/ingestion/ingestion_listener.py
+++ b/snovault/ingestion/ingestion_listener.py
@@ -37,6 +37,7 @@ from .ingestion_listener_base import (
     DEBUG_SUBMISSIONS,
     IngestionListenerBase,
 )
+from .ingestion_message import IngestionMessage
 from .ingestion_message_handler_decorator import call_ingestion_message_handler
 from .ingestion_processor_decorator import get_ingestion_processor
 from .queue_utils import IngestionQueueManager
@@ -45,6 +46,22 @@ from .queue_utils import IngestionQueueManager
 log = structlog.getLogger(__name__)
 EPILOG = __doc__
 INGESTION_QUEUE = 'ingestion_queue'
+
+
+def summarize_message_for_log(raw_message):
+    """ Return a short, safe identifier for an SQS ingestion message for diagnostic logging.
+
+        Deliberately does NOT include the message ``Body``: it may be large and may carry
+        submission data we should not spray into logs. Only the SQS-assigned ``MessageId``
+        (and body checksum, if present) are emitted -- enough to correlate a poison message
+        with the SQS console / metrics without leaking its contents.
+    """
+    if isinstance(raw_message, dict):
+        return "MessageId=%s MD5OfBody=%s" % (
+            raw_message.get('MessageId', '<unknown>'),
+            raw_message.get('MD5OfBody', '<unknown>'),
+        )
+    return "<non-dict message %s>" % type(raw_message).__name__
 
 
 def includeme(config):
@@ -380,6 +397,13 @@ class IngestionListener(IngestionListenerBase):
     DELETE_RETRIES = 3
     INGEST_AS_USER = environ_bool('INGEST_AS_USER', default=True)  # The new way, but possible to disable for now
 
+    # Dispositions returned by handle_one_message(), consumed by run() to decide what to do
+    # with the underlying SQS message. See handle_one_message for the full contract.
+    MESSAGE_HANDLED = 'handled'      # a handler processed it successfully -> delete (ack)
+    MESSAGE_UNHANDLED = 'unhandled'  # a handler ran but returned falsy -> leave (prior fallback-ack behavior)
+    MESSAGE_DEFERRED = 'deferred'    # a handler raised -> leave for redelivery, do NOT ack
+    MESSAGE_POISON = 'poison'        # message could not even be parsed -> delete so it cannot crash-loop
+
     def __init__(self, vapp, _queue_manager=None, _update_status=None):
         self.vapp = vapp
 
@@ -464,6 +488,47 @@ class IngestionListener(IngestionListenerBase):
             }              # from we assume the msg has sufficient info to work backwards from - Will 4/9/21
         ]
 
+    def handle_one_message(self, message):
+        """ Parse and dispatch a single raw SQS ingestion message, isolating ALL failures so
+            that one bad message cannot crash (and crash-loop) the entire listener.
+
+            Returns one of:
+              - MESSAGE_POISON:    the raw message could not be parsed into an IngestionMessage
+                                   (malformed JSON, missing "Body"/"uuid", etc.). It is
+                                   structurally invalid and can never be processed, so the caller
+                                   should delete it to stop it from redelivering and crash-looping.
+              - MESSAGE_DEFERRED:  the message parsed fine but a registered handler raised. The
+                                   message is (structurally) valid, so we must NOT acknowledge it;
+                                   the caller leaves it for SQS redelivery instead of deleting.
+              - MESSAGE_HANDLED:   a handler processed it and returned truthy -> caller deletes it.
+              - MESSAGE_UNHANDLED: a handler ran and returned falsy -> caller preserves the prior
+                                   behavior (message left in the batch for the fallback delete).
+
+            This method never raises for a single message: parsing and handler dispatch are each
+            guarded, and a safe (body-free) message identity is logged for diagnosis.
+        """
+        try:
+            parsed = IngestionMessage(message)
+        except Exception as e:
+            # Structurally invalid message (bad JSON, missing uuid, ...). Historically this
+            # exception propagated out of run() and, in composite mode, tripped
+            # ErrorHandlingThread's SIGINT self-restart -- so a single poison message with the
+            # queue's 3h visibility timeout would restart the listener every 3h indefinitely.
+            log.error("Discarding unparseable ingestion message (%s): %r"
+                      % (summarize_message_for_log(message), e))
+            return self.MESSAGE_POISON
+        try:
+            handled = call_ingestion_message_handler(parsed, self)
+        except Exception as e:
+            # A registered handler raised unexpectedly. The message parsed, so treat it as
+            # possibly-transient: do NOT ack it, leave it for redelivery. (The default handler
+            # already swallows its own exceptions, so in practice this covers custom handlers
+            # and the "no handler registered" RuntimeError.)
+            log.error("Error handling ingestion message (%s, type=%s): %r"
+                      % (summarize_message_for_log(message), getattr(parsed, 'type', None), e))
+            return self.MESSAGE_DEFERRED
+        return self.MESSAGE_HANDLED if handled else self.MESSAGE_UNHANDLED
+
     def run(self, vapp=None):
         """ Main process for this class. Runs forever doing ingestion as needed.
 
@@ -504,12 +569,27 @@ class IngestionListener(IngestionListenerBase):
 
                 debuglog("Message:", message)
 
-                # C4-990/2023-02-09/dmichaels
-                # This calls at most one our message handlers
-                # registered via the @ingestion_message_handler decorator.
-                if call_ingestion_message_handler(message, self):
-                    # Here one of our message handlers was called and it processed this message.
+                # This dispatches (at most) one of our @ingestion_message_handler-registered
+                # handlers, isolating parse/handler failures so one bad message cannot crash the
+                # whole listener (see handle_one_message for the disposition contract).
+                disposition = self.handle_one_message(message)
+
+                if disposition == self.MESSAGE_POISON:
+                    # Unparseable message: delete it so it can't redeliver and crash-loop the
+                    # listener. Skip note_post_ingestion -- we have no valid parsed message to note.
                     discard(message)
+                    continue
+                if disposition == self.MESSAGE_DEFERRED:
+                    # Handler raised on an otherwise-valid message. Do NOT acknowledge it: drop it
+                    # from our local to-do list (so the fallback delete below can't ack it) and
+                    # leave it in SQS for redelivery once its visibility timeout elapses.
+                    messages.remove(message)
+                    continue
+                if disposition == self.MESSAGE_HANDLED:
+                    # A handler processed this message; remove it from SQS.
+                    discard(message)
+                # else MESSAGE_UNHANDLED: a handler ran but returned falsy -- leave the message in
+                # `messages` so the fallback delete below acks it (unchanged prior behavior).
                 app_project().note_post_ingestion(message, context=vapp)
 
             # This is just fallback cleanup in case messages weren't cleaned up within the loop.

--- a/snovault/stats.py
+++ b/snovault/stats.py
@@ -79,8 +79,15 @@ def stats_tween_factory(handler, registry):
                 log_keys['telemetry_id'] = request.params['telemetry_id']
             if 'log_action' in request.params:
                 log_keys['log_action'] = request.params['log_action']
-            if request.registry.settings.get('env_name'):
-                log_keys['ff_env'] = request.registry.settings.get('env_name')
+            # NOTE: the setting key is the dotted 'env.name' (as read everywhere else in the
+            # framework -- util.get_env_name, authentication, root, indexer_queue, ...), NOT the
+            # underscore 'env_name'. The underscore form was a typo that no code ever sets, so
+            # 'ff_env' -- the primary environment filter/facet for log aggregation and for any
+            # consumer Sentry LoggingIntegration that captures this "Request timings" event --
+            # was silently always absent. (Audit finding T4.)
+            env_name = request.registry.settings.get('env.name')
+            if env_name:
+                log_keys['ff_env'] = env_name
 
             # If stray unicode characters are inserted in the query string, for example, it's possible
             # to get an error such as:

--- a/snovault/tests/test_access_key.py
+++ b/snovault/tests/test_access_key.py
@@ -115,3 +115,75 @@ def test_access_key_defaults_to_requesting_user(app, testapp):
     res = attacker_testapp.post_json('/access-keys', {}, status=201)
     access_key = res.json['@graph'][0]
     assert access_key['user'].strip('/').split('/')[-1] == attacker['uuid']
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the AccessKey `reset-secret` broken-object-level-authorization
+# (BOLA/IDOR) fix. The `reset-secret` view rotates a key's secret and returns the new
+# plaintext `secret_access_key`. It was historically gated on `permission='add'`; on an
+# AccessKey *item* context that permission has no matching ACE (the item ACL's terminal
+# deny only covers view/edit), so it fell through to the access-keys *collection*'s
+# `(Allow, Authenticated, 'add')` -- meaning ANY authenticated user could rotate and read
+# ANY user's key secret and then authenticate as that user. The fix changes the view to
+# `permission='edit'`, which on the item context is granted only to `role.owner` and
+# `group.admin`. These tests assert owner + admin succeed while an authenticated non-owner
+# is refused. (Against the pre-fix `permission='add'`, the non-owner case returns 200 with
+# a new secret rather than 403 -- i.e. these tests fail on the old code, confirming they
+# exercise the hole.)
+# ---------------------------------------------------------------------------
+
+def _create_access_key_for(owner_testapp):
+    """ Create an access key owned by the user behind `owner_testapp` and return the item
+        (its `@id` is the item path used to reach the `reset-secret` view). """
+    res = owner_testapp.post_json('/access-keys', {}, status=201)
+    return res.json['@graph'][0]
+
+
+def _reset_secret(some_testapp, access_key, status='*'):
+    return some_testapp.post_json('%s@@reset-secret' % access_key['@id'], {}, status=status)
+
+
+def test_access_key_reset_secret_owner_succeeds(app, testapp):
+    """ The key's owner may rotate its own secret and receive the new plaintext secret. """
+    owner = _create_user(testapp, 'Olive', 'Owner', 'olive.owner@example.com')
+    owner_testapp = _testapp_for_user(app, owner)
+    access_key = _create_access_key_for(owner_testapp)
+
+    res = _reset_secret(owner_testapp, access_key)
+    assert res.status_int == 200, (
+        "Expected the key owner to be able to reset their own secret, got %s: %r"
+        % (res.status_int, res.json))
+    assert res.json.get('secret_access_key'), (
+        "Owner reset should return a fresh plaintext secret_access_key, got: %r" % res.json)
+
+
+def test_access_key_reset_secret_admin_succeeds(app, testapp):
+    """ An admin (the `testapp` fixture) may reset any key's secret. """
+    owner = _create_user(testapp, 'Owen', 'Owner', 'owen.owner@example.com')
+    owner_testapp = _testapp_for_user(app, owner)
+    access_key = _create_access_key_for(owner_testapp)
+
+    res = _reset_secret(testapp, access_key)
+    assert res.status_int == 200, (
+        "Expected an admin to be able to reset any key's secret, got %s: %r"
+        % (res.status_int, res.json))
+    assert res.json.get('secret_access_key'), (
+        "Admin reset should return a fresh plaintext secret_access_key, got: %r" % res.json)
+
+
+def test_access_key_reset_secret_non_owner_forbidden(app, testapp):
+    """ CORE SECURITY REGRESSION: an authenticated user who is NOT the key's owner (and not
+        an admin) must NOT be able to rotate/read another user's key secret. Against the
+        pre-fix `permission='add'` this returned 200 with a usable new secret. """
+    owner = _create_user(testapp, 'Victor', 'Keyowner', 'victor.keyowner@example.com')
+    attacker = _create_user(testapp, 'Mallory', 'Attacker', 'mallory.attacker@example.com')
+    owner_testapp = _testapp_for_user(app, owner)
+    attacker_testapp = _testapp_for_user(app, attacker)
+    access_key = _create_access_key_for(owner_testapp)
+
+    res = _reset_secret(attacker_testapp, access_key)
+    assert res.status_int == 403, (
+        "Expected a non-owner authenticated user to be forbidden (403) from resetting "
+        "another user's key secret, got %s: %r" % (res.status_int, res.json))
+    assert not res.json.get('secret_access_key'), (
+        "A forbidden reset must not leak a new secret_access_key, got: %r" % res.json)

--- a/snovault/tests/test_ingestion_poison_message.py
+++ b/snovault/tests/test_ingestion_poison_message.py
@@ -1,0 +1,112 @@
+"""
+Offline (no live SQS/DB/ES) regression tests for the ingestion listener's poison-message
+isolation (audit finding T8).
+
+Before the fix, `IngestionListener.run()` called the message handler with no exception guard.
+A single malformed SQS message -- non-JSON body, or a body missing the required ``uuid`` --
+raised out of the per-message loop (`IngestionMessage.__init__` parses the body BEFORE any
+handler runs). In composite/WSGI mode that tripped `ErrorHandlingThread`'s `SIGINT`
+self-restart; combined with the ingestion queue's 3h visibility timeout and no dead-letter
+queue, the poison message redelivered and crashed the listener every 3h indefinitely, blocking
+ALL submissions rather than just the bad one.
+
+The fix routes every message through `IngestionListener.handle_one_message`, which isolates
+parse and handler failures and returns a disposition telling `run()` whether to delete
+(ack) the message, leave it for redelivery, or discard it as poison. These tests assert that
+contract without any live services.
+"""
+
+from snovault.ingestion import ingestion_listener as il
+from snovault.ingestion.ingestion_listener import IngestionListener, summarize_message_for_log
+
+
+def _raw(body, **extra):
+    """ Build a raw SQS-style message dict. `body` is used verbatim as the ``Body`` string. """
+    msg = {'MessageId': 'msg-abc-123', 'MD5OfBody': 'deadbeef', 'ReceiptHandle': 'rh-xyz', 'Body': body}
+    msg.update(extra)
+    return msg
+
+
+def _listener():
+    """ A bare IngestionListener with no __init__ side effects (no vapp/registry/SQS). Only
+        handle_one_message is exercised, which needs no instance state of its own. """
+    return object.__new__(IngestionListener)
+
+
+# --- poison (unparseable) messages: real IngestionMessage parsing must be guarded ---------
+
+def test_handle_one_message_invalid_json_is_poison():
+    listener = _listener()
+    disposition = listener.handle_one_message(_raw('this is not json{{'))
+    assert disposition == IngestionListener.MESSAGE_POISON
+
+
+def test_handle_one_message_missing_uuid_is_poison():
+    listener = _listener()
+    # Valid JSON, but no "uuid" key -> IngestionMessage.__init__ raises KeyError.
+    disposition = listener.handle_one_message(_raw('{"ingestion_type": "vcf"}'))
+    assert disposition == IngestionListener.MESSAGE_POISON
+
+
+def test_handle_one_message_missing_body_is_poison():
+    listener = _listener()
+    # No "Body" key at all -> IngestionMessage.__init__ raises KeyError on raw_message["Body"].
+    disposition = listener.handle_one_message({'MessageId': 'msg-no-body'})
+    assert disposition == IngestionListener.MESSAGE_POISON
+
+
+def test_handle_one_message_never_raises_on_poison():
+    """ The whole point: a poison message must NOT propagate an exception out of
+        handle_one_message (which is what previously crash-looped the listener). """
+    listener = _listener()
+    for bad in ['', '{', 'null', '[]', '{"no_uuid": 1}']:
+        # Must return a disposition rather than raise.
+        assert listener.handle_one_message(_raw(bad)) in (
+            IngestionListener.MESSAGE_POISON, IngestionListener.MESSAGE_HANDLED,
+            IngestionListener.MESSAGE_UNHANDLED, IngestionListener.MESSAGE_DEFERRED,
+        )
+
+
+# --- valid messages: disposition follows the handler's outcome ---------------------------
+
+def _valid_body():
+    return '{"uuid": "1111-2222", "ingestion_type": "vcf"}'
+
+
+def test_handle_one_message_handler_success_is_handled(monkeypatch):
+    listener = _listener()
+    monkeypatch.setattr(il, 'call_ingestion_message_handler', lambda message, self_: True)
+    assert listener.handle_one_message(_raw(_valid_body())) == IngestionListener.MESSAGE_HANDLED
+
+
+def test_handle_one_message_handler_falsy_is_unhandled(monkeypatch):
+    listener = _listener()
+    monkeypatch.setattr(il, 'call_ingestion_message_handler', lambda message, self_: False)
+    # A handler that runs but declines the message keeps the prior fallback-ack behavior.
+    assert listener.handle_one_message(_raw(_valid_body())) == IngestionListener.MESSAGE_UNHANDLED
+
+
+def test_handle_one_message_handler_raises_is_deferred(monkeypatch):
+    listener = _listener()
+
+    def boom(message, self_):
+        raise RuntimeError("handler blew up")
+
+    monkeypatch.setattr(il, 'call_ingestion_message_handler', boom)
+    # A valid message whose handler raised must NOT be acked; it is deferred for redelivery,
+    # and the exception must be swallowed (no crash).
+    assert listener.handle_one_message(_raw(_valid_body())) == IngestionListener.MESSAGE_DEFERRED
+
+
+# --- safe diagnostic logging identity ----------------------------------------------------
+
+def test_summarize_message_for_log_includes_id_excludes_body():
+    summary = summarize_message_for_log(_raw('{"uuid": "secret-sensitive-payload"}'))
+    assert 'msg-abc-123' in summary          # MessageId is logged
+    assert 'deadbeef' in summary             # MD5OfBody is logged
+    assert 'secret-sensitive-payload' not in summary  # the Body is NEVER logged
+
+
+def test_summarize_message_for_log_handles_missing_fields_and_non_dict():
+    assert '<unknown>' in summarize_message_for_log({})
+    assert summarize_message_for_log('not-a-dict').startswith('<non-dict message')

--- a/snovault/tests/test_stats.py
+++ b/snovault/tests/test_stats.py
@@ -1,5 +1,66 @@
 from dcicutils.qa_utils import known_bug_expected
 
+from snovault.stats import stats_tween_factory
+
+
+# ---------------------------------------------------------------------------
+# Audit finding T4: the per-request "Request timings" structured log bound its environment
+# field (`ff_env`) from a mistyped setting key `env_name` (underscore) that no code ever sets,
+# instead of the dotted `env.name` used everywhere else in the framework -- so `ff_env` was
+# silently always absent (degrading log-aggregation filtering and any consumer Sentry
+# LoggingIntegration that captures this event). These DB-free unit tests exercise the real
+# `stats_tween` and assert it now reads `env.name`. (The discriminating test below fails
+# against the pre-fix code, which read `env_name`.)
+# ---------------------------------------------------------------------------
+
+class _FakeRegistry:
+    def __init__(self, settings):
+        self.settings = settings
+
+
+class _FakeResponse:
+    def __init__(self):
+        self.headers = {}
+
+
+class _FakeRequest:
+    def __init__(self, settings, params=None):
+        self.registry = _FakeRegistry(settings)
+        self.params = params or {}
+        self.path = '/some/path'
+        self.query_string = ''
+        self.host = 'example.org:6543'
+        self.environ = {}
+
+
+def _run_stats_tween(settings):
+    """ Run the real stats_tween with a trivial handler and return the internal stats dict
+        (which includes the bound log_keys, i.e. ff_env when set). No DB/ES/live services. """
+    def handler(request):
+        return _FakeResponse()
+    tween = stats_tween_factory(handler, _FakeRegistry(settings))
+    request = _FakeRequest(settings)
+    tween(request)
+    return request._stats
+
+
+def test_stats_tween_binds_ff_env_from_env_dot_name():
+    """ DISCRIMINATING: with the dotted `env.name` set, ff_env must be bound. Fails against the
+        pre-fix code (which read the underscore `env_name`). """
+    stats = _run_stats_tween({'env.name': 'fourfront-mastertest'})
+    assert stats.get('ff_env') == 'fourfront-mastertest'
+
+
+def test_stats_tween_ignores_legacy_underscore_env_name():
+    """ The old underscore key is no longer honored (nothing in the framework ever sets it). """
+    stats = _run_stats_tween({'env_name': 'legacy-should-be-ignored'})
+    assert 'ff_env' not in stats
+
+
+def test_stats_tween_omits_ff_env_when_unset():
+    stats = _run_stats_tween({})
+    assert 'ff_env' not in stats
+
 
 def test_query_param_unicode_decode_error_c4_887_regression(testapp):
     """

--- a/snovault/types/access_key.py
+++ b/snovault/types/access_key.py
@@ -142,7 +142,12 @@ def access_key_add(context, request):
 
 
 @view_config(name='reset-secret', context=AccessKey,
-             permission='add',
+             # Must be 'edit' (an item-scoped permission owned only by role.owner + group.admin
+             # per STATUS_ACL), NOT 'add'. On an AccessKey *item* context, 'add' has no matching
+             # ACE (the item ACL's terminal deny only covers view/edit), so it falls through to the
+             # collection's (Allow, Authenticated, 'add') -- which would let ANY authenticated user
+             # rotate and read ANY key's secret. See test_access_key.py::test_access_key_reset_secret_*.
+             permission='edit',
              request_method='POST', subpath_segments=0)
 @debug_log
 def access_key_reset_secret(context, request):


### PR DESCRIPTION
## Summary

Captain-authorized implementation of four verified findings from the snovault opportunity
audit (`snovault-feature-scout-7h`). One labeled commit per finding, so the security fix (T0)
can be cherry-picked/backported independently. Version bumped `11.33.1` → `11.34.0` with a
`CHANGELOG` entry. **Not to be merged by this PR author.**

### T0 — [Security] AccessKey `reset-secret` broken object-level authorization
`snovault/types/access_key.py` — the `reset-secret` view was gated on `permission='add'`. On an
AccessKey **item** context that permission has no matching ACE (the item ACL's terminal deny,
`ONLY_ADMIN_VIEW_ACL`, covers only `view`/`edit`), so it fell through to the access-keys
**collection**'s `(Allow, Authenticated, 'add')` — letting **any authenticated user rotate and
read any other user's access-key secret** (returned as plaintext) and then authenticate as that
user. Fixed by gating the view on `permission='edit'` (item-scoped to `role.owner` +
`group.admin`). Collection-level `add` (self-service key creation) is unchanged.

Adds owner/admin/non-owner regression tests. Against the pre-fix code the non-owner case returns
200 + a new secret; with the fix it returns 403. **These tests require the Postgres `testapp`
fixture and are CI-gated** — local Postgres is unavailable in the implementation environment, so
they were verified by collection + by hand-tracing the ACL lineage, not executed locally.

### T8 — [Reliability] Poison-message isolation in the ingestion listener
`snovault/ingestion/ingestion_listener.py` — a single malformed SQS message (bad JSON, or a body
missing `uuid`) raised out of `run()`'s per-message loop (the parse happens in
`IngestionMessage.__init__`, before any handler). In composite mode that tripped
`ErrorHandlingThread`'s `SIGINT` self-restart; with the queue's 3h visibility timeout and no DLQ
the poison message redelivered and crashed the listener every 3h, blocking **all** submissions.

New `IngestionListener.handle_one_message` isolates parse/handler failures and returns a
disposition applied by `run()`:
- **POISON** (unparseable) → delete, so it can't redeliver-and-crash;
- **HANDLED** (handler truthy) → delete (unchanged);
- **UNHANDLED** (handler falsy) → left in the batch for the fallback delete (**prior behavior preserved**);
- **DEFERRED** (handler raised) → left for redelivery, **not** acknowledged.

Logs a body-free identity (`MessageId`/`MD5OfBody`) via `summarize_message_for_log` — never the
message body. Adds offline mocked tests (no live SQS/DB/ES). **The separate ES indexer
dead-letter-queue policy question (audit finding B-ES-1) is intentionally not addressed here.**

### T7 — [Dependencies] Remove unused `pmdarima` + `xlrd`; keep `numpy`
`pyproject.toml` / `poetry.lock` — `pmdarima` and `xlrd` are imported nowhere in snovault (both
vestiges of an abandoned Python-3.12 upgrade). Removing them drops the entire `pmdarima`
scientific-computing closure from the lockfile: `scikit-learn`, `statsmodels`, `patsy`, `scipy`,
`joblib`, `cython`, `pandas`, `threadpoolctl`, `tzdata`.

**`numpy` is deliberately retained.** Consumer envs (fourfront/cgap/smaht-portal/encoded-core)
rely on `dcicsnovault` as their *declared* numpy provider and do not declare numpy themselves —
removing it would break transitive provision. `xlrd` is safe to drop (consumers also get it via
`pandas` / their own declaration). **Downstream note:** `pmdarima` is declared *only* by
`dcicsnovault` in those consumer envs, so `scikit-learn`/`statsmodels`/`patsy` (which no consumer
app declares) leave their closure too; any consumer importing those undeclared should add its own
explicit dependency.

### T4 — [Observability] Fix the `ff_env` timing-log field; document the Sentry integration point
`snovault/stats.py` — the per-request "Request timings" structured log bound its environment field
`ff_env` from a mistyped setting key `env_name` (underscore) that **no code ever sets**, instead of
the dotted `env.name` used everywhere else in the framework (`util.get_env_name`, `authentication`,
`root`, `indexer_queue`, ...). So `ff_env` — the primary environment filter for log aggregation and
for any consumer log→Sentry bridge — was silently always absent. Fixed to read `env.name`; adds
DB-free unit tests pinning the behavior (bound from `env.name`, legacy `env_name` ignored, omitted
when unset).

**Sentry integration boundary (investigated; deliberately no framework Sentry code).** `sentry-sdk`
is **not** a snovault dependency, and Sentry is initialized **consumer-side** via the `SENTRY_DSN`
deployment setting (see `dcicutils` deployment support). A framework-side Sentry hook was evaluated
and rejected as **not genuinely simple and safe**:
- The natural request-completion hook (end of `stats_tween`) runs **after** `handler(request)`,
  which is not wrapped — so on errored requests (exactly what Sentry captures) it never executes and
  could not enrich those events.
- An early per-request env tag would be redundant with the consumer's `sentry_sdk.init(environment=…)`
  and would couple to the consumer's Sentry scope lifecycle.

**Recommended consumer-side integration point (no framework change needed):** the consumer already
initializes Sentry (`SENTRY_DSN`, setting `environment=<env.name>`); to capture snovault's
per-request/DB timing telemetry, point a Sentry `LoggingIntegration` (or any structured-logging
bridge) at the `"Request timings"` structlog event — which now carries the correct low-cardinality
`ff_env` plus bounded aggregate fields (`wsgi_time`, `db_time`, `db_count`, `rss_change`,
`queue_time`) and **never** bodies/secrets/PHI/SQL. This keeps observability optional and no-op when
no observer is installed, with zero new coupling or per-item/high-cardinality instrumentation.

## Validation
- `poetry check` ✅ (before and after version bump); lockfile regenerated via `poetry lock --no-update`.
- `flake8` clean on all changed files.
- Offline (no live services) tests: T8 poison-message **9/9**; T4 `env.name` **3/3**; broader
  DB-free ingestion subset (decorator/queue/processor/poison) **23/23**.
- Confirmed the poison inputs genuinely raise (`JSONDecodeError`/`KeyError`); `import snovault` clean.
- T0 tests collect cleanly; execution is CI-gated (no local Postgres on the impl host).
- Not run locally (require live services / CI): the T0 `testapp` tests and the full ES/indexing suite.

## Notes
- No merge requested. The `numpy`-keep, B-ES-1-separate, and no-framework-Sentry decisions are
  deliberate per the ship scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
