### PR TITLE
Fix nested-object/array linkTo invalidation-scope false negative

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,6 +349,20 @@ real `testapp.app.registry` so `crawl_schema` can resolve the real embed path â€
 `snovault/tests/test_invalidation_scope.py`. Before trusting a regression test for a
 mutation/aliasing bug, temporarily revert the fix and confirm the test actually fails.
 
+The field-match loop's on-path check is a **token-boundary prefix**: a diff field counts as
+lying on an embed path when the terminal embed field equals it *or* starts with `field + '.'`
+(never a bare unbounded `startswith`, which would let `associated_sample` match a sibling
+`associated_sample_other`). This is what makes an edit to a `linkTo` nested inside an object or
+array-of-objects (diff `sample_objects.associated_sample`) invalidate an embedder of
+`sources.sample_objects.associated_sample.alias`; before this, only exact-terminal or
+single-token top-level links matched, so nested-link edits silently kept a stale ES doc.
+The service-free way to exercise the matcher for both nested-object and array-of-object shapes
+is `TestInvalidationScopeNestedLinkUnit` (a tiny fake type registry feeding the real
+`filter_invalidation_scope`/`crawl_schema`). Note the older `TestInvalidationScopeUnit` class is
+**deliberately still `@pytest.mark.skip`**: its mocks predate the current backtracking matcher and
+crawl into fake `linkTo` target types (`Item_C`, ...) that are not registered, so `crawl_schema`
+raises on the full-embed prefix â€” don't waste time trying to just un-skip it.
+
 ## `ItemNamespace.__getattr__` sharp edge (calculated.py)
 
 `ItemNamespace.__getattr__` resolves unknown names via `self.registry` / `self._properties`

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,31 @@ snovault
 Change Log
 ----------
 
+11.35.2
+=======
+
+* Invalidation-scope correctness (``snovault/elasticsearch/indexer_utils.py``,
+  ``filter_invalidation_scope``): fix a false negative in secondary-reindexing scope. When a
+  changed item had a ``linkTo`` field nested inside an object or array-of-objects (e.g. a diff
+  ``sample_objects.associated_sample``), the field-match loop only recognized a diff as lying on
+  an embed path when the terminal embed field equaled it exactly or was a single path token in the
+  embed. A nested link is a multi-token string, so an embed such as
+  ``sources.sample_objects.associated_sample.alias`` was not matched and every embedder was wrongly
+  pruned from re-indexing, leaving a stale Elasticsearch document. The match loop now also treats a
+  diff field as on-path when the terminal embed field starts with ``field + '.'`` (a token-boundary
+  prefix, not an unbounded string prefix, so ``associated_sample`` still does not match a sibling
+  ``associated_sample_other``). Behavior for direct links, leaf edits, wildcard embeds, parent/child
+  types, default embeds, creates/deletes, and reverse links is unchanged.
+
+* Testing: add focused regression coverage in ``snovault/tests/test_invalidation_scope.py`` for the
+  above -- ``TestInvalidationScopeNestedLinkUnit`` (service-free unit tests driving the real
+  ``filter_invalidation_scope``/``crawl_schema`` against a small fake type registry, covering both
+  the nested-object and array-of-object link edits plus true-negative sibling and token-boundary
+  cases) and two integrated tests exercising the real biosource ``sample_objects.associated_sample``
+  schema shape (positive and true-negative sibling). The pre-existing ``TestInvalidationScopeUnit``
+  class remains skipped: its mocks predate the current backtracking matcher and crawl into fake
+  ``linkTo`` target types that are not registered, so repairing it was out of scope for this fix.
+
 11.35.1
 =======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.35.1"
