### PR TITLE
Disallow skip_links on persisting requests; fix loadxl validate_only+patch_only write

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,6 +394,25 @@ exists receives one conservative full type reindex the first time selective mode
 enabled; subsequent unchanged deployments can skip it. See
 `snovault/tests/test_selective_reindex.py` for the decision matrix.
 
+## `skip_links` is only legal on non-persisting (`check_only=true`) requests
+
+`skip_links=true` makes the schema machinery tolerate unresolvable `linkTo` values, so honoring it
+on a write would store links that were never validated. `snovault/schema_validation.py::parse_skip_links`
+is the **single** parse point (pyramid `asbool` over `request.params`; never raw-URL/substring
+matching) and raises `HTTPBadRequest` when `skip_links` is true without `check_only=true`. It is
+called from `schema_utils.linkTo`, `schema_validation.normalize_links`, and the top of
+`crud_views.collection_add`/`item_edit` — the view-level calls are load-bearing, because
+`validate=false` and bodies with no `linkTo` fields never reach the schema machinery at all. Add new
+`skip_links` reads through this helper, not a fresh `asbool(...)`.
+
+Corollary in `loadxl.load_all_gen`: `validate_only` must issue every request with `check_only=true`.
+The round-two PATCH is reachable under `validate_only` only when `patch_only` is also set (round one
+otherwise leaves `second_round_items` empty), and it used to persist while sending `skip_links`.
+Tests: `snovault/tests/test_post_put_patch.py` (`test_skip_links_*`, `test_parse_skip_links_unit`)
+and `snovault/tests/test_loadxl_validate_only.py`. loadxl tests over the framework's own test types
+must pass `noset_last_modified=True` — those schemas have no `last_modified` mixin, so the injected
+field otherwise 422s.
+
 ## Maintaining this file
 
 Keep this file for knowledge useful to almost every future agent session in this project.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,9 +35,11 @@ Change Log
   one. The ordinary (not ``validate_only``) load path is unchanged and still writes.
 
 * Regression coverage in ``snovault/tests/test_post_put_patch.py`` (rejected/accepted cases,
-  ``validate=false``, exact ``asbool`` parameter parsing, unit coverage of ``parse_skip_links``)
-  and ``snovault/tests/test_loadxl_validate_only.py`` (the ``validate_only``/``patch_only``
-  boundary, asserted against the stored item and its revision history).
+  ``validate=false``, exact ``asbool`` parameter parsing, unit coverage of ``parse_skip_links``,
+  and a test pinning that the schema-level sites themselves go through it) and
+  ``snovault/tests/test_loadxl_validate_only.py`` (the ``validate_only``/``patch_only`` boundary
+  asserted against the stored item and its revision history, plus round one's sanctioned
+  ``check_only=true&skip_links=true`` existing-item validation PATCH).
 
 11.35.2
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,39 @@ snovault
 Change Log
 ----------
 
