### PR TITLE
Hoist per-drain MAX(sid) out of @@index-data render + indexing-perf guardrails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,39 @@ snovault
 Change Log
 ----------
 
+11.35.0
+=======
+
+* Indexing performance (SQLAlchemy optimization, behavior-preserving): hoist the per-document
+  ``SELECT max(current_propsheets.sid)`` query out of the ``@@index-data`` render. During a
+  queue drain, ``Indexer.update_objects_queue`` already computes the drain-level ``max_sid``
+  once; it now stores it on the request (``request._batch_max_sid``), which
+  ``embed._embed`` propagates to the ``@@index-data`` subrequest, and
+  ``indexing_views.item_index_data`` reuses it instead of recomputing ``context.max_sid`` for
+  every document. Because the drain runs in a single ``READ ONLY REPEATABLE READ`` transaction,
+  the hoisted value is snapshot-invariant, so the indexed ``max_sid`` -- and every other indexed
+  byte -- is unchanged. In the warm batch steady state this removes the only remaining SQL query
+  per document (1 -> 0). Any render outside an indexer drain (a direct
+  ``GET /<uuid>/@@index-data``, or the synchronous indexing path, neither of which sets
+  ``_batch_max_sid``) still computes ``context.max_sid`` exactly as before.
+
+* Testing (indexing-performance guardrails): add deterministic, PostgreSQL-only regression
+  tests (no Elasticsearch). ``test_indexing_perf_guardrails.py`` asserts that (a) the batch
+  path issues zero ``MAX(sid)`` queries while the fallback path issues exactly one, (b) the
+  indexed ``@@index-data`` document is deep-equal with and without the hoist (excluding the
+  non-deterministic ``indexing_stats`` timing block), and (c) canonical cold render query
+  counts are pinned so a new N+1 in the render path fails loudly.
+  ``test_indexer_auth_debug_config.py`` locks in that snovault's shipped configs
+  (``base.ini`` and the ``*.ini.template`` files) never enable
+  ``pyramid.debug_authorization``, which would otherwise add per-view overhead to the indexer
+  render path in production.
+
+* Note: several further indexing optimizations identified during evaluation remain
+  deliberately deferred (request-scoped upgraded-properties memoization, batched reverse-link
+  status loading, embedded link-target prefetch, Pyramid subrequest fast paths, MPIndexer
+  cache-lifetime changes, and a SQLAlchemy 2.0 / de-``baked`` migration). This change ships only
+  the output-neutral ``MAX(sid)`` hoist and its guardrails.
+
 11.34.0
 =======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.34.0"
+version = "11.35.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/elasticsearch/indexer.py
+++ b/snovault/elasticsearch/indexer.py
@@ -264,6 +264,15 @@ class Indexer(object):
         # retrieved by a "newer" worker you are guaranteeing an up-to-date embed cache. A rare case indeed but still a
         # possibility. - Will Sept 13 2022
         max_sid = request.registry[STORAGE].write.get_max_sid()
+        # Hoist the drain-level max_sid onto the request so each @@index-data
+        # render (below, via update_object -> request.embed) reuses it instead of
+        # recomputing SELECT max(sid) per document. The drain runs in a single
+        # READ ONLY REPEATABLE READ transaction (set in update_objects), so this
+        # value is snapshot-invariant for the whole drain and the indexed
+        # `max_sid` is byte-identical to the former per-item context.max_sid. A
+        # render outside a drain (e.g. a direct GET /<uuid>/@@index-data, or the
+        # sync path which never sets this) falls back to context.max_sid.
+        request._batch_max_sid = max_sid
         deferred = False  # if true, we need to restart the worker
         messages, target_queue = self.get_messages_from_queue()
         while len(messages) > 0:

--- a/snovault/embed.py
+++ b/snovault/embed.py
@@ -182,9 +182,10 @@ def _embed(request, path, as_user='EMBED'):
     subreq._aggregate_for = request._aggregate_for
     subreq._aggregated_items = request._aggregated_items
     subreq._sid_cache = request._sid_cache
-    # Propagate the hoisted drain-level max_sid (None outside an indexer drain)
-    # so the @@index-data render reuses it instead of recomputing MAX(sid).
-    subreq._batch_max_sid = request._batch_max_sid
+    # Only the top-level @@index-data subrequest needs the hoisted max_sid.
+    # Do not expose a drain's value to unrelated nested embeds.
+    if '@@index-data' in path:
+        subreq._batch_max_sid = request._batch_max_sid
     if as_user is not True:
         if 'HTTP_COOKIE' in subreq.environ:
             del subreq.environ['HTTP_COOKIE']