+version = "11.35.2"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/elasticsearch/indexer_utils.py
+++ b/snovault/elasticsearch/indexer_utils.py
@@ -314,8 +314,13 @@ def filter_invalidation_scope(registry, diff, invalidated_with_type, secondary_u
             # be embedded! In addition, if you embed * on a linkTo, modifications to that linkTo will ALWAYS
             # invalidate the item_type
             for field in all_possible_diffs:
-                # if terminal field matches a diff exactly, invalidate
-                if terminal_field == field:
+                # if terminal field matches a diff exactly, or the diff is a link/object field
+                # that lies on the embedded path to the terminal field (e.g. terminal
+                # 'sample_objects.associated_sample.alias' with diff 'sample_objects.associated_sample',
+                # a nested-object/array-of-object linkTo edit), invalidate. The `field + '.'` guard
+                # keeps this a token-boundary prefix match, not an unbounded string prefix, so a diff
+                # like 'associated_sample' does not match a sibling 'associated_sample_other'.
+                if terminal_field == field or terminal_field.startswith(field + '.'):
                     log.info(f'Invalidating item type {invalidated_item_type} based on edit to field {field} given exact'
                              f'embed {terminal_field}')
                 # if terminal field is *, invalidate

--- a/snovault/tests/test_invalidation_scope.py
+++ b/snovault/tests/test_invalidation_scope.py
@@ -366,6 +366,126 @@ class TestInvalidationScopeUnit:
         assert abstract_item_type_child_types == ['AbstractItemTestSecondSubItem', 'AbstractItemTestSubItem']
 
 
+class _FakeTypeInfo:
+    """ Minimal stand-in for a registry TypeInfo: crawl_schema only needs `.schema`. """
+    def __init__(self, schema):
+        self.schema = schema
+
+
+class _FakeTypes:
+    """ Minimal stand-in for registry[TYPES]: crawl_schema only needs `.all[linkTo]`. """
+    def __init__(self, mapping):
+        self.all = mapping
+
+
+class _FakeRegistry:
+    """ Minimal registry that only answers registry['types'] (what crawl_schema uses).
+        All other registry access in filter_invalidation_scope goes through the
+        extract_*/determine_* helpers, which these tests mock out. """
+    def __init__(self, types):
+        self._types = types
+
+    def __getitem__(self, key):
+        if key == 'types':
+            return self._types
+        raise KeyError(key)
+
+
+class TestInvalidationScopeNestedLinkUnit:
+    """ Regression coverage for the false negative where a linkTo nested inside an object or
+        array-of-objects on an intermediate linked item was not recognized as lying on an embed
+        path to a deeper leaf, so embedders were wrongly pruned and kept a stale ES document.
+
+        These drive the REAL filter_invalidation_scope + crawl_schema against a small fake type
+        registry (no ES/Postgres needed): an 'Embedder' type embeds through a leading linkTo into
+        an 'Intermediate' type whose nested link points at a 'Leaf' type. The edit repoints that
+        nested link on 'Intermediate' (the exact shape DiffManager produces for a nested-object or
+        array-of-object linkTo patch, with array subscripts elided). """
+
+    EMBEDDER = 'Embedder'
+    INTERMEDIATE = 'Intermediate'
+    LEAF = 'Leaf'
+
+    LEAF_SCHEMA = {'properties': {'name': {'type': 'string'}, 'other': {'type': 'string'}}}
+
+    # Intermediate reached via leading linkTo 'leading_link'; it holds the nested link two ways.
+    OBJECT_INTERMEDIATE_SCHEMA = {
+        'properties': {
+            'meta': {
+                'type': 'object',
+                'properties': {
+                    'owner': {'type': 'string', 'linkTo': LEAF},
+                    'sibling': {'type': 'string', 'linkTo': LEAF},
+                }
+            }
+        }
+    }
+    ARRAY_INTERMEDIATE_SCHEMA = {
+        'properties': {
+            'samples': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'associated': {'type': 'string', 'linkTo': LEAF},
+                        'sibling': {'type': 'string', 'linkTo': LEAF},
+                    }
+                }
+            }
+        }
+    }
+
+    EMBEDDER_SCHEMA = {'leading_link': {'type': 'string', 'linkTo': INTERMEDIATE}}
+
+    def _run(self, intermediate_schema, embedded_list, diff):
+        """ Returns len(secondary) after filtering a single Embedder uuid. """
+        registry = _FakeRegistry(_FakeTypes({
+            self.INTERMEDIATE: _FakeTypeInfo(intermediate_schema),
+            self.LEAF: _FakeTypeInfo(self.LEAF_SCHEMA),
+        }))
+        invalidated = [(UUID1, self.EMBEDDER)]
+        secondary = {UUID1}
+        with invalidation_scope_mocks(schema=self.EMBEDDER_SCHEMA, embedded_list=embedded_list,
+                                      base_types=[], child_types=[]):
+            filter_invalidation_scope(registry, diff, invalidated, secondary)
+        return len(secondary)
+
+    def test_nested_object_link_edit_invalidates(self):
+        """ Editing meta.owner (nested-object linkTo) on Intermediate must invalidate an embedder
+            of leading_link.meta.owner.name. """
+        assert self._run(self.OBJECT_INTERMEDIATE_SCHEMA,
+                         ['leading_link.meta.owner.name'],
+                         [self.INTERMEDIATE + '.meta.owner']) == 1
+
+    def test_array_of_object_link_edit_invalidates(self):
+        """ Editing samples.associated (array-of-object linkTo) on Intermediate must invalidate an
+            embedder of leading_link.samples.associated.name. """
+        assert self._run(self.ARRAY_INTERMEDIATE_SCHEMA,
+                         ['leading_link.samples.associated.name'],
+                         [self.INTERMEDIATE + '.samples.associated']) == 1
+
+    def test_nested_object_sibling_link_edit_does_not_invalidate(self):
+        """ True negative: editing a sibling nested link (meta.sibling) that is not on the embed
+            path must NOT invalidate. """
+        assert self._run(self.OBJECT_INTERMEDIATE_SCHEMA,
+                         ['leading_link.meta.owner.name'],
+                         [self.INTERMEDIATE + '.meta.sibling']) == 0
+
+    def test_array_of_object_sibling_link_edit_does_not_invalidate(self):
+        """ True negative (array variant): editing samples.sibling must NOT invalidate an embedder
+            of leading_link.samples.associated.name. """
+        assert self._run(self.ARRAY_INTERMEDIATE_SCHEMA,
+                         ['leading_link.samples.associated.name'],
+                         [self.INTERMEDIATE + '.samples.sibling']) == 0
+
+    def test_token_boundary_prefix_does_not_invalidate(self):
+        """ The prefix match is token-bounded (field + '.'), so a diff that is a bare string prefix
+            of a path token (meta.own vs meta.owner) must NOT invalidate. """
+        assert self._run(self.OBJECT_INTERMEDIATE_SCHEMA,
+                         ['leading_link.meta.owner.name'],
+                         [self.INTERMEDIATE + '.meta.own']) == 0
+
+
 ###########################################################
 # Tests based on actual views defined in testing_views.py #
 ###########################################################