+11.36.0
+=======
+
+* Disallow ``skip_links=true`` on every persisting request.
+
+  ``skip_links=true`` tells the schema machinery to tolerate unresolvable ``linkTo`` values. That
+  is legitimate only for callers doing partial/out-of-order validation that never writes (notably
+  smaht-submitr), but nothing stopped it from riding along on a real POST/PUT/PATCH, which would
+  persist items whose links were never validated.
+
+  * New single parse point ``snovault/schema_validation.py::parse_skip_links`` (plus
+    ``is_check_only_request``). It parses the request parameter with pyramid's ``asbool`` - no raw
+    URL or substring inspection - and raises ``HTTPBadRequest`` (HTTP 400) when ``skip_links``
+    is true without ``check_only=true``, instead of silently honoring or silently ignoring it.
+  * Applied at every generic use: ``schema_utils.linkTo`` (generic link validation),
+    ``schema_validation.normalize_links`` (link normalization), and the top of
+    ``crud_views.collection_add`` / ``crud_views.item_edit`` so the contract also holds for
+    requests that never reach link validation (e.g. ``validate=false``, or a body with no links).
+  * The supported non-persisting workflow is unchanged: ``skip_links=true`` together with
+    ``check_only=true`` still validates without writing and still defers link checks.
+
+* ``loadxl``: fix ``validate_only`` + ``patch_only`` persisting updates while claiming to be
+  validation-only. With both set, round one is skipped and every item is handled by the round-two
+  PATCH, which was issued without ``check_only=true`` - a genuine write, and the one place snovault
+  itself sent ``skip_links`` on a write. The round-two PATCH is now issued with ``check_only=true``
+  whenever ``validate_only`` is set, and reports ``CHECK:`` rather than ``PATCH:`` to match round
+  one. The ordinary (not ``validate_only``) load path is unchanged and still writes.
+
+* Regression coverage in ``snovault/tests/test_post_put_patch.py`` (rejected/accepted cases,
+  ``validate=false``, exact ``asbool`` parameter parsing, unit coverage of ``parse_skip_links``)
+  and ``snovault/tests/test_loadxl_validate_only.py`` (the ``validate_only``/``patch_only``
+  boundary, asserted against the stored item and its revision history).
+
 11.35.2
 =======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,8 @@ snovault
 Change Log
 ----------
 
-11.36.0
-=======
+11.36.0.0b1
+===========
 
 * Disallow ``skip_links=true`` on every persisting request.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.36.0"
+version = "11.36.0.0b1"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.35.2"
+version = "11.36.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/crud_views.py
+++ b/snovault/crud_views.py
@@ -24,6 +24,7 @@ from .resources import (
     Collection,
     Item,
 )