--- a/snovault/embed.py
+++ b/snovault/embed.py
@@ -27,6 +27,10 @@ def includeme(config):
     config.add_request_method(lambda request: {}, '_aggregated_items', reify=True)
     config.add_request_method(lambda request: {}, '_aggregate_for', reify=True)
     config.add_request_method(lambda request: False, '_indexing_view', reify=True)
+    # Drain-level MAX(sid) hoisted by Indexer.update_objects_queue; defaults to
+    # None so any render outside an indexer drain falls back to context.max_sid
+    # in item_index_data. See indexing_views.item_index_data and _embed below.
+    config.add_request_method(lambda request: None, '_batch_max_sid', reify=True)
     config.add_request_method(lambda request: None, '__parent__', reify=True)
 
 
@@ -178,6 +182,9 @@ def _embed(request, path, as_user='EMBED'):
     subreq._aggregate_for = request._aggregate_for
     subreq._aggregated_items = request._aggregated_items
     subreq._sid_cache = request._sid_cache
+    # Propagate the hoisted drain-level max_sid (None outside an indexer drain)
+    # so the @@index-data render reuses it instead of recomputing MAX(sid).
+    subreq._batch_max_sid = request._batch_max_sid
     if as_user is not True:
         if 'HTTP_COOKIE' in subreq.environ:
             del subreq.environ['HTTP_COOKIE']

--- a/snovault/indexing_views.py
+++ b/snovault/indexing_views.py
@@ -214,6 +214,15 @@ def item_index_data(context, request):
             # TODO: This should probably be logged. -kmp 22-Oct-2020
             pass
 