@@ -591,6 +711,29 @@ class TestingInvalidationScopeIntegrated:
         secondary = {obj['@id'] for obj in groups}
         with type_embedded_list_mock(embedded_list=['sources.sample_objects.notes']):
             self.runtest(testapp, diff, invalidated, secondary, 1)
+
+    def test_invalidation_scope_integrated_nested_array_link_edit(self, testapp, invalidation_scope_workbook):
+        """ Regression (real schemas) for the nested array-of-object link false negative: patching
+            biosource.sample_objects.associated_sample (repointing the nested linkTo) must invalidate
+            a biogroup that embeds through it via sources.sample_objects.associated_sample.alias -
+            editing the nested link changes the embedded alias, so the embedder must be re-indexed. """
+        groups, _, _, _ = invalidation_scope_workbook
+        diff = ['TestingBiosourceSno.sample_objects.associated_sample']
+        invalidated = [(obj['@id'], obj['@type'][0]) for obj in groups]
+        secondary = {obj['@id'] for obj in groups}
+        with type_embedded_list_mock(embedded_list=['sources.sample_objects.associated_sample.alias']):
+            self.runtest(testapp, diff, invalidated, secondary, 1)
+
+    def test_invalidation_scope_integrated_nested_array_sibling_edit(self, testapp, invalidation_scope_workbook):
+        """ True negative companion to the above: patching a sibling nested field (sample_objects.notes)
+            that is not on the sources.sample_objects.associated_sample.alias embed path must NOT
+            invalidate the biogroup. """
+        groups, _, _, _ = invalidation_scope_workbook
+        diff = ['TestingBiosourceSno.sample_objects.notes']
+        invalidated = [(obj['@id'], obj['@type'][0]) for obj in groups]
+        secondary = {obj['@id'] for obj in groups}
+        with type_embedded_list_mock(embedded_list=['sources.sample_objects.associated_sample.alias']):
+            self.runtest(testapp, diff, invalidated, secondary, 0)
 
     @pytest.mark.parametrize('diff,expected', [
         (['TestingNoteSno.superseding_note'], 2),


### PR DESCRIPTION
## Summary

Fixes a confirmed under-invalidation defect in `filter_invalidation_scope`
(`snovault/elasticsearch/indexer_utils.py`). When a changed item repoints a
`linkTo` field **nested inside an object or array-of-objects**, embedders that
embed *through* that nested link to a deeper leaf were wrongly pruned from
secondary re-indexing and kept a **stale Elasticsearch document**.

Concretely: an edit producing the diff `TestingBiosourceSno.sample_objects.associated_sample`
did not match an embed like `sources.sample_objects.associated_sample.alias`,
because the field-match loop only recognized a diff as on-path via an exact
terminal match or a single-token top-level link (`field in split_embed`). A
nested link is a multi-token string, so it matched neither.

## Fix

Add a token-boundary prefix case to the match loop:

```python
if terminal_field == field or terminal_field.startswith(field + '.'):
```

The `field + '.'` guard keeps this a token-boundary prefix (not an unbounded
string prefix), so a diff `associated_sample` still does not match a sibling
`associated_sample_other`. Behavior is unchanged for direct links, leaf edits,
wildcard (`*`) embeds, parent/child abstract types, default embeds,
creates/deletes, and reverse links (all confirmed by the existing passing tests).

## Tests

Added to `snovault/tests/test_invalidation_scope.py`:

- **`TestInvalidationScopeNestedLinkUnit`** — service-free unit tests driving the
  real `filter_invalidation_scope`/`crawl_schema` against a small fake type
  registry, covering **both** the nested-object and array-of-object link edits,
  plus a true-negative sibling field and a token-boundary case. The two positive
  tests fail on the pre-fix code and pass with the fix; the true-negatives pass
  either way.
- Two integrated tests over the real `sample_objects.associated_sample` biosource
  schema shape (positive + true-negative sibling).

The pre-existing `TestInvalidationScopeUnit` class remains `@pytest.mark.skip`:
its mocks predate the current backtracking matcher and crawl into fake `linkTo`
target types that are not registered, so repairing it was out of scope here.

Version bumped to `11.35.2` with a `CHANGELOG.rst` entry; `AGENTS.md`/`CLAUDE.md`
updated with the token-boundary matcher contract and the skipped-class caveat.

## Verification

- `pytest snovault/tests/test_invalidation_scope.py` → 30 passed, 28 skipped.
- New unit tests fail with the fix reverted (confirmed they discriminate the bug).
- `flake8 snovault/` clean; `-m static` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)