+from .schema_validation import parse_skip_links
 from .util import debug_log
 from .validation import ValidationFailure
 from .validators import (
@@ -178,6 +179,10 @@ def render_item(request, context, render, return_uri_also=False):
 @debug_log
 def collection_add(context, request, render=None):
     '''Endpoint for adding a new Item.'''
+    # Rejects skip_links=true unless this is a non-persisting (check_only=true) request. Done here,
+    # and not only in the schema machinery, so the contract also holds for requests that never reach
+    # link validation at all - eg. validate=false, or a body containing no linkTo fields.
+    parse_skip_links(request)
     check_only = asbool(request.params.get('check_only', False))
     if check_only:
         return {
@@ -230,6 +235,8 @@ def item_edit(context, request, render=None):
     PATCH, always return a dummy response with `check_only=true` and do not
     actually modify the DB with `update_item`
     '''
+    # See collection_add: skip_links=true is only valid on a non-persisting request.
+    parse_skip_links(request)
     check_only = asbool(request.params.get('check_only', False))
     if check_only:
         return {

--- a/snovault/loadxl.py
+++ b/snovault/loadxl.py
@@ -426,6 +426,11 @@ def load_all_gen(testapp, inserts, docsdir, overwrite=True, itype=None, from_jso
         post_only (bool)   : if set to true posts full item no second round or lookup -
                              use with care - will not work if linkTos to items not in db yet
         skip_types (list)  : if set to a list of item files the process will ignore these files
+        validate_only (bool): if set to true no POST/PATCH persists anything; every request is
+                             made with check_only=true so only the validators run
+        skip_links (bool)  : if set to true, defer link (linkTo) integrity checking to the caller;
+                             only legal together with validate_only, as the server rejects
+                             skip_links=true on any request that is not check_only=true
     Yields:
         Bytes with information on POSTed/PATCHed items
 
@@ -601,6 +606,7 @@ def load_all_gen(testapp, inserts, docsdir, overwrite=True, itype=None, from_jso
                             # To be safe we will unconditionally do skip_links in this case;
                             # to get away with not doing this would require more analysis.
                             # See: https://github.com/4dn-dcic/snovault/pull/283
+                            # Legal because check_only=true above already makes this non-persisting.
                             validate_patch_path += "&skip_links=true"
                             try:
                                 progress(PROGRESS.PATCH) if progress else None
@@ -701,13 +707,20 @@ def load_all_gen(testapp, inserts, docsdir, overwrite=True, itype=None, from_jso
                 if not identifying_path:
                     raise Exception("Item has no uuid nor any other identifying property; cannot PATCH.")
                 normalized_item, deleted_properties = normalize_deleted_properties(an_item)
+                query_params = []
                 if deleted_properties:
-                    if validate_only and skip_links:
-                        identifying_path += f"?delete_fields={','.join(deleted_properties)}&skip_links=true"
-                    else:
-                        identifying_path += f"?delete_fields={','.join(deleted_properties)}"
-                elif validate_only and skip_links:
-                    identifying_path += f"?skip_links=true"
+                    query_params.append(f"delete_fields={','.join(deleted_properties)}")
+                if validate_only:
+                    # This round is normally unreachable in validate_only mode (round one leaves
+                    # second_round_items empty), EXCEPT when patch_only is also set, in which case
+                    # the items come from the patch_only branch above. Without check_only=true this
+                    # PATCH really persists, which both contradicts validate_only and would be the
+                    # one place snovault itself sends skip_links on a write. Make it non-persisting.
+                    query_params.append("check_only=true")
+                    if skip_links:
+                        query_params.append("skip_links=true")
+                if query_params:
+                    identifying_path += "?" + "&".join(query_params)
                 progress(PROGRESS.PATCH) if progress else None
                 res = testapp.patch_json(identifying_path, normalized_item)
                 assert res.status_code == 200
@@ -720,7 +733,9 @@ def load_all_gen(testapp, inserts, docsdir, overwrite=True, itype=None, from_jso
                     filename = " " + filename
                 else:
                     filename = ""
-                yield str.encode(f'PATCH: {identifying_value}{" " + a_type if verbose else ""}{filename}\n')
+                # Mirror round one: validate_only reports CHECK rather than PATCH, since nothing was written.
+                action = "CHECK" if validate_only else "PATCH"
+                yield str.encode(f'{action}: {identifying_value}{" " + a_type if verbose else ""}{filename}\n')
             except Exception as e:
                 progress(PROGRESS.ERROR) if progress else None
                 print('Patching {} failed. Patch body:\n{}\n\nError Message:\n{}'.format(

--- a/snovault/schema_utils.py
+++ b/snovault/schema_utils.py
@@ -10,12 +10,15 @@ import pkg_resources
 from datetime import datetime
 from dcicutils.misc_utils import ignored
 from dcicutils.bundle_utils import SchemaManager
-from snovault.schema_validation import SerializingSchemaValidator
+from snovault.schema_validation import (
+    SerializingSchemaValidator,
+    is_check_only_request,
+    parse_skip_links,
+)
 from jsonschema import FormatChecker
 from jsonschema import RefResolver
 from jsonschema.exceptions import ValidationError, RefResolutionError
 from pyramid.path import AssetResolver, caller_package
-from pyramid.settings import asbool
 from pyramid.threadlocal import get_current_request
 from pyramid.traversal import find_resource
 from uuid import UUID
@@ -277,8 +280,8 @@ def mixinSchemas(schema, resolver, key_name='properties'):
 def linkTo(validator, linkTo, instance, schema):
     # 2024-02-21/dmichaels:
     # New skip_links functionality for smaht-submitr since it does link integrity checking.
-    skip_links = (request := get_current_request()) and asbool(request.params.get('skip_links', False))
-    if skip_links:
+    # Only honored on check_only=true (non-persisting) requests; see parse_skip_links.
+    if parse_skip_links():
         return
     if not validator.is_type(instance, "string"):
         return
@@ -296,8 +299,7 @@ def linkTo(validator, linkTo, instance, schema):
     try:
         item = find_resource(base, instance.replace(':', '%3A'))
     except KeyError:
-        check_only = (request := get_current_request()) and asbool(request.params.get('check_only', False))
-        if not check_only:
+        if not is_check_only_request():
             error = "%r not found" % instance
             yield ValidationError(error)
         return

--- a/snovault/schema_validation.py
+++ b/snovault/schema_validation.py
@@ -2,12 +2,57 @@ from copy import deepcopy
 from jsonschema import Draft202012Validator
 from jsonschema import validators
 from jsonschema.exceptions import ValidationError
+from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.settings import asbool
 from pyramid.threadlocal import get_current_request
 from pyramid.traversal import find_resource
 
 
 NO_DEFAULT = object()
+
+SKIP_LINKS_PARAM = 'skip_links'
+CHECK_ONLY_PARAM = 'check_only'
+
+SKIP_LINKS_REQUIRES_CHECK_ONLY_MESSAGE = (
+    f"The '{SKIP_LINKS_PARAM}=true' request parameter defers link (linkTo) resolution and integrity"
+    f" checking, so it is only allowed on non-persisting validation requests."
+    f" Pass '{CHECK_ONLY_PARAM}=true' along with it, or drop '{SKIP_LINKS_PARAM}'."
+)
+
+
+def is_check_only_request(request=None) -> bool:
+    """ Returns True iff the given (or current) request carries check_only=true, meaning the
+        request runs validators but must not persist anything.
+    """
+    request = request if request is not None else get_current_request()
+    if request is None:
+        return False
+    return asbool(request.params.get(CHECK_ONLY_PARAM, False))
+
+
+def parse_skip_links(request=None) -> bool:
+    """ Single point of truth for the skip_links request parameter.
+
+        skip_links=true tells the schema machinery to tolerate unresolvable linkTo values, which is
+        legitimate only for callers doing partial/out-of-order validation that never writes (notably
+        smaht-submitr, via check_only=true). Honoring it on a request that actually persists would
+        write items whose links were never validated, so that combination is rejected outright with
+        an HTTP 400 rather than being silently honored (unsafe) or silently ignored (confusing).
+
+        Returns True if link checks may be deferred, False otherwise.
+        Raises HTTPBadRequest if skip_links=true is used without check_only=true.
+    """
+    request = request if request is not None else get_current_request()
+    if request is None:
+        return False
+    if not asbool(request.params.get(SKIP_LINKS_PARAM, False)):
+        return False
+    if not is_check_only_request(request):
+        raise HTTPBadRequest(
+            detail=SKIP_LINKS_REQUIRES_CHECK_ONLY_MESSAGE,
+            comment=SKIP_LINKS_REQUIRES_CHECK_ONLY_MESSAGE,
+        )
+    return True
 
 
 def get_resource_base(validator, linkTo):
@@ -22,7 +67,7 @@ def get_resource_base(validator, linkTo):
 
 
 def normalize_links(validator, links, linkTo):
-    skip_links = (request := get_current_request()) and asbool(request.params.get('skip_links', False))
+    skip_links = parse_skip_links()
     resource_base = get_resource_base(validator, linkTo)
     normalized_links = []
     errors = []
@@ -49,6 +94,8 @@ def normalize_links(validator, links, linkTo):
             # 2024-02-21/dmichaels:
             # If skip_links then ignore reference/linkTo errors.
             # Currently ONLY used by smaht-submitr (via smaht-portal/loadxl_extensions.py).
+            # See parse_skip_links: this can only be set on a check_only=true (non-persisting)
+            # request, so a real write never stores links that were never resolved.
 
             if not skip_links:
                 errors.append(

--- a/snovault/tests/test_loadxl_validate_only.py
+++ b/snovault/tests/test_loadxl_validate_only.py
@@ -93,3 +93,22 @@ def test_loadxl_validate_only_creates_nothing(testapp, external_tx):
     assert not any(line.startswith('ERROR:') for line in output)
     assert any(line.startswith('CHECK:') for line in output)
     testapp.get(f'/{uuid}', status=404)
+
+
+def test_loadxl_validate_only_existing_item_uses_check_only_skip_links(testapp, loadxl_item):
+    """ The primary sanctioned skip_links use in the tree: round one's existing-item validation
+        PATCH (loadxl.py, ?check_only=true&skip_links=true). It must stay legal under the new
+        contract and must still not persist.
+    """
+    store = {ITEM_TYPE: [{'uuid': EXISTING_ITEM['uuid'],
+                          'required': 'never written',
+                          'simple1': 'never written'}]}
+    output = run_load_all_gen(testapp, store, overwrite=True, validate_only=True, skip_links=True)
+
+    assert not any(line.startswith('ERROR:') for line in output)
+    # the item already exists, so round one takes the SKIP path (which issues the check_only PATCH)
+    assert any(line.startswith('SKIP:') for line in output)
+
+    res = testapp.get(loadxl_item)
+    assert res.json['required'] == EXISTING_ITEM['required']
+    assert res.json['simple1'] == 'simple1 default'

--- a/snovault/tests/test_loadxl_validate_only.py
+++ b/snovault/tests/test_loadxl_validate_only.py
@@ -1,0 +1,95 @@
+import pytest
+
+from dcicutils.qa_utils import notice_pytest_fixtures
+
+from ..loadxl import load_all_gen
+
+
+pytestmark = [pytest.mark.setone, pytest.mark.working]
+
+
+COLLECTION_URL = '/testing-post-put-patch-sno/'
+ITEM_TYPE = 'testing_post_put_patch_sno'
+
+EXISTING_ITEM = {
+    'uuid': 'a8a1e6dc-2ea2-4b5b-8d0d-0d1b06e3cd44',
+    'required': 'original required value',
+}
+
+
+@pytest.fixture
+def loadxl_item(testapp, external_tx):
+    notice_pytest_fixtures(external_tx)
+    res = testapp.post_json(COLLECTION_URL, EXISTING_ITEM, status=201)
+    return res.json['@graph'][0]['@id']
+
+
+def run_load_all_gen(testapp, store, **kwargs):
+    """ Drains the load_all_gen generator, returning its (decoded) yielded lines.
+
+        noset_last_modified because the testing item types here do not mixin last_modified.
+    """
+    return [line.decode('utf-8') if isinstance(line, bytes) else line
+            for line in load_all_gen(testapp, store, None, from_json=True,
+                                     noset_last_modified=True, **kwargs)]
+
+
+def test_loadxl_validate_only_with_patch_only_does_not_persist(testapp, loadxl_item):
+    """ validate_only + patch_only skips round one entirely, so every item is handled by the
+        round two PATCH. That PATCH must not write anything - previously it did, while also
+        sending skip_links, which is exactly the "claims validation-only but persists" case.
+    """
+    store = {ITEM_TYPE: [{'uuid': EXISTING_ITEM['uuid'],
+                          'required': 'mutated by validate_only run',
+                          'simple1': 'mutated by validate_only run'}]}
+    output = run_load_all_gen(testapp, store, overwrite=True, validate_only=True, patch_only=True,
+                              skip_links=True)
+
+    assert not any(line.startswith('ERROR:') for line in output)
+    assert any(line.startswith('CHECK:') for line in output)
+    assert not any(line.startswith('PATCH:') for line in output)
+
+    # nothing was written
+    res = testapp.get(loadxl_item)
+    assert res.json['required'] == EXISTING_ITEM['required']
+    assert res.json['simple1'] == 'simple1 default'
+    revisions = testapp.get(loadxl_item + '@@revision-history').json['revisions']
+    assert len(revisions) == 1
+
+
+def test_loadxl_validate_only_without_skip_links_also_does_not_persist(testapp, loadxl_item):
+    """ Same boundary, without skip_links: validate_only must still be non-persisting. """
+    store = {ITEM_TYPE: [{'uuid': EXISTING_ITEM['uuid'],
+                          'required': 'mutated by validate_only run'}]}
+    output = run_load_all_gen(testapp, store, overwrite=True, validate_only=True, patch_only=True)
+
+    assert not any(line.startswith('ERROR:') for line in output)
+    assert testapp.get(loadxl_item).json['required'] == EXISTING_ITEM['required']
+
+
+def test_loadxl_normal_patch_round_still_persists(testapp, loadxl_item):
+    """ The ordinary (not validate_only) load path is unchanged and still writes. """
+    store = {ITEM_TYPE: [{'uuid': EXISTING_ITEM['uuid'],
+                          'required': 'updated by loadxl',
+                          'simple1': 'updated by loadxl'}]}
+    output = run_load_all_gen(testapp, store, overwrite=True, patch_only=True)
+
+    assert not any(line.startswith('ERROR:') for line in output)
+    assert any(line.startswith('PATCH:') for line in output)
+    res = testapp.get(loadxl_item)
+    assert res.json['required'] == 'updated by loadxl'
+    assert res.json['simple1'] == 'updated by loadxl'
+
+
+def test_loadxl_validate_only_creates_nothing(testapp, external_tx):
+    """ validate_only over an item that does not exist yet validates via check_only POST and
+        creates nothing.
+    """
+    notice_pytest_fixtures(external_tx)
+    uuid = 'b7b1e6dc-2ea2-4b5b-8d0d-0d1b06e3cd45'
+    store = {ITEM_TYPE: [{'uuid': uuid, 'required': 'never written'}]}
+    output = run_load_all_gen(testapp, store, overwrite=True, validate_only=True, skip_links=True)
+
+    assert not any(line.startswith('ERROR:') for line in output)
+    assert any(line.startswith('CHECK:') for line in output)
+    testapp.get(f'/{uuid}', status=404)

--- a/snovault/tests/test_post_put_patch.py
+++ b/snovault/tests/test_post_put_patch.py
@@ -366,3 +366,153 @@ def test_create_es_item_without_es(content, testapp):
     target_data = {'name': 'es_target_test'}
     res = testapp.post_json('/testing-link-targets-elastic-search/', target_data, status=500)
     assert res.json['detail'] == 'Forced datastore elasticsearch is not configured'
+
+
+LINK_SOURCE_URL = '/testing-link-sources-sno/'
+UNRESOLVABLE_LINK = 'c0ffee00-0000-4000-8000-000000000bad'
+
+
+def test_skip_links_rejected_without_check_only(content, testapp):
+    """ skip_links=true defers link integrity checking, so it may never ride along on a request
+        that actually persists - such a request is a 400, not a silent skip.
+    """
+    url = content['@id']
+    for query in ['?skip_links=true', '?skip_links=true&check_only=false',
+                  '?skip_links=true&delete_fields=field_no_default']:
+        res = testapp.patch_json(url + query, {'simple1': 'supplied simple1'}, status=400)
+        assert 'check_only=true' in res.json['detail']
+        res = testapp.put_json(url + query, item_with_uuid[0], status=400)
+        assert 'check_only=true' in res.json['detail']
+    testapp.post_json(COLLECTION_URL + '?skip_links=true', {'required': ''}, status=400)
+    # The item was not modified by any of the above.
+    assert testapp.get(url).json['simple1'] == 'simple1 default'
+
+
+def test_skip_links_rejected_without_check_only_on_unvalidated_write(content, testapp):
+    """ validate=false skips the schema machinery entirely, so this case is caught only by the
+        view level guard - without it skip_links would be silently ignored here.
+    """
+    url = content['@id']
+    testapp.patch_json(url + '?validate=false&skip_links=true', {'simple1': 'supplied simple1'},
+                       status=400)
+    testapp.put_json(url + '?validate=false&skip_links=true', item_with_uuid[0], status=400)
+    testapp.post_json(COLLECTION_URL + '?validate=false&skip_links=true', {'required': ''},
+                      status=400)
+    assert testapp.get(url).json['simple1'] == 'simple1 default'
+
+
+def test_skip_links_rejected_on_write_with_unresolvable_link(testapp, link_targets):
+    """ The pre-existing failure mode: an unresolvable link plus skip_links used to be written
+        through as-is. It is now a 400 and nothing is created.
+    """
+    notice_pytest_fixtures(link_targets)
+    testapp.post_json(LINK_SOURCE_URL + '?skip_links=true',
+                      {'name': 'skip-links-write', 'target': UNRESOLVABLE_LINK}, status=400)
+    testapp.get('/testing-link-sources-sno/skip-links-write', status=404)
+
+
+def test_skip_links_allowed_with_check_only(content, testapp, link_targets):
+    """ The supported (non-persisting) partial validation workflow still works, and still defers
+        link checks.
+    """
+    notice_pytest_fixtures(link_targets)
+    url = content['@id']
+    query = '?check_only=true&skip_links=true'
+
+    # POST of an item whose link cannot be resolved validates cleanly and creates nothing
+    res = testapp.post_json(LINK_SOURCE_URL + query,
+                            {'name': 'skip-links-check', 'target': UNRESOLVABLE_LINK}, status=200)
+    assert res.json['status'] == 'success'
+    assert res.json['@type'] == ['result']
+    testapp.get('/testing-link-sources-sno/skip-links-check', status=404)
+
+    # PATCH and PUT likewise validate without persisting
+    res = testapp.patch_json(url + query, {'simple1': 'supplied simple1'}, status=200)
+    assert res.json['status'] == 'success'
+    res = testapp.put_json(url + query, item_with_uuid[0], status=200)
+    assert res.json['status'] == 'success'
+    assert testapp.get(url).json['simple1'] == 'simple1 default'
+
+    # and without skip_links the unresolvable link is still reported
+    res = testapp.post_json(LINK_SOURCE_URL + '?check_only=true',
+                            {'name': 'skip-links-check-2', 'target': UNRESOLVABLE_LINK},
+                            status=422)
+    assert any('Unable to resolve link' in error['description'] for error in res.json['errors'])
+
+
+def test_skip_links_absent_or_false_does_not_disturb_normal_writes(content, testapp):
+    """ Normal create/update, with and without an explicitly false skip_links, is unaffected. """
+    url = content['@id']
+    res = testapp.patch_json(url, {'simple1': 'supplied simple1'}, status=200)
+    assert res.json['@graph'][0]['simple1'] == 'supplied simple1'
+    res = testapp.patch_json(url + '?skip_links=false', {'simple2': 'supplied simple2'},
+                             status=200)
+    assert res.json['@graph'][0]['simple2'] == 'supplied simple2'
+    res = testapp.post_json(COLLECTION_URL + '?skip_links=0', {'required': 'required value'},
+                            status=201)
+    assert res.json['@graph'][0]['required'] == 'required value'
+
+
+@pytest.mark.parametrize('value,rejected', [
+    ('true', True),
+    ('True', True),
+    ('TRUE', True),
+    ('t', True),
+    ('1', True),
+    ('yes', True),
+    ('on', True),
+    ('false', False),
+    ('False', False),
+    ('0', False),
+    ('no', False),
+    ('', False),
+    ('banana', False),  # pyramid asbool treats anything unrecognized as False
+])
+def test_skip_links_parameter_parsing(content, testapp, value, rejected):
+    """ Parsing is exactly pyramid's asbool over the parsed query parameter - no substring or raw
+        URL matching, so `skip_links=banana` is False (allowed) rather than merely "present".
+    """
+    url = content['@id']
+    status = 400 if rejected else 200
+    testapp.patch_json(f'{url}?skip_links={value}', {'simple1': 'supplied simple1'}, status=status)
+
+
+def test_skip_links_parameter_parsing_not_fooled_by_lookalike_params(content, testapp):
+    """ A parameter merely containing the name, or a check_only lookalike, is not the parameter. """
+    url = content['@id']
+    # not skip_links at all
+    testapp.patch_json(url + '?no_skip_links=true', {'simple1': 'supplied simple1'}, status=200)
+    # check_only must itself parse as true to license skip_links
+    testapp.patch_json(url + '?skip_links=true&check_only=banana', {'simple1': 'x'}, status=400)
+    testapp.patch_json(url + '?skip_links=true&check_only=1', {'simple1': 'x'}, status=200)
+
+
+def test_parse_skip_links_unit():
+    """ Unit level coverage of the single parse point used by both the views and the schema
+        machinery (generic linkTo validation and link normalization).
+    """
+    from pyramid.httpexceptions import HTTPBadRequest
+    from snovault.schema_validation import is_check_only_request, parse_skip_links
+
+    class FakeRequest:
+        def __init__(self, **params):
+            self.params = params
+
+    # no request at all (eg. non-request contexts) is simply False, never an error
+    assert parse_skip_links(None) is False
+
+    assert parse_skip_links(FakeRequest()) is False
+    assert parse_skip_links(FakeRequest(skip_links='false')) is False
+    assert parse_skip_links(FakeRequest(skip_links='true', check_only='true')) is True
+    assert parse_skip_links(FakeRequest(skip_links='1', check_only='yes')) is True
+    # skip_links=false does not need check_only, even on a persisting request
+    assert parse_skip_links(FakeRequest(skip_links='no', check_only='false')) is False
+
+    with pytest.raises(HTTPBadRequest):
+        parse_skip_links(FakeRequest(skip_links='true'))
+    with pytest.raises(HTTPBadRequest):
+        parse_skip_links(FakeRequest(skip_links='true', check_only='false'))
+
+    assert is_check_only_request(FakeRequest(check_only='true')) is True
+    assert is_check_only_request(FakeRequest()) is False
+    assert is_check_only_request(None) is False

--- a/snovault/tests/test_post_put_patch.py
+++ b/snovault/tests/test_post_put_patch.py
@@ -516,3 +516,29 @@ def test_parse_skip_links_unit():
     assert is_check_only_request(FakeRequest(check_only='true')) is True
     assert is_check_only_request(FakeRequest()) is False
     assert is_check_only_request(None) is False
+
+
+def test_schema_level_sites_enforce_skip_links_contract():
+    """ Pins that the generic link validation and link normalization sites themselves go through
+        parse_skip_links - the view level guard alone would not cover validation entry points
+        outside collection_add/item_edit (eg. authentication.create_unauthorized_user,
+        embed.validate_request, or a downstream app's own views).
+    """
+    from pyramid import testing
+    from pyramid.httpexceptions import HTTPBadRequest
+    from pyramid.threadlocal import get_current_request
+    from snovault.schema_utils import linkTo
+    from snovault.schema_validation import normalize_links
+
+    testing.setUp(request=testing.DummyRequest(params={'skip_links': 'true'}))
+    try:
+        # guard against a vacuous pass if the threadlocal was not actually pushed
+        assert get_current_request() is not None
+
+        # both guards are the first statement in their function, before any registry access
+        with pytest.raises(HTTPBadRequest):
+            list(linkTo(None, 'TestingLinkTargetSno', 'anything', {}))
+        with pytest.raises(HTTPBadRequest):
+            normalize_links(None, ['anything'], 'TestingLinkTargetSno')
+    finally:
+        testing.tearDown()


### PR DESCRIPTION
## Summary

Require `check_only=true` when using `skip_links`; persisting requests now receive HTTP 400. Fix the `validate_only + patch_only` path so it performs no writes.

## Release

Versioned as the public beta `11.36.0.0b1` (`pyproject.toml` and the `CHANGELOG.rst` heading), released from this branch under tag `11.36.0.0b1`.

Note: repository precedent for betas is to bump only `pyproject.toml` and leave the changelog heading at the target final version (e.g. `11.23.0.4b1` shipped under heading `11.24.0`). Both were bumped here as specified for this release. Before merge, the version must be bumped again to `11.36.0` — otherwise `main.yml`'s publish job reads `11.36.0.0b1`, finds the tag and the PyPI release already present, and never releases `11.36.0`.

## Tests

- Focused POST/PUT/PATCH and loadxl validation tests: 46 passed
- `flake8` and static tests passed
- `test_misc.py::test_version_and_changelog` passed; built sdist/wheel metadata reports exactly `11.36.0.0b1`

## Compatibility

`check_only=true&skip_links=true` remains supported. Clients using `skip_links=true` on writes must remove it or switch to a check-only request.

Supersedes the approach in #307, which depends on `skip_links` during writes.