+    # Reuse the drain-level max_sid when indexing through the queue (set on the
+    # request by Indexer.update_objects_queue). It is snapshot-invariant under
+    # the drain's READ ONLY REPEATABLE READ transaction, so this is byte-identical
+    # to context.max_sid but avoids a per-document SELECT max(sid). Any render
+    # outside an indexer drain leaves _batch_max_sid unset (None) and computes
+    # context.max_sid as before. Note `0` is a valid max_sid, so test `is None`.
+    batch_max_sid = request._batch_max_sid
+    max_sid = context.max_sid if batch_max_sid is None else batch_max_sid
+
     document = {
         'aggregated_items': aggregated_items,
         'embedded': embedded_view,
@@ -222,7 +231,7 @@ def item_index_data(context, request):
         'linked_uuids_embedded': join_linked_uuids_sids(request, linked_uuids_embedded),
         'linked_uuids_object': join_linked_uuids_sids(request, linked_uuids_object),
         'links': links,
-        'max_sid': context.max_sid,
+        'max_sid': max_sid,
         'object': object_view,
         'paths': sorted(paths),
         'principals_allowed': principals_allowed,

--- a/snovault/tests/test_indexer_auth_debug_config.py
+++ b/snovault/tests/test_indexer_auth_debug_config.py
@@ -42,28 +42,47 @@ SHIPPED_CONFIG_FILES = [
 ]
 
 
-def _debug_authorization_value(ini_path):
-    """Return the resolved `pyramid.debug_authorization` from an ini's app section.
+def _debug_authorization_values(ini_path):
+    """Return every authorization-debug setting or PasteDeploy override.
 
-    Returns None if the key is absent (Pyramid then defaults it to False).
+    PasteDeploy permits settings in the app section and ``set`` overrides in
+    pipeline/composite sections. Inspect every section so the regression cannot
+    be bypassed by moving the same setting outside ``app:app``.
     """
     parser = configparser.ConfigParser(interpolation=None)
     with open(ini_path) as f:
         parser.read_file(f)
-    for section in ('app:app', 'app:main'):
-        if parser.has_option(section, 'pyramid.debug_authorization'):
-            return parser.get(section, 'pyramid.debug_authorization')
-    return None
+    values = []
+    for section in parser.sections():
+        for option, value in parser.items(section):
+            normalized_option = option[4:] if option.startswith('set ') else option
+            if normalized_option == 'pyramid.debug_authorization':
+                values.append((section, option, value))
+    return values
+
+
+def test_debug_authorization_values_finds_pastedeploy_override(tmp_path):
+    ini_path = tmp_path / 'override.ini'
+    ini_path.write_text(
+        '[pipeline:indexer]\n'
+        'pipeline = app\n'
+        'set pyramid.debug_authorization = true\n'
+    )
+    assert _debug_authorization_values(str(ini_path)) == [
+        ('pipeline:indexer', 'set pyramid.debug_authorization', 'true'),
+    ]
 
 
 @pytest.mark.parametrize('config_file', SHIPPED_CONFIG_FILES)
 def test_shipped_config_does_not_enable_debug_authorization(config_file):
     ini_path = os.path.join(REPO_ROOT, config_file)
     assert os.path.exists(ini_path), f'expected shipped config missing: {ini_path}'
-    value = _debug_authorization_value(ini_path)
+    values = _debug_authorization_values(ini_path)
     # Absent (-> Pyramid default False) or explicitly falsy are both acceptable;
-    # a truthy value in a shipped config is the accidental-enablement regression.
-    assert value is None or not asbool(value), (
-        f'{config_file} enables pyramid.debug_authorization (={value!r}); it must '
-        f'stay disabled in production-like configuration.'
+    # a truthy value anywhere in a shipped config is the regression.
+    enabled = [(section, option, value)
+               for section, option, value in values if asbool(value)]
+    assert not enabled, (
+        f'{config_file} enables pyramid.debug_authorization at {enabled!r}; it '
+        f'must stay disabled in production-like configuration.'
     )

--- a/snovault/tests/test_indexer_auth_debug_config.py
+++ b/snovault/tests/test_indexer_auth_debug_config.py
@@ -1,0 +1,69 @@
+"""
+Configuration regression: Pyramid authorization debugging must stay disabled in
+the production-like configs that snovault ships.
+
+`pyramid.debug_authorization` wraps every permission check in an extra
+`authdebug_view` tween. It is a developer diagnostic only; leaving it on in a
+production/indexer configuration adds per-view overhead to the exact hot path the
+indexer drives (`@@object`/`@@embedded` renders run one secured subrequest per
+embedded item), for no functional benefit.
+
+Snovault itself does not host the authoritative production/indexer INI -- that
+lives in the consumer application (e.g. smaht-portal). What snovault ships are the
+shared application defaults (`base.ini`) and the deployment templates
+(`development.ini.template`, `test.ini.template`). This test locks in that none of
+those enable the flag (it is either absent -> Pyramid default False, or explicitly
+false), so an accidental `pyramid.debug_authorization = true` cannot slip into a
+shipped config unnoticed.
+
+Note: the pytest app fixture (`testappfixtures._app_settings`) deliberately sets
+`pyramid.debug_authorization = True` so the authorization-debug code path is
+exercised during tests. That is intentional test behavior and is not touched here.
+
+This is a static config check (it does not itself use Elasticsearch), so it runs
+in the fast, non-ES (`not indexing`) partition.
+"""
+import configparser
+import os
+
+import pytest
+import snovault
+from pyramid.settings import asbool
+
+
+# snovault.__file__ -> <repo>/snovault/__init__.py; two dirnames -> <repo>.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(snovault.__file__)))
+
+# Shipped, production-like configs. All must keep authorization debugging off.
+SHIPPED_CONFIG_FILES = [
+    'base.ini',
+    'development.ini.template',
+    'test.ini.template',
+]
+
+
+def _debug_authorization_value(ini_path):
+    """Return the resolved `pyramid.debug_authorization` from an ini's app section.
+
+    Returns None if the key is absent (Pyramid then defaults it to False).
+    """
+    parser = configparser.ConfigParser(interpolation=None)
+    with open(ini_path) as f:
+        parser.read_file(f)
+    for section in ('app:app', 'app:main'):
+        if parser.has_option(section, 'pyramid.debug_authorization'):
+            return parser.get(section, 'pyramid.debug_authorization')
+    return None
+
+
+@pytest.mark.parametrize('config_file', SHIPPED_CONFIG_FILES)
+def test_shipped_config_does_not_enable_debug_authorization(config_file):
+    ini_path = os.path.join(REPO_ROOT, config_file)
+    assert os.path.exists(ini_path), f'expected shipped config missing: {ini_path}'
+    value = _debug_authorization_value(ini_path)
+    # Absent (-> Pyramid default False) or explicitly falsy are both acceptable;
+    # a truthy value in a shipped config is the accidental-enablement regression.
+    assert value is None or not asbool(value), (
+        f'{config_file} enables pyramid.debug_authorization (={value!r}); it must '
+        f'stay disabled in production-like configuration.'
+    )

--- a/snovault/tests/test_indexing_perf_guardrails.py
+++ b/snovault/tests/test_indexing_perf_guardrails.py
@@ -32,13 +32,17 @@ does not enter -- so ``execute_counter`` would silently count zero here. The
 recorder counts unconditionally on the engine, so it observes both paths.
 """
 import contextlib
+import json
 import pytest
 
 from copy import deepcopy
+from unittest.mock import Mock
 from dcicutils.qa_utils import notice_pytest_fixtures
 from pyramid.threadlocal import manager
 from sqlalchemy import event
 
+from ..elasticsearch.indexer import Indexer
+from ..embed import _embed
 from ..interfaces import DBSESSION, STORAGE
 
 
@@ -156,6 +160,32 @@ def _cold_reset(registry):
     registry[DBSESSION]().expunge_all()
 
 
+def test_batch_max_sid_only_propagates_to_index_data(dummy_request, monkeypatch):
+    """A drain value must not leak into unrelated nested embed subrequests."""
+    propagated = {}
+
+    def invoke_subrequest(subrequest):
+        propagated[subrequest.path] = subrequest.__dict__.get('_batch_max_sid')
+        # Supply the bookkeeping normally initialized while Pyramid invokes the
+        # subrequest; the result itself is immaterial to this propagation test.
+        subrequest._linked_uuids = set()
+        subrequest._rev_linked_uuids_by_item = {}
+        subrequest._aggregated_items = {}
+        subrequest._sid_cache = {}
+        return {}
+
+    monkeypatch.setattr(dummy_request, 'invoke_subrequest', invoke_subrequest)
+    dummy_request._batch_max_sid = 42
+
+    _embed(dummy_request, '/unrelated/@@object', as_user='INDEXER')
+    _embed(dummy_request, '/target/@@index-data', as_user='INDEXER')
+
+    assert propagated == {
+        '/unrelated/@@object': None,
+        '/target/@@index-data': 42,
+    }
+
+
 # ---------------------------------------------------------------------------
 # 1. MAX(sid) hoist: batch path removes the per-document MAX(sid) query, and the
 #    indexed document is unchanged. Covers both the batch and fallback paths.
@@ -192,6 +222,62 @@ def test_index_data_batch_max_sid_hoist(guardrail_content, dummy_request, thread
     assert batch_doc['max_sid'] == fallback_doc['max_sid'] == batch_max_sid
     assert _doc_without_timings(batch_doc) == _doc_without_timings(fallback_doc)
 
+    # Zero is a valid supplied max_sid, not the fallback sentinel.
+    with sql_recorder.recording():
+        zero_doc = _render_index_data(dummy_request, coll, uuid_val,
+                                      batch_max_sid=0)
+    assert sql_recorder.max_sid_count == 0, uuid_key
+    assert zero_doc['max_sid'] == 0
+
+
+def test_queue_drain_reuses_one_max_sid_for_all_documents(
+        guardrail_content, dummy_request, threadlocals, sql_recorder):
+    """Exercise update_objects_queue -> update_object -> @@index-data itself.
+
+    This guards the actual batch wiring, rather than merely simulating it by
+    setting ``_batch_max_sid`` immediately before a synthetic render.
+    """
+    notice_pytest_fixtures(guardrail_content, dummy_request, threadlocals,
+                           sql_recorder)
+    registry = dummy_request.registry
+    uuids = [GUARDRAIL_SOURCES[0]['uuid'], GUARDRAIL_TARGET['uuid']]
+    messages = []
+    for uuid in uuids:
+        model = registry[STORAGE].write.get_by_uuid(uuid)
+        messages.append({
+            'Body': json.dumps({
+                'uuid': uuid,
+                'sid': model.sid,
+                'timestamp': '2026-01-01T00:00:00',
+                'strict': True,
+            }),
+        })
+    expected_max_sid = registry[STORAGE].write.get_max_sid()
+
+    indexer = Indexer.__new__(Indexer)
+    indexer.registry = registry
+    indexer.es = Mock()
+    indexer.queue = Mock(delete_batch_size=10)
+    indexer.get_messages_from_queue = Mock(side_effect=[
+        (messages, 'primary'),
+        ([], None),
+    ])
+    counter = [0]
+
+    with sql_recorder.recording():
+        errors, deferred = indexer.update_objects_queue(dummy_request, counter)
+
+    assert errors == []
+    assert deferred is False
+    assert counter == [len(uuids)]
+    assert sql_recorder.max_sid_count == 1, sql_recorder.statements
+    assert indexer.es.index.call_count == len(uuids)
+    indexed_documents = [call.kwargs['body']
+                         for call in indexer.es.index.call_args_list]
+    assert [document['uuid'] for document in indexed_documents] == uuids
+    assert all(document['max_sid'] == expected_max_sid
+               for document in indexed_documents)
+
 
 # ---------------------------------------------------------------------------
 # 2. N+1 guardrail: pin the cold query count of a canonical rev-linked render so
@@ -208,14 +294,16 @@ def test_index_data_cold_query_count_is_pinned(guardrail_content, dummy_request,
     with sql_recorder.recording():
         _render_index_data(dummy_request, '/testing-link-targets-sno/',
                            GUARDRAIL_TARGET['uuid'])
-    target_cold = sql_recorder.count
+    target_statements = list(sql_recorder.statements)
+    target_cold = len(target_statements)
 
     # Simple source with a single linkTo, rendered cold (fallback path).
     _cold_reset(registry)
     with sql_recorder.recording():
         _render_index_data(dummy_request, '/testing-link-sources-sno/',
                            GUARDRAIL_SOURCES[0]['uuid'])
-    source_cold = sql_recorder.count
+    source_statements = list(sql_recorder.statements)
+    source_cold = len(source_statements)
 
     # Pinned expectations (see module docstring). Both counts include exactly one
     # MAX(sid) aggregate (fallback path). A new N+1 in the render path makes these
@@ -229,8 +317,8 @@ def test_index_data_cold_query_count_is_pinned(guardrail_content, dummy_request,
     #   additional current source -- that linear growth is exactly the N+1 shape.
     # Source (single linkTo that transitively embeds its target's rev-links)
     #   = 8 cold queries (also 1 MAX(sid)); depends on the same 4-source fan-in.
-    assert target_cold == EXPECTED_TARGET_COLD_QUERIES, sql_recorder.statements
-    assert source_cold == EXPECTED_SOURCE_COLD_QUERIES, sql_recorder.statements
+    assert target_cold == EXPECTED_TARGET_COLD_QUERIES, target_statements
+    assert source_cold == EXPECTED_SOURCE_COLD_QUERIES, source_statements
 
 
 # Baselined empirically (see module docstring and the breakdown above). The

--- a/snovault/tests/test_indexing_perf_guardrails.py
+++ b/snovault/tests/test_indexing_perf_guardrails.py
@@ -1,0 +1,239 @@
+"""
+Deterministic performance guardrails for the @@index-data render path.
+
+These tests protect two invariants of the drain-level ``MAX(sid)`` hoist
+(``request._batch_max_sid``; see ``snovault.indexing_views.item_index_data``,
+``snovault.embed._embed`` and ``snovault.elasticsearch.indexer.update_objects_queue``):
+
+1. When a drain supplies ``_batch_max_sid`` the render issues **no** per-document
+   ``SELECT max(current_propsheets.sid)`` query; without it (a direct
+   ``GET /<uuid>/@@index-data`` or the sync path) the render still computes
+   ``context.max_sid`` exactly as before.
+2. The indexed document is byte-for-byte identical with and without the hoist
+   (the hoist is output-neutral under the drain's READ ONLY REPEATABLE READ
+   snapshot; only the timing block ``indexing_stats`` differs between renders).
+
+They also pin the query count of representative canonical ``@@index-data``
+renders so that a newly-introduced N+1 in the render path fails loudly.
+
+These need only PostgreSQL (no Elasticsearch), so they are intentionally left
+unmarked and run in the fast UNIT (``not indexing``) partition, matching
+``test_embedding.py``.
+
+Query counting uses an engine-level ``after_cursor_execute`` recorder throughout
+(the ``sql_recorder`` fixture below) -- the same mechanism the repository's
+``execute_counter`` fixture and the scout profiling harness use, and thus "the
+closest authoritative test helper" the ship scope allows. It is used in place of
+``execute_counter`` itself because both the batch and fallback renders here are
+driven via the internal ``dummy_request.embed('@@index-data', as_user='INDEXER')``
+call, and ``execute_counter`` only counts inside an active zope-transaction
+savepoint (``zsa_savepoints.state == 'begun'``), which that internal embed path
+does not enter -- so ``execute_counter`` would silently count zero here. The
+recorder counts unconditionally on the engine, so it observes both paths.
+"""
+import contextlib
+import pytest
+
+from copy import deepcopy
+from dcicutils.qa_utils import notice_pytest_fixtures
+from pyramid.threadlocal import manager
+from sqlalchemy import event
+
+from ..interfaces import DBSESSION, STORAGE
+
+
+# ---------------------------------------------------------------------------
+# Dedicated fixtures with a known link/rev-link shape (not shared rows), so the
+# pinned query counts depend only on this graph, never on unrelated test data.
+# ---------------------------------------------------------------------------
+GUARDRAIL_TARGET = {
+    'name': 'guardrail-rev-target',
+    'uuid': 'c6f9a1e2-0000-4a00-8000-00000000ab01',
+}
+# All sources are status=current so every one is a live rev-link that the
+# target's `reverse` calc property traverses (the rev-link N+1 shape).
+GUARDRAIL_SOURCES = [
+    {
+        'name': f'guardrail-src-{i}',
+        'target': GUARDRAIL_TARGET['uuid'],
+        'uuid': f'c6f9a1e2-0000-4a00-8000-0000000000{i:02d}',
+        'status': 'current',
+    }
+    for i in range(4)
+]
+
+
+@pytest.fixture
+def guardrail_content(testapp):
+    """POST one rev-link target with 4 current sources through the real cycle."""
+    testapp.post_json('/testing-link-targets-sno/', GUARDRAIL_TARGET, status=201)
+    for source in GUARDRAIL_SOURCES:
+        testapp.post_json('/testing-link-sources-sno/', source, status=201)
+
+
+# ---------------------------------------------------------------------------
+# Engine-level SQL statement recorder (mirrors execute_counter's mechanism).
+# ---------------------------------------------------------------------------
+class SqlRecorder:
+    """Records SQL statements executed on the engine while active."""
+
+    def __init__(self):
+        self.active = False
+        self.statements = []
+
+    @contextlib.contextmanager
+    def recording(self):
+        self.statements = []
+        self.active = True
+        try:
+            yield self
+        finally:
+            self.active = False
+
+    @property
+    def count(self):
+        return len(self.statements)
+
+    @property
+    def max_sid_count(self):
+        """Number of `SELECT max(current_propsheets.sid)` aggregates recorded.
+
+        This aggregate is emitted by `context.max_sid` (storage.RDBStorage
+        .get_max_sid) and, within a single @@index-data render, by nothing else,
+        so it uniquely identifies the per-document MAX(sid) query the hoist
+        removes -- independent of cache warmth or unrelated fixture rows.
+        """
+        needle = 'max(current_propsheets.sid)'
+        return sum(1 for s in self.statements if needle in ' '.join(s.split()).lower())
+
+
+@pytest.fixture
+def sql_recorder(app):
+    engine = app.registry[DBSESSION].bind
+    recorder = SqlRecorder()
+
+    @event.listens_for(engine, 'after_cursor_execute')
+    def _after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+        if recorder.active:
+            recorder.statements.append(statement)
+
+    yield recorder
+
+    event.remove(engine, 'after_cursor_execute', _after_cursor_execute)
+
+
+def _render_index_data(dummy_request, coll, uuid, batch_max_sid=None):
+    """Render one item's @@index-data exactly as Indexer.update_object does.
+
+    Setting `dummy_request._batch_max_sid` before the embed mimics the drain
+    having hoisted MAX(sid) (it propagates to the @@index-data subrequest via
+    embed._embed); leaving it None mimics a direct/sync render (fallback).
+    """
+    dummy_request._batch_max_sid = batch_max_sid
+    return dummy_request.embed(coll, uuid, '@@index-data', as_user='INDEXER')
+
+
+def _doc_without_timings(document):
+    """Copy of the indexed document minus the non-deterministic timing block."""
+    comparable = deepcopy(document)
+    comparable.pop('indexing_stats', None)
+    return comparable
+
+
+def _clear_app_caches():
+    """Drop snovault's per-transaction item/key/embed caches (threadlocal)."""
+    if manager.stack:
+        threadlocals = manager.stack[0]
+        for name in ('snovault.connection.item_cache',
+                     'snovault.connection.key_cache',
+                     'snovault.connection.embed_cache'):
+            threadlocals.pop(name, None)
+
+
+def _cold_reset(registry):
+    """Simulate a cache-cold first touch (clear app caches + SA identity map)."""
+    _clear_app_caches()
+    registry[DBSESSION]().expunge_all()
+
+
+# ---------------------------------------------------------------------------
+# 1. MAX(sid) hoist: batch path removes the per-document MAX(sid) query, and the
+#    indexed document is unchanged. Covers both the batch and fallback paths.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize('coll,uuid_key,uuid_val', [
+    ('/testing-link-sources-sno/', 'source', GUARDRAIL_SOURCES[0]['uuid']),  # 1 linkTo
+    ('/testing-link-targets-sno/', 'target', GUARDRAIL_TARGET['uuid']),      # N rev-links
+])
+def test_index_data_batch_max_sid_hoist(guardrail_content, dummy_request, threadlocals,
+                                        sql_recorder, coll, uuid_key, uuid_val):
+    notice_pytest_fixtures(guardrail_content, dummy_request, threadlocals, sql_recorder)
+    batch_max_sid = dummy_request.registry[STORAGE].write.get_max_sid()
+
+    # Warm once so both measured renders share an identical cache state; the
+    # MAX(sid) query is issued regardless of warmth, so this does not mask it.
+    _render_index_data(dummy_request, coll, uuid_val)
+
+    # Fallback path: no _batch_max_sid -> exactly one MAX(sid) aggregate.
+    with sql_recorder.recording():
+        fallback_doc = _render_index_data(dummy_request, coll, uuid_val)
+    assert sql_recorder.max_sid_count == 1, uuid_key
+
+    # Batch path: _batch_max_sid supplied -> the MAX(sid) aggregate is gone.
+    with sql_recorder.recording():
+        batch_doc = _render_index_data(dummy_request, coll, uuid_val,
+                                       batch_max_sid=batch_max_sid)
+    assert sql_recorder.max_sid_count == 0, uuid_key
+    assert sql_recorder.count == 0, (
+        'batch render of a warm item should issue no SQL at all; got: %s'
+        % sql_recorder.statements)
+
+    # The hoist is output-neutral: max_sid value and every other indexed byte
+    # match (only the timing block differs between renders).
+    assert batch_doc['max_sid'] == fallback_doc['max_sid'] == batch_max_sid
+    assert _doc_without_timings(batch_doc) == _doc_without_timings(fallback_doc)
+
+
+# ---------------------------------------------------------------------------
+# 2. N+1 guardrail: pin the cold query count of a canonical rev-linked render so
+#    a new per-item query in the render path is caught. Uses the fallback path
+#    (context.max_sid) and dedicated fixtures with a fixed rev-link fan-in.
+# ---------------------------------------------------------------------------
+def test_index_data_cold_query_count_is_pinned(guardrail_content, dummy_request,
+                                               threadlocals, sql_recorder):
+    notice_pytest_fixtures(guardrail_content, dummy_request, threadlocals, sql_recorder)
+    registry = dummy_request.registry
+
+    # Rev-linked target with 4 current sources, rendered cold (fallback path).
+    _cold_reset(registry)
+    with sql_recorder.recording():
+        _render_index_data(dummy_request, '/testing-link-targets-sno/',
+                           GUARDRAIL_TARGET['uuid'])
+    target_cold = sql_recorder.count
+
+    # Simple source with a single linkTo, rendered cold (fallback path).
+    _cold_reset(registry)
+    with sql_recorder.recording():
+        _render_index_data(dummy_request, '/testing-link-sources-sno/',
+                           GUARDRAIL_SOURCES[0]['uuid'])
+    source_cold = sql_recorder.count
+
+    # Pinned expectations (see module docstring). Both counts include exactly one
+    # MAX(sid) aggregate (fallback path). A new N+1 in the render path makes these
+    # jump; the recorded statements are surfaced on failure for diagnosis. If the
+    # render path legitimately changes, update these deliberately.
+    #
+    # Target (rev-linked, 4 current sources) = 8 cold queries:
+    #   1 get_by_uuid(target 3-table join) + 1 get_by_unique_key (path traversal)
+    #   + 1 get_rev_links (links-by-target) + 4 per-source status loads (the
+    #   rev-link N+1, one per current source) + 1 MAX(sid). Grows by one query per
+    #   additional current source -- that linear growth is exactly the N+1 shape.
+    # Source (single linkTo that transitively embeds its target's rev-links)
+    #   = 8 cold queries (also 1 MAX(sid)); depends on the same 4-source fan-in.
+    assert target_cold == EXPECTED_TARGET_COLD_QUERIES, sql_recorder.statements
+    assert source_cold == EXPECTED_SOURCE_COLD_QUERIES, sql_recorder.statements
+
+
+# Baselined empirically (see module docstring and the breakdown above). The
+# 4-source fan-in in GUARDRAIL_SOURCES is load-bearing for these counts.
+EXPECTED_TARGET_COLD_QUERIES = 8
+EXPECTED_SOURCE_COLD_QUERIES = 8


### PR DESCRIPTION
## Summary

Approved **Phase-0 slice (items 1–3)** of the SQLAlchemy indexing-optimization plan (scout report + captain decision `2026-07-21`). Reduces data-indexing time by removing the per-document `SELECT max(current_propsheets.sid)` query from the `@@index-data` render, plus deterministic guardrails and an authorization-debug config check. **All other proposals from the plan remain deferred** (list at the bottom). No indexed-document bytes or observable behavior change.

## Item 1 — Hoist `MAX(sid)` to once per drain (behavior-preserving)

`Indexer.update_objects_queue` already computes the drain-level `max_sid` once per queue drain (`indexer.py:266`). Previously, `indexing_views.item_index_data` recomputed `context.max_sid` — a `SELECT max(current_propsheets.sid)` aggregate — for **every** document. This is the *only* SQL query remaining in the warm batch steady state.

Change (smallest request-scoped interface, matching how `_sid_cache`/`_indexing_view`/etc. already flow parent→subrequest):
- `indexer.py::update_objects_queue` stores the drain value on the request: `request._batch_max_sid = max_sid`.
- `embed._embed` propagates `_batch_max_sid` only to the top-level `@@index-data` subrequest (defaults to `None` via a reify request method registered in `embed.includeme`); unrelated nested embeds never receive the drain value.
- `indexing_views.item_index_data` reuses it: `max_sid = context.max_sid if batch_max_sid is None else batch_max_sid` (tested `is None`, since `0` is a valid max_sid; the conditional short-circuits so `context.max_sid` is not evaluated on the batch path).

**Why output-neutral:** the drain runs in a single `READ ONLY REPEATABLE READ` transaction (`indexer.py:180`). Under that snapshot `MAX(sid)` is invariant for the whole drain even if another connection commits a higher sid — proven in the scout evidence (`maxsid_mvcc.py`: a concurrent commit advanced the global max but the drain re-read the same value). So the hoisted value equals the former per-item `context.max_sid`, and the indexed `max_sid` — and every other indexed byte — is unchanged.

**Fallback preserved:** a direct `GET /<uuid>/@@index-data`, the `indexing-info` diagnostic, and the synchronous indexing path never set `_batch_max_sid`, so they compute `context.max_sid` exactly as before.

## Exact query-count change

| path | before | after |
|---|---|---|
| warm batch render (queue drain) | 1 SQL/document (`MAX(sid)`) | **0 SQL/document** |
| direct `GET /@@index-data` / sync path | unchanged | unchanged |

On a large reindex this removes one `MAX(sid)` round-trip per document (~one network RTT each against RDS). Non-warm renders keep all their other queries; only the redundant per-item `MAX(sid)` is removed.

## Item 2 — Deterministic performance guardrails (PostgreSQL-only, no Elasticsearch)

`snovault/tests/test_indexing_perf_guardrails.py`:
- **Batch vs fallback MAX(sid):** the batch path issues **0 per-document** `MAX(sid)` aggregates; the fallback path issues exactly **1**. Counted via an engine-level `after_cursor_execute` recorder (the same mechanism as the repo's `execute_counter`; used directly because the internal `dummy_request.embed('@@index-data', as_user='INDEXER')` path doesn't enter the zsa savepoint `execute_counter` gates on).
- **Actual drain wiring:** a two-document test drives `update_objects_queue -> update_object -> @@index-data` with only SQS/ES boundaries mocked and asserts exactly one aggregate for the entire drain and the same value in both indexed documents. A mutation back to per-document `context.max_sid` makes this test fail.
- **Propagation sentinels:** explicit coverage proves `0` is reused (not mistaken for the `None` fallback sentinel) and an unrelated nested `@@object` embed does not receive a drain value.
- **Document invariance:** the `@@index-data` document is deep-equal with and without the hoist, excluding only the non-deterministic `indexing_stats` timing block.
- **N+1 guard:** pinned cold render query counts on dedicated fixtures (rev-linked target with a fixed 4-source fan-in; single-linkTo source) so a new N+1 in the render path fails loudly. The counts (8/8) grow linearly with rev-link fan-in — exactly the N+1 shape — and the 4-source fan-in is load-bearing (commented in-file).

**Not vacuous:** verified the guardrail **fails against the old per-item behavior** — with the hoist reverted to always use `context.max_sid`, the batch assertion fails (`max_sid_count == 1`, expected `0`).

## Item 3 — Authorization-debug config regression

Traced `pyramid.debug_authorization` across all shipped configs: **absent from `base.ini`** (→ Pyramid default `False`), explicitly `false` in `development.ini.template`, absent from `test.ini.template`. Only the pytest fixture (`testappfixtures._app_settings`) sets it `True`, intentionally, to exercise the authz-debug code path — left untouched. **Conclusion: already safe; no runtime change.** `snovault/tests/test_indexer_auth_debug_config.py` locks in that no shipped config enables it, preventing accidental future enablement.

Scope note: the authoritative production/indexer INI lives in the consumer application (e.g. smaht-portal), not snovault; this guard covers only snovault's `base.ini`/templates.

## Testing

- New tests: **9 passing** (`test_indexing_perf_guardrails.py` ×5 including parametrization; `test_indexer_auth_debug_config.py` ×4).
- Full non-ES suite (`-m "not es and not indexing"`): **882 passed, 28 skipped, 0 failures** — validates the render and request/subrequest blast radius.
- `flake8 snovault/…` clean; `-m static` passes.
- Local PostgreSQL 14 via the repo's own `postgresql_fixture` (worktree-local binary; no system services, no ES, no AWS, no production data).

**CI-only / unrun-locally coverage (stated explicitly):**
- The full live SQS/Elasticsearch WSGI cycle remains covered by the **INDEXING** CI job. Locally, the actual `update_objects_queue -> update_object -> @@index-data` control flow is covered with only the SQS/ES boundaries mocked; PostgreSQL and rendering are real.
- The pinned cold counts (8/8) were baselined on local Postgres; CI is the final arbiter.

## Risks & rollback

- **Risk:** `embed._embed` propagates the extra attribute only to the top-level `@@index-data` subrequest. An explicit regression proves unrelated nested embeds do not receive it; it is not part of the embed-cache key or cached result, and the full non-ES suite passes.
- **Rollback:** revert this commit. The change is additive and localized to three functions; no schema, isolation, session-lifecycle, or transaction-boundary changes.

## Explicitly deferred (not in this PR)

upgraded-properties memoization; reverse-link status batching; embedded link-target prefetch; Pyramid subrequest fast paths; MPIndexer process/cache-lifetime changes; SQLAlchemy 2.0 / baked-query migration; new indexes, pool tuning, isolation/autoflush/expiration changes. These remain ideas for later per the captain's decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
