### PR TITLE
Stop normal encrypted S3 uploads from generating Sentry error events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,21 @@ snovault
 Change Log
 ----------
 
+11.35.1
+=======
+
+* Fix logging noise (Sentry error events) from ``extra_kwargs_for_s3_encrypt_key_id``
+  (``snovault/util.py``): the normal, successful encrypted-upload path -- reached on every
+  routine ``s3_output_stream``/``create_empty_s3_file`` upload once a KMS encrypt key is
+  configured -- previously logged at ``log.error``, generating a Sentry error event for
+  completely expected behavior. That path now logs at ``log.info`` instead, and no longer
+  includes the KMS key identifier value in the log message. The no-key path (this setting is
+  optional; many environments legitimately have no KMS key configured) is downgraded to
+  ``log.warning`` rather than removed, so it stays visible without generating a Sentry error.
+  The actual S3 ``ExtraArgs`` (``ServerSideEncryption: aws:kms`` / ``SSEKMSKeyId``) are
+  unchanged. Added regression coverage in ``snovault/tests/test_util.py`` asserting the built
+  ``ExtraArgs`` for both paths and that the encrypted path no longer logs at error level.
+
 11.35.0
 =======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.35.0"
+version = "11.35.1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/tests/test_util.py
+++ b/snovault/tests/test_util.py
@@ -3,10 +3,13 @@ import pytest
 import random
 import re
 
+from unittest import mock
+
 from dcicutils.misc_utils import override_environ
+from .. import util
 from ..util import (
     dictionary_lookup, DictionaryKeyError, merge_calculated_into_properties, CachedField,
-    generate_indexer_namespace_for_testing,
+    generate_indexer_namespace_for_testing, extra_kwargs_for_s3_encrypt_key_id, ExtraArgs,
 )
 
 
@@ -225,3 +228,40 @@ class TestCachedField:
         assert field.timeout == self.DEFAULT_TIMEOUT
         field.set_timeout(30)
         assert field.timeout == 30
+
+
+class TestExtraKwargsForS3EncryptKeyId:
+    """ extra_kwargs_for_s3_encrypt_key_id's normal (has-key) path must not log at error
+        level -- that previously generated a Sentry error event on every routine encrypted
+        S3 upload -- while the actual S3 encryption ExtraArgs must be unchanged. """
+
+    KEY_ID = "some-kms-key-id"
+
+    def test_encrypted_path_builds_correct_extra_args(self):
+        extra_kwargs = extra_kwargs_for_s3_encrypt_key_id(s3_encrypt_key_id=self.KEY_ID,
+                                                          client_name='test_client')
+        assert extra_kwargs == {
+            "ExtraArgs": {
+                ExtraArgs.SERVER_SIDE_ENCRYPTION: "aws:kms",
+                ExtraArgs.SSE_KMS_KEY_ID: self.KEY_ID,
+            }
+        }
+
+    def test_encrypted_path_does_not_log_error(self):
+        with mock.patch.object(util, 'log') as mocked_log:
+            extra_kwargs_for_s3_encrypt_key_id(s3_encrypt_key_id=self.KEY_ID, client_name='test_client')
+        assert mocked_log.error.call_count == 0
+        assert mocked_log.info.call_count == 1
+        # The KMS key identifier itself should not be logged.
+        logged_message = mocked_log.info.call_args[0][0]
+        assert self.KEY_ID not in logged_message
+
+    def test_no_key_path_returns_no_extra_args(self):
+        extra_kwargs = extra_kwargs_for_s3_encrypt_key_id(s3_encrypt_key_id=None, client_name='test_client')
+        assert extra_kwargs == {}
+
+    def test_no_key_path_logs_warning_not_error(self):
+        with mock.patch.object(util, 'log') as mocked_log:
+            extra_kwargs_for_s3_encrypt_key_id(s3_encrypt_key_id=None, client_name='test_client')
+        assert mocked_log.error.call_count == 0
+        assert mocked_log.warning.call_count == 1

--- a/snovault/util.py
+++ b/snovault/util.py
@@ -1554,13 +1554,15 @@ def extra_kwargs_for_s3_encrypt_key_id(s3_encrypt_key_id, client_name):
 
     extra_kwargs = {}
     if s3_encrypt_key_id:
-        log.error(f"{client_name} adding SSEKMSKeyId ({s3_encrypt_key_id}) arguments in upload_fileobj call.")
+        # Normal path -- stays below error level so routine uploads don't page Sentry.
+        log.info(f"{client_name} adding SSEKMSKeyId argument in upload_fileobj call.")
         extra_kwargs["ExtraArgs"] = {
             ExtraArgs.SERVER_SIDE_ENCRYPTION: "aws:kms",
             ExtraArgs.SSE_KMS_KEY_ID: s3_encrypt_key_id,
         }
     else:
-        log.error(f"{client_name} found no s3 encrypt key id ({SettingsKey.S3_ENCRYPT_KEY_ID})"
-                  f" in request.registry.settings.")
+        # No key is a valid config (e.g. no KMS in this env), not an error condition.
+        log.warning(f"{client_name} found no s3 encrypt key id ({SettingsKey.S3_ENCRYPT_KEY_ID})"
+                    f" in request.registry.settings.")
 
     return extra_kwargs


### PR DESCRIPTION
## Summary

- `extra_kwargs_for_s3_encrypt_key_id` (`snovault/util.py`) logged at `log.error` on the
  normal, successful encrypted-upload path — reached on every routine
  `s3_output_stream` / `create_empty_s3_file` / `submit_for_ingestion` upload once a KMS
  encrypt key is configured. Since this is expected, correct behavior (not an error), it
  was generating a Sentry error event for every encrypted S3 upload — pure noise with no
  actionable signal.
- The encrypted-key path now logs at `log.info` instead, and the message no longer
  includes the KMS key identifier value (avoids logging the key id unnecessarily).
- The no-key path is downgraded from `log.error` to `log.warning` rather than silently
  dropped: `s3_encrypt_key_id` is an optional setting that many environments (e.g. local/
  dev) legitimately leave unset, so it isn't a hard error either — but it stays visible at
  warning level rather than being hidden entirely. This mirrors the existing precedent in
  `make_s3_client` (same file), which already uses `log.warning` for its analogous
  "no identity configured" case.
- The actual S3 encryption arguments (`ServerSideEncryption: aws:kms` / `SSEKMSKeyId`) are
  completely unchanged — only the log level/content changed.

## Test plan

- [x] Added `TestExtraKwargsForS3EncryptKeyId` in `snovault/tests/test_util.py`:
  - Asserts the built `ExtraArgs` are correct for both the encrypted and no-key paths.
  - Asserts the encrypted path logs at `info` (not `error`) and the log message does not
    contain the KMS key id value.
  - Asserts the no-key path logs at `warning` (not `error`).
- [x] Verified the new tests fail against the pre-fix code (both `log.error` assertions
  fail) and pass against the fix — confirms the tests actually exercise the change.
- [x] `poetry run pytest snovault/tests/test_util.py` — 9 passed (offline, no AWS/ES/DB
  required for this file).
- [x] `flake8 snovault/util.py snovault/tests/test_util.py` — clean.
- [x] Bumped `pyproject.toml` version 11.35.0 → 11.35.1 and added a `CHANGELOG.rst` entry.
- Not run: live AWS S3/KMS calls, Sentry delivery, or ES/indexing-marked tests — none of
  these are touched by this change and none were exercised (per task constraints, no live
  AWS/Sentry/production access was used).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
