### PR TITLE
Configurable side-by-side authentication: stateless JWT vs Redis-backed session tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,44 @@ read` (needed by the `build` job's AWS OIDC auth); `contents: write` (needed to 
 tag) is scoped to the `publish` job only, since a job-level `permissions:` block replaces
 rather than merges with the workflow-level one.
 
+## Two authentication modes (stateless JWT vs. Redis session tokens)
+
+`snovault/authentication.py` implements two mutually exclusive authentication modes. Which
+one is active is decided **only** by configuration — `redis_is_active(request)`, i.e. whether
+`redis.server` is in settings, deliberately the same condition `snovault/__init__.py::main`
+uses to `config.include('snovault.redis')`. Never infer the mode by inspecting a token value.
+The contract itself is stated where it belongs, next to the code:
+`authentication.SESSION_TOKEN_MODE_NOTES` and `snovault/redis/README.rst`.
+
+Invariants worth knowing before touching this area:
+
+- Both modes use the same `jwtToken` cookie name (`SESSION_COOKIE_NAME`) so downstream
+  front-ends are unaffected, but in Redis mode its value is an opaque session token and is
+  **never** decoded as a JWT. A raw JWT presented in Redis mode is just an unknown Redis key.
+- Failure kinds must not collapse: token miss/expiry/revocation/malformation is a 401;
+  Redis being unreachable is `RedisSessionUnavailable` (503). Scope `except` clauses to
+  `REDIS_OPERATIONAL_ERRORS`, not `Exception` — `RedisSessionToken.from_redis` signals a miss
+  by returning `None`, not by raising.
+- `registry[REDIS]` can legitimately be `None`: `redis/redis_connection.py::includeme`
+  swallows startup connection errors and stores `None`. Always go through
+  `get_redis_handler`.
+- Anonymous requests return before touching Redis, so an outage cannot take down public
+  traffic. Preserve that ordering.
+- Identity in Redis mode is the email recorded at login, not a per-request JWT decode. That
+  is what keeps the RAS (RS256/`auth0.public.key`) flow working —
+  `Auth0AuthenticationPolicy.get_token_info` is Auth0-only (HS256/`auth0.secret`) — and keeps
+  session lifetime on exactly one clock, the Redis TTL. `from_redis` yields `''` (not `None`)
+  for a record stored without an email, so the JWT fallback must test truthiness.
+- `session_namespace(registry)` (`env.name` → `indexer.namespace` → constant) must be used at
+  every touchpoint; a writer/reader mismatch silently 401s every session and looks like a
+  token bug.
+
+Tests: `snovault/tests/test_redis_session_auth.py` drives both modes with a dict-backed
+`RedisBase` fake and locally-signed synthetic JWTs — no live Redis, no cloud credentials, no
+outbound Auth0 calls, and no DB. Note that raising an `HTTPException` from a Pyramid tween or
+from the authentication policy does become a proper response (verified); the excview tween's
+"can't catch tweens above it" caveat does not apply to `HTTPException` subclasses.
+
 ## Self-registration field whitelist (`create_unauthorized_user`)
 
 `snovault/authentication.py::create_unauthorized_user` (`POST /create-unauthorized-user`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,10 +147,18 @@ Invariants worth knowing before touching this area:
 - Both modes use the same `jwtToken` cookie name (`SESSION_COOKIE_NAME`) so downstream
   front-ends are unaffected, but in Redis mode its value is an opaque session token and is
   **never** decoded as a JWT. A raw JWT presented in Redis mode is just an unknown Redis key.
+- **All Redis behavior belongs to dcicutils** (`redis_utils` / `redis_tools`); snovault only
+  reads pyramid settings and translates outcomes into HTTP. Never reimplement connection,
+  token generation, key layout, TTL, rotation or revocation here. In particular never derive
+  `<namespace>:session:<token>` yourself — resolve the record via `from_redis` first, so that
+  layout exists in exactly one place. `snovault/redis/README.rst` has the delegation table.
 - Failure kinds must not collapse: token miss/expiry/revocation/malformation is a 401;
-  Redis being unreachable is `RedisSessionUnavailable` (503). Scope `except` clauses to
-  `REDIS_OPERATIONAL_ERRORS`, not `Exception` — `RedisSessionToken.from_redis` signals a miss
-  by returning `None`, not by raising.
+  Redis being unreachable is `RedisSessionUnavailable` (503). `RedisSessionToken.from_redis`
+  signals a miss by returning `None`, not by raising, so the distinction never rests on
+  exception types. Known upstream gap: dcicutils normalizes driver errors to `RedisException`
+  in `store_session_token` **only** — `from_redis`, `delete_session_token` and
+  `update_session_token` leak raw `redis.exceptions.*`, which is why
+  `REDIS_OPERATIONAL_ERRORS` still has to name `RedisError`. Drop it if that is fixed upstream.
 - `registry[REDIS]` can legitimately be `None`: `redis/redis_connection.py::includeme`
   swallows startup connection errors and stores `None`. Always go through
   `get_redis_handler`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,10 +155,15 @@ Invariants worth knowing before touching this area:
 - Failure kinds must not collapse: token miss/expiry/revocation/malformation is a 401;
   Redis being unreachable is `RedisSessionUnavailable` (503). `RedisSessionToken.from_redis`
   signals a miss by returning `None`, not by raising, so the distinction never rests on
-  exception types. Known upstream gap: dcicutils normalizes driver errors to `RedisException`
-  in `store_session_token` **only** — `from_redis`, `delete_session_token` and
-  `update_session_token` leak raw `redis.exceptions.*`, which is why
-  `REDIS_OPERATIONAL_ERRORS` still has to name `RedisError`. Drop it if that is fixed upstream.
+  exception types.
+- **Catch only `dcicutils.redis_utils.RedisException`** — never a `redis.exceptions.*` type.
+  Normalizing driver errors is dcicutils' job. As of dcicutils 8.19.0 only
+  `store_session_token` does so; `from_redis`, `delete_session_token` and
+  `update_session_token` still leak raw driver errors, so those paths currently yield an
+  untyped 500 instead of a 503. Snovault deliberately does **not** compensate for that
+  locally — an upstream fix is in progress. A `strict` xfail in
+  `test_redis_session_auth.py` fails loudly once it lands; the follow-up is to raise the
+  `dcicutils` floor in `pyproject.toml` and drop the marker. See `snovault/redis/README.rst`.
 - `registry[REDIS]` can legitimately be `None`: `redis/redis_connection.py::includeme`
   swallows startup connection errors and stores `None`. Always go through
   `get_redis_handler`.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,66 @@ snovault
 Change Log
 ----------
 
+11.36.0
+=======
+
+* Configurable side-by-side authentication (``snovault/authentication.py``). Snovault now supports
+  exactly two mutually exclusive authentication modes, selected by configuration alone -- the
+  presence of the ``redis.server`` setting, which is the same condition that decides whether
+  ``snovault.redis`` is included at all. The contract is stated in
+  ``authentication.SESSION_TOKEN_MODE_NOTES`` and in ``snovault/redis/README.rst``.
+
+  * **No Redis configured**: the existing stateless Auth0 JWT behavior is unchanged for login,
+    request authentication, registration, logout and cookie handling. ``/callback`` remains
+    refused.
+  * **Redis configured**: ``POST /login`` (the SPA flow the front-end actually uses) and
+    ``GET /callback`` verify the provider JWT once, store it in Redis under
+    ``<namespace>:session:<token>`` with a TTL, and return only an opaque session token. Previously
+    only ``/callback`` had any Redis implementation, so Redis mode was unreachable through the live
+    login flow.
+
+* Redis mode is now strict about failure kinds and cannot be bypassed:
+
+  * The caller-supplied credential is never decoded as a JWT, so a raw JWT presented as a cookie or
+    bearer token is just an unknown Redis key and is rejected. There is no fallback to the
+    stateless path once Redis mode is selected.
+  * Absent / unknown / expired / revoked / malformed session tokens are authentication failures
+    (401) and mark ``request.auth0_expired`` so ``renderers.py`` unsets the stale cookie.
+  * A Redis outage -- including the ``registry[REDIS] is None`` state that
+    ``redis/redis_connection.py::includeme`` leaves behind when it cannot connect at startup -- now
+    raises ``RedisSessionUnavailable`` (HTTP 503) rather than producing a ``500``/``AttributeError``
+    or silently misbehaving.
+  * Anonymous requests return before touching Redis, so an outage cannot take down unauthenticated
+    traffic.
+
+* Per-request authentication (``Auth0AuthenticationPolicy.unauthenticated_userid``) resolves the
+  session token to the identity recorded server-side before authorization. Previously it always
+  tried to decode the cookie as a JWT, so no authenticated request could succeed in Redis mode.
+  Identity comes from the email recorded at login; the server-held JWT is only decoded as a
+  fallback (which keeps the RAS/RS256 flow working and keeps session lifetime governed by exactly
+  one clock, the Redis TTL).
+
+* ``/logout`` now revokes the session server-side in Redis, and ``/login`` and ``/callback`` revoke
+  the caller's previous session before minting a new one. ``/impersonate-user`` wraps its minted
+  token in a session in Redis mode instead of setting a raw JWT cookie that could never resolve.
+
+* ``/callback`` repairs: ``auth0_response.json()`` was called on ``auth0_response`` while it was
+  still ``None`` (an unconditional crash on the Auth0 branch); ``registry.settings['env.name']`` and
+  ``registry[REDIS]`` were read without guards; and ``get_token_info(...).get(...)`` could raise on
+  a ``None`` return. Registration (``create-unauthorized-user``) likewise called
+  ``RedisSessionToken.from_redis(...).decode_jwt(...)`` without checking for the ``None`` returned
+  on a session miss.
+
+* Cookie/token handling is consolidated in ``set_session_cookie`` / ``get_auth_token`` behind the
+  ``SESSION_COOKIE_NAME`` constant so every touchpoint agrees. ``get_jwt`` is retained as a
+  delegating alias for downstream callers.
+
+* Testing: add ``snovault/tests/test_redis_session_auth.py`` -- 40 tests covering unchanged
+  no-Redis behavior, Redis-mode login/callback/authenticated request/registration/logout, expiry,
+  revocation, re-login, raw-JWT non-bypass, outage-vs-auth-failure distinction, and error messages
+  not leaking token values. Runs against a dict-backed ``RedisBase`` fake and locally-signed
+  synthetic JWTs: no live Redis, no cloud credentials and no outbound Auth0 calls.
+
 11.35.2
 =======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,7 +60,7 @@ Change Log
   ``SESSION_COOKIE_NAME`` constant so every touchpoint agrees. ``get_jwt`` is retained as a
   delegating alias for downstream callers.
 
-* Testing: add ``snovault/tests/test_redis_session_auth.py`` -- 40 tests covering unchanged
+* Testing: add ``snovault/tests/test_redis_session_auth.py`` -- 42 tests covering unchanged
   no-Redis behavior, Redis-mode login/callback/authenticated request/registration/logout, expiry,
   revocation, re-login, raw-JWT non-bypass, outage-vs-auth-failure distinction, and error messages
   not leaking token values. Runs against a dict-backed ``RedisBase`` fake and locally-signed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,11 +60,28 @@ Change Log
   ``SESSION_COOKIE_NAME`` constant so every touchpoint agrees. ``get_jwt`` is retained as a
   delegating alias for downstream callers.
 
-* Testing: add ``snovault/tests/test_redis_session_auth.py`` -- 42 tests covering unchanged
+* All Redis connection, session and token behavior is delegated to the canonical
+  ``dcicutils.redis_utils`` / ``dcicutils.redis_tools`` API; snovault contributes only pyramid
+  settings resolution and HTTP translation. ``create_session_token`` uses ``RedisSessionToken`` +
+  ``store_session_token``, ``resolve_session_token`` uses ``from_redis``, ``rotate_session_token``
+  uses ``update_session_token`` (dcicutils' own rotation primitive) and ``revoke_session_token``
+  uses ``delete_session_token``. In particular snovault never derives a Redis key itself:
+  revocation and rotation resolve the real record first, so the ``<namespace>:session:<token>``
+  layout exists only in dcicutils. See the delegation table in ``snovault/redis/README.rst``.
+
+* Known upstream gap (documented, not worked around): ``dcicutils.redis_tools`` normalizes driver
+  errors to ``RedisException`` in ``store_session_token`` only -- ``from_redis``,
+  ``delete_session_token`` and ``update_session_token`` leak raw ``redis.exceptions.*``. Since
+  ``from_redis`` is on the per-request authentication path, ``REDIS_OPERATIONAL_ERRORS`` must still
+  name ``redis.exceptions.RedisError`` or an outage would surface as an untyped 500 rather than the
+  contracted 503. That entry should be removed once dcicutils normalizes those three functions.
+
+* Testing: add ``snovault/tests/test_redis_session_auth.py`` -- 47 tests covering unchanged
   no-Redis behavior, Redis-mode login/callback/authenticated request/registration/logout, expiry,
   revocation, re-login, raw-JWT non-bypass, outage-vs-auth-failure distinction, and error messages
-  not leaking token values. Runs against a dict-backed ``RedisBase`` fake and locally-signed
-  synthetic JWTs: no live Redis, no cloud credentials and no outbound Auth0 calls.
+  not leaking token values, plus delegation tests pinning the canonical dcicutils primitives.
+  Runs against a dict-backed ``RedisBase`` fake and locally-signed synthetic JWTs: no live Redis,
+  no cloud credentials and no outbound Auth0 calls.
 
 11.35.2
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,14 +69,22 @@ Change Log
   revocation and rotation resolve the real record first, so the ``<namespace>:session:<token>``
   layout exists only in dcicutils. See the delegation table in ``snovault/redis/README.rst``.
 
-* Known upstream gap (documented, not worked around): ``dcicutils.redis_tools`` normalizes driver
-  errors to ``RedisException`` in ``store_session_token`` only -- ``from_redis``,
-  ``delete_session_token`` and ``update_session_token`` leak raw ``redis.exceptions.*``. Since
-  ``from_redis`` is on the per-request authentication path, ``REDIS_OPERATIONAL_ERRORS`` must still
-  name ``redis.exceptions.RedisError`` or an outage would surface as an untyped 500 rather than the
-  contracted 503. That entry should be removed once dcicutils normalizes those three functions.
+* Snovault catches only ``dcicutils.redis_utils.RedisException`` and holds no knowledge of the
+  redis driver's exception hierarchy; normalizing driver errors is dcicutils' responsibility.
+  As of dcicutils 8.19.0 that contract is only partly implemented -- ``store_session_token``
+  wraps its body in ``except Exception -> raise RedisException``, while ``from_redis``,
+  ``delete_session_token`` and ``update_session_token`` still let raw driver exceptions through.
+  A dcicutils change completing the contract is in progress and snovault deliberately does not
+  compensate for it locally.
 
-* Testing: add ``snovault/tests/test_redis_session_auth.py`` -- 47 tests covering unchanged
+  Interim behavior on the unnormalized paths is an untyped 500 rather than the intended 503 -- a
+  degraded error label, not a correctness hole: the failure is still 5xx, still logged, and is
+  never silently downgraded into an authentication failure or a stateless-JWT fallback. When the
+  dcicutils release lands, raise its floor in ``pyproject.toml`` and drop the ``strict`` xfail in
+  ``test_redis_session_auth.py``, which fails loudly at that moment so the follow-up cannot be
+  lost. See ``snovault/redis/README.rst``.
+
+* Testing: add ``snovault/tests/test_redis_session_auth.py`` -- 48 tests covering unchanged
   no-Redis behavior, Redis-mode login/callback/authenticated request/registration/logout, expiry,
   revocation, re-login, raw-JWT non-bypass, outage-vs-auth-failure distinction, and error messages
   not leaking token values, plus delegation tests pinning the canonical dcicutils primitives.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,12 @@ elasticsearch = "7.13.4"  # versions >= 7.14.0 lock out AWS ES
 elasticsearch_dsl = "^7.4.0"
 #python-3.12 elasticsearch = "^7.17.9"
 #python-3.12 elasticsearch_dsl = "^7.4.1"
+# NOTE: Redis session authentication (snovault/authentication.py) needs dcicutils to raise
+# RedisException for infrastructure failures across its whole session API. As of 8.19.0 only
+# store_session_token does; from_redis/delete_session_token/update_session_token still leak raw
+# driver errors. Snovault deliberately does not compensate locally. Raise this floor to the
+# release that completes that contract when it ships -- a strict xfail in
+# snovault/tests/test_redis_session_auth.py fails loudly at that moment.
 dcicutils = "^8.18.0"
 future = "^0.18.3"
 html5lib = ">=1.1"  # experimental, should be OK now that we're not using moto server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcicsnovault"
-version = "11.35.2"
+version = "11.36.0"
 description = "Storage support for 4DN Data Portals."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/snovault/authentication.py
+++ b/snovault/authentication.py
@@ -14,7 +14,7 @@ from pyramid.authentication import (
     BasicAuthAuthenticationPolicy as _BasicAuthAuthenticationPolicy,
     CallbackAuthenticationPolicy
 )
-from pyramid.httpexceptions import HTTPForbidden, HTTPUnauthorized
+from pyramid.httpexceptions import HTTPForbidden, HTTPServiceUnavailable, HTTPUnauthorized
 from pyramid.path import DottedNameResolver, caller_package
 from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.view import view_config
@@ -29,6 +29,8 @@ from snovault.validators import no_validate_item_content_post
 from urllib.parse import urlencode
 from snovault.redis.interfaces import REDIS
 from dcicutils.redis_tools import RedisSessionToken
+from dcicutils.redis_utils import RedisException
+from redis.exceptions import RedisError
 
 
 log = structlog.getLogger(__name__)
@@ -64,6 +66,40 @@ CONTENT_TYPE = "Content-Type"
 JSON_CONTENT_TYPE = "application/json"
 STANDARD_HEADERS = {CONTENT_TYPE: JSON_CONTENT_TYPE}
 
+# Name of the cookie carrying the caller's credential. Historically this always held a raw
+# Auth0 JWT; when Redis session configuration is present it instead holds an opaque, server-side
+# session token. The name is unchanged in both modes so downstream front-ends keep working, but
+# the *interpretation* is never ambiguous: it is decided solely by `redis_is_active(request)`,
+# i.e. by the presence of the `redis.server` setting - the same condition that decides whether
+# `snovault.redis` is even included (see snovault/__init__.py::main). See
+# `SESSION_TOKEN_MODE_NOTES` below for the full contract.
+SESSION_COOKIE_NAME = 'jwtToken'
+
+# Fallback namespace for Redis session keys when neither `env.name` nor `indexer.namespace` is
+# configured. Only reachable in local/test configurations; deployed environments always set one.
+DEFAULT_SESSION_NAMESPACE = 'snovault'
+
+# Redis failures we treat as *operational* (=> 5xx). Deliberately narrow: a cache miss is not an
+# error (RedisSessionToken.from_redis returns None), and a broad `except Exception` here would
+# collapse the exact distinction between "Redis is down" (5xx) and "this token is not valid"
+# (401) that the two-mode contract depends on.
+REDIS_OPERATIONAL_ERRORS = (RedisException, RedisError)
+
+SESSION_TOKEN_MODE_NOTES = """
+Snovault supports two mutually exclusive authentication modes, selected by configuration:
+
+1. Stateless JWT mode (no `redis.server` setting). The `jwtToken` cookie / `Authorization: Bearer`
+   value IS the Auth0 JWT. It is decoded and verified on every request. This is the historical
+   behavior and is unchanged.
+
+2. Redis session mode (`redis.server` configured). The `jwtToken` cookie / `Authorization: Bearer`
+   value is an opaque session token minted by `make_session_token()`. The Auth0 JWT never leaves
+   the server; it is stored in Redis under `<namespace>:session:<token>` with a TTL. In this mode
+   the server NEVER attempts to interpret the caller-supplied value as a JWT, and never falls back
+   to mode 1 - an unknown/expired/revoked/malformed token is an authentication failure (401) and a
+   Redis outage is an operational failure (503).
+"""
+
 
 def includeme(config):
     config.include('.edw_hash')
@@ -88,9 +124,180 @@ def includeme(config):
     config.add_route('callback', '/callback')
     config.scan(__name__)
 
+class RedisSessionUnavailable(HTTPServiceUnavailable):
+    """ Raised when Redis session mode is configured but the session store cannot be reached.
+
+        This is deliberately a 5xx: it is an operational failure of a required dependency, NOT an
+        authentication failure, and it must never be downgraded into a stateless-JWT fallback.
+    """
+    title = 'Session Store Unavailable'
+
+
 def redis_is_active(request):
-    """ Quick helper to standardize detecting whether redis is in use """
+    """ Quick helper to standardize detecting whether redis is in use.
+
+        NOTE: this intentionally mirrors the exact condition used in snovault/__init__.py::main to
+        decide whether to `config.include('snovault.redis')`, so mode selection can never disagree
+        with whether the Redis machinery was configured at all.
+    """
     return 'redis.server' in request.registry.settings
+
+
+def session_namespace(registry):
+    """ Resolves the Redis key namespace for session tokens.
+
+        Must be resolved identically at every touchpoint (login, callback, per-request auth,
+        registration, logout) - a mismatch would silently 401 every session.
+
+        `env.name` is preferred, but is deliberately NOT required: it is absent in test settings and
+        must stay absent there (a truthy `env.name` makes snovault.elasticsearch's includeme attempt
+        a blue/green mirror lookup that raises without an IDENTITY - see CLAUDE.md).
+    """
+    settings = registry.settings
+    return settings.get('env.name') or settings.get('indexer.namespace') or DEFAULT_SESSION_NAMESPACE
+
+
+def get_redis_handler(request):
+    """ Returns the RedisBase handle for this app, or raises RedisSessionUnavailable (503).
+
+        snovault/redis/redis_connection.py::includeme swallows connection errors at startup and
+        stores None, so a Redis that was unreachable at boot is indistinguishable from a healthy one
+        by looking at settings alone - it has to be caught here.
+    """
+    handler = request.registry.get(REDIS)
+    if handler is None:
+        log.error('Redis session mode is configured but no Redis connection is available')
+        raise RedisSessionUnavailable(
+            detail='Session store is not available. Authentication cannot be performed.'
+        )
+    return handler
+
+
+def resolve_session_token(request, token):
+    """ Resolves an opaque session token to its stored RedisSessionToken record.
+
+        Tri-state, and the distinction matters (each is separately asserted in the test suite):
+          * returns a RedisSessionToken  -> the session is live
+          * returns None                 -> absent / unknown / expired / revoked / malformed token,
+                                            i.e. an authentication failure. NO JWT decode is ever
+                                            attempted on the caller-supplied value, so a raw JWT
+                                            presented in Redis mode simply misses and is rejected.
+          * raises RedisSessionUnavailable -> Redis itself is unreachable (operational, 5xx)
+    """
+    if not token:
+        return None
+    handler = get_redis_handler(request)
+    try:
+        return RedisSessionToken.from_redis(
+            redis_handler=handler,
+            namespace=session_namespace(request.registry),
+            token=token
+        )
+    except REDIS_OPERATIONAL_ERRORS as e:
+        # Note: no token value in the log message - session tokens are credentials.
+        log.error(f'Redis error resolving session token: {type(e).__name__}: {e}')
+        raise RedisSessionUnavailable(
+            detail='Session store is not available. Authentication cannot be performed.'
+        )
+
+
+def create_session_token(request, *, jwt_token, email):
+    """ Mints and persists a new opaque session token wrapping the given (already validated) JWT. """
+    handler = get_redis_handler(request)
+    session = RedisSessionToken(
+        namespace=session_namespace(request.registry),
+        jwt=jwt_token,
+        email=email
+    )
+    try:
+        session.store_session_token(redis_handler=handler)
+    except REDIS_OPERATIONAL_ERRORS as e:
+        log.error(f'Redis error storing session token: {type(e).__name__}: {e}')
+        raise RedisSessionUnavailable(detail='Session store is not available. Cannot establish session.')
+    return session
+
+
+def revoke_session_token(request, token):
+    """ Deletes the given session token from Redis, immediately invalidating it server-side.
+
+        Constructs the key directly rather than reading the record first - revocation should not
+        depend on the record being readable, and it saves a round trip.
+    """
+    if not token:
+        return False
+    handler = get_redis_handler(request)
+    session = RedisSessionToken(
+        namespace=session_namespace(request.registry),
+        jwt='', email='', token=token
+    )
+    try:
+        return session.delete_session_token(redis_handler=handler)
+    except REDIS_OPERATIONAL_ERRORS as e:
+        log.error(f'Redis error revoking session token: {type(e).__name__}: {e}')
+        raise RedisSessionUnavailable(detail='Session store is not available. Cannot revoke session.')
+
+
+def decode_session_jwt(request, session):
+    """ Decodes the JWT held server-side by a resolved session, handling both the Auth0 (HS256 +
+        shared secret) and RAS (RS256 + public key) configurations. Returns None if it cannot be
+        decoded - callers must treat that as an authentication failure, not as an outage.
+    """
+    settings = request.registry.settings
+    auth0_domain = settings.get('auth0.domain') or ''
+    if 'auth0' in auth0_domain:
+        secret = settings.get('auth0.secret')
+        algorithms = JWT_DECODING_ALGORITHMS
+    else:  # RAS
+        secret = settings.get('auth0.public.key')
+        algorithms = ['RS256']
+    if not secret:
+        log.error('No key configured with which to decode the session JWT')
+        return None
+    try:
+        return session.decode_jwt(
+            audience=settings.get('auth0.client'),
+            secret=secret,
+            algorithms=algorithms
+        )
+    except jwt.exceptions.PyJWTError as e:
+        log.error(f'Could not decode JWT held by session: {type(e).__name__}: {e}')
+        return None
+
+
+def session_identity(request, session):
+    """ Returns the lower-cased email identifying a resolved session, or None.
+
+        The stored email is authoritative: it was established by a validated Auth0/RAS login before
+        the session was ever written, and using it (rather than re-decoding the JWT on every
+        request) keeps the session's lifetime governed by exactly one clock - the Redis TTL - and
+        keeps the RAS flow working, whose JWTs `Auth0AuthenticationPolicy.get_token_info` cannot
+        verify. The JWT is only consulted if no email was recorded.
+    """
+    email = session.get_email()
+    if email:  # note: from_redis yields '' (not None) when no email was stored
+        return email.lower()
+    jwt_info = decode_session_jwt(request, session)
+    if not jwt_info:
+        return None
+    email = jwt_info.get('email')
+    return email.lower() if email else None
+
+
+def set_session_cookie(request, value, *, samesite):
+    """ Sets the credential cookie. `value` is a raw JWT in stateless mode and an opaque session
+        token in Redis mode; see SESSION_TOKEN_MODE_NOTES.
+    """
+    request.response.set_cookie(
+        SESSION_COOKIE_NAME,
+        value=value,
+        domain=request.domain,
+        path='/',
+        httponly=True,
+        samesite=samesite,
+        overwrite=True,
+        secure=(request.scheme == 'https')
+    )
+
 
 @view_config(route_name='callback', request_method='GET', permission=NO_PERMISSION_REQUIRED)
 def callback(context, request):
@@ -102,7 +309,6 @@ def callback(context, request):
     auth0_code = request.params.get('code', None)
     if not auth0_code:
         raise HTTPForbidden('No code sent back from Auth0')
-    is_https = request.scheme == "https"
 
     # Acquire Auth0 configuration
     registry = request.registry
@@ -127,7 +333,6 @@ def callback(context, request):
         auth0_post_url = f'https://{auth0_domain}/oauth/token'
         auth0_payload_json = json.dumps(auth0_payload)
         auth0_headers = STANDARD_HEADERS
-        auth0_response_json = auth0_response.json()
         auth0_response = requests.post(auth0_post_url, data=auth0_payload_json, headers=auth0_headers)
     elif 'nih.gov' in auth0_domain:
         # RAS
@@ -139,34 +344,39 @@ def callback(context, request):
     else:
         raise HTTPForbidden('Unknown authentication domain, no callback possible')
    
-    auth0_response_json = auth0_response.json()
+    try:
+        auth0_response_json = auth0_response.json()
+    except ValueError:
+        raise LoginDenied('Malformed response from the authentication provider')
     auth0_jwt = auth0_response_json.get('id_token')
     if not auth0_jwt:
         raise LoginDenied('No JWT returned from Auth0, check Auth0 configuration')
-    
+
     # email
+    email = ''
     if 'auth0' in auth0_domain:
         # Check that the user exists in our database, if they do not, redirect them to /registration
-        email = Auth0AuthenticationPolicy.get_token_info(auth0_jwt, request).get('email', '').lower()
+        token_info = Auth0AuthenticationPolicy.get_token_info(auth0_jwt, request) or {}
+        email = (token_info.get('email') or '').lower()
     elif 'nih.gov' in auth0_domain:
         # In RAS authentication, user info is not included in the JWT token, but in a passport that requires an extra request.
         passport_post_url = f'https://{auth0_domain}/openid/connect/v1/userinfo'
         passport_headers = {'Authorization': f'Bearer {auth0_response_json["access_token"]}'}
         passport_response = requests.post(passport_post_url, headers=passport_headers)
         passport_response_json = passport_response.json()
-        email = passport_response_json.get('email', '').lower()
+        email = (passport_response_json.get('email') or '').lower()
 
     if not email:
         raise LoginDenied('No email extracted from JWT, not possible to continue')
-    
-    # Generate a session from Redis
-    redis_handler = registry[REDIS]
-    env_name = registry.settings['env.name']
-    redis_session_token = RedisSessionToken(
-        namespace=env_name,
-        jwt=auth0_jwt,
-        email=email
-    )
+
+    # Re-login: if the caller already holds a session token, revoke it before minting a new one so
+    # a single browser never leaves live orphaned sessions behind in Redis.
+    revoke_session_token(request, request.cookies.get(SESSION_COOKIE_NAME))
+
+    # Generate a session from Redis. Note this is stored *before* the DB lookup below: the token is
+    # issued unconditionally (see comment further down), and storing first keeps the "what is in
+    # Redis" and "what is in the cookie" answers identical on every exit path from here.
+    redis_session_token = create_session_token(request, jwt_token=auth0_jwt, email=email)
 
     try:
         Auth0AuthenticationPolicy.get_user_info(request, email, redis_session_token.get_session_token())
@@ -189,21 +399,15 @@ def callback(context, request):
             'title': 'callback'
     }
 
-    # Give a session token unconditionally so we can retrieve JWT later on
-    # in the registration scenario (if an unknown user) or make auth'd requests
-    # as an existing user
-    redis_session_token.store_session_token(redis_handler=redis_handler)
-    request.response.set_cookie(
-        'jwtToken',  # note that although we are setting jwtToken, it is NOT a JWT when going through this route
-        value=redis_session_token.get_session_token(),
-        domain=request.domain,
-        path='/',
-        httponly=True,
-        samesite='lax',
-        overwrite=True,
-        secure=is_https
-    )
+    # The session token is handed back unconditionally so we can retrieve the JWT later on, either
+    # in the registration scenario (if an unknown user) or to make auth'd requests as an existing
+    # user. Note that although the cookie is named jwtToken, its value here is NOT a JWT - it is the
+    # opaque session token. See SESSION_TOKEN_MODE_NOTES.
+    # samesite is 'lax' rather than 'strict' because this cookie is set on the top-level navigation
+    # back from the identity provider.
+    set_session_cookie(request, redis_session_token.get_session_token(), samesite='lax')
     return resp_json
+
 
 class NamespacedAuthenticationPolicy(object):
     """ Wrapper for authentication policy classes
@@ -338,11 +542,16 @@ class Auth0AuthenticationPolicy(CallbackAuthenticationPolicy):
             return cached
 
         # try to find the token in the request (should be in the header)
-        id_token = get_jwt(request)
+        id_token = get_auth_token(request)
         if not id_token:
+            # No credential at all: this is an anonymous request. Return before touching Redis so a
+            # session-store outage cannot take down unauthenticated traffic.
             # can I thrown an 403 here?
             # print('Missing assertion.', 'unauthenticated_userid', request)
             return None
+
+        if redis_is_active(request):
+            return self._redis_unauthenticated_userid(request, id_token)
 
         jwt_info = self.get_token_info(id_token, request)
         if not jwt_info:
@@ -354,6 +563,35 @@ class Auth0AuthenticationPolicy(CallbackAuthenticationPolicy):
         # but we don't know yet if this email is in our database. `authenticated_userid` should take care of this.
 
         app_project().note_auth0_authentication_policy_unauthenticated_userid(self, request, email, id_token)
+
+        return email
+
+    def _redis_unauthenticated_userid(self, request, session_token):
+        """ Redis session mode: resolve the caller-supplied opaque session token to the identity
+            recorded server-side. The supplied value is NEVER decoded as a JWT here, so presenting a
+            raw JWT in this mode is just an unknown key and fails authentication like any other.
+
+            A Redis outage propagates out of `resolve_session_token` as a 503; it is never
+            downgraded to the stateless JWT path.
+        """
+        session = resolve_session_token(request, session_token)
+        email = session_identity(request, session) if session is not None else None
+        if not email:
+            # Absent / unknown / expired / revoked / malformed session token. Mark the request the
+            # same way an expired JWT is marked so renderers.py unsets the stale cookie and reports
+            # the expired session to the front-end.
+            request.set_property(lambda r: True, 'auth0_expired')
+            return None
+
+        request.set_property(lambda r: False, 'auth0_expired')
+        request._auth0_authenticated = email
+        # The JWT stays server-side; stash it on the request for the (few) call sites that need the
+        # underlying provider token without going back to Redis.
+        request._auth0_session_jwt = session.get_jwt()
+
+        app_project().note_auth0_authentication_policy_unauthenticated_userid(
+            self, request, email, session.get_jwt()
+        )
 
         return email
 
@@ -460,16 +698,29 @@ def get_jwt_from_auth_header(request):
     return None
 
 
-def get_jwt(request):
+def get_auth_token(request):
+    """ Returns the caller-supplied credential, from the Authorization header if present and the
+        cookie otherwise.
 
-    # First try to obtain JWT from headers (case: some REST API requests)
+        In stateless mode this is a raw Auth0 JWT; in Redis session mode it is an opaque session
+        token. This function does not (and must not) attempt to tell which - that is decided by
+        configuration, not by inspecting the value. See SESSION_TOKEN_MODE_NOTES.
+    """
+    # First try to obtain the token from headers (case: some REST API requests)
     token = get_jwt_from_auth_header(request)
 
-    # If the JWT is not in the headers, get it from cookies (case: AJAX requests from portal & other clients)
+    # If not in the headers, get it from cookies (case: AJAX requests from portal & other clients)
     if not token:
-        token = request.cookies.get('jwtToken')
+        token = request.cookies.get(SESSION_COOKIE_NAME)
 
     return token
+
+
+def get_jwt(request):
+    """ Retained under its historical name for downstream callers. Prefer `get_auth_token`: in
+        Redis session mode the value returned is an opaque session token, not a JWT.
+    """
+    return get_auth_token(request)
 
 
 @view_config(route_name='login', request_method='POST', permission=NO_PERMISSION_REQUIRED)
@@ -480,7 +731,14 @@ def login_view(context, request, samesite: str = "strict"):
 
 def login(context, request, *, samesite: str = "strict"):
     """
-    Save JWT as httpOnly cookie
+    Establish a session for the caller.
+
+    Stateless mode (no Redis configured): save the caller-supplied Auth0 JWT as an httpOnly cookie,
+    exactly as before.
+
+    Redis session mode: validate the caller-supplied Auth0 JWT, keep it server-side in Redis, and
+    hand back only an opaque session token. This is the SPA login flow - the same flow the
+    front-end already uses - so Redis mode is reachable without also adopting the /callback flow.
     """
     ignored(context)
 
@@ -490,18 +748,39 @@ def login(context, request, *, samesite: str = "strict"):
     if request_token is None:
         request_token = request.json_body.get("id_token", None)
 
-    is_https = (request.scheme == "https")
+    if redis_is_active(request):
+        return _redis_login(request, request_token, samesite=samesite)
 
-    request.response.set_cookie(
-        "jwtToken",
-        value=request_token,
-        domain=request.domain,
-        path="/",
-        httponly=True,
-        samesite=samesite,
-        overwrite=True,
-        secure=is_https
-    )
+    set_session_cookie(request, request_token, samesite=samesite)
+
+    return {"saved_cookie": True}
+
+
+def _redis_login(request, id_token, *, samesite: str):
+    """ Redis session mode implementation of `login`.
+
+        The JWT supplied here is the provider's token from the SPA's Auth0 handshake - this is the
+        one place it is legitimately accepted from the caller, and it is verified before anything is
+        written to Redis. Every *subsequent* request must present the opaque session token instead.
+    """
+    if not id_token:
+        raise LoginDenied(domain=request.domain, title='No id_token supplied')
+
+    jwt_info = Auth0AuthenticationPolicy.get_token_info(id_token, request)
+    if not jwt_info:
+        raise LoginDenied(domain=request.domain)
+
+    email = (jwt_info.get('email') or '').lower()
+    if not email:
+        raise LoginDenied(domain=request.domain, title='No email present on supplied id_token')
+
+    # Re-login: revoke whatever session the caller was previously holding rather than leaving it
+    # live in Redis until its TTL lapses. Read the cookie directly - `get_auth_token` prefers the
+    # Authorization header, which on this route carries the *new* id_token, not the old session.
+    revoke_session_token(request, request.cookies.get(SESSION_COOKIE_NAME))
+
+    session = create_session_token(request, jwt_token=id_token, email=email)
+    set_session_cookie(request, session.get_session_token(), samesite=samesite)
 
     return {"saved_cookie": True}
 
@@ -523,12 +802,19 @@ def logout(context, request):
 
     The front-end handles logging out by discarding the locally-held JWT from
     browser cookies and re-requesting the current 4DN URL.
+
+    In Redis session mode the server-side session is revoked first, so the token is dead even if
+    the client keeps presenting it. If Redis is unreachable the revocation cannot be honored, and
+    that surfaces as a 503 rather than a logout that silently did nothing.
     """
     ignored(context)
 
+    if redis_is_active(request):
+        revoke_session_token(request, get_auth_token(request))
+
     # Deletes the cookie
     request.response.set_cookie(
-        name='jwtToken',
+        name=SESSION_COOKIE_NAME,
         value=None,
         domain=request.domain,
         max_age=0,
@@ -707,18 +993,16 @@ def impersonate_user(context, request):
         algorithm=JWT_ENCODING_ALGORITHM
     )
 
-    is_https = request.scheme == "https"
     token_value = id_token.decode('utf-8') if isinstance(id_token, bytes) else id_token
-    request.response.set_cookie(
-        "jwtToken",
-        value=token_value,
-        domain=request.domain,
-        path="/",
-        httponly=True,
-        samesite="strict",
-        overwrite=True,
-        secure=is_https
-    )
+
+    if redis_is_active(request):
+        # In Redis mode a raw JWT cookie would simply fail to resolve on the next request (it is
+        # never decoded as a JWT), so the impersonation token has to be wrapped in a session too.
+        revoke_session_token(request, request.cookies.get(SESSION_COOKIE_NAME))
+        session = create_session_token(request, jwt_token=token_value, email=userid)
+        token_value = session.get_session_token()
+
+    set_session_cookie(request, token_value, samesite="strict")
 
     return user_properties
 
@@ -804,8 +1088,6 @@ def create_unauthorized_user(context, request):
     if not recaptcha_resp:
         raise LoginDenied(f'Did not receive response from recaptcha!')
     
-    registry = request.registry
-
     # old method for retrieving auth'd email - request object should have _auth0_authenticated set
     # NOTE: it is not obvious to me how this works... probably should be looked into - Will March 29 2023
     if not redis_is_active(request):
@@ -816,31 +1098,13 @@ def create_unauthorized_user(context, request):
     # new method for retrieving auth'd email - request should have transmitted a session token
     # from which we can get the JWT and the email they auth'd with
     else:
-        id_token = get_jwt(request)
-        redis_handler = registry[REDIS]
-        env_name = registry.settings['env.name']
-        auth0_domain = request.registry.settings['auth0.domain']
-        if 'auth0' in auth0_domain:
-            secret = request.registry.settings['auth0.secret']
-            algorithms = JWT_DECODING_ALGORITHMS
-        else:
-            # RAS
-            secret = request.registry.settings['auth0.public.key']
-            algorithms = ['RS256']
-
-        redis_session_token = RedisSessionToken.from_redis(
-            redis_handler=redis_handler,
-            namespace=env_name,
-            token=id_token
-        )
-        jwt_info = redis_session_token.decode_jwt(
-                audience=request.registry.settings['auth0.client'],
-                secret=secret,
-                algorithms=algorithms
-        )
-        if jwt_info.get('email') is None:
-            jwt_info['email'] = redis_session_token.get_email()
-        email = jwt_info.get('email', '<no e-mail supplied>').lower()
+        # A miss here (unknown/expired/revoked/malformed token) is an authentication failure, not a
+        # server error; a Redis outage raises RedisSessionUnavailable (503) out of this call.
+        session = resolve_session_token(request, get_auth_token(request))
+        email = session_identity(request, session) if session is not None else None
+        if not email:
+            raise LoginDenied(domain=request.domain,
+                              title='No valid session; log in again before registering')
 
     user_props = request.json
     user_props_email = user_props.get("email", "<no e-mail supplied>").lower()

--- a/snovault/authentication.py
+++ b/snovault/authentication.py
@@ -283,6 +283,25 @@ def session_identity(request, session):
     return email.lower() if email else None
 
 
+def _note_session_established(request):
+    """ Asserts the `auth0_expired` marker is clear now that a session has just been established.
+
+        Login and callback are the only routes where the *incoming* credential is legitimately not
+        a resolvable session - it is the provider's JWT, or a lapsed session being replaced - so
+        per-request authentication may already have marked the request expired earlier in the tween
+        chain (it does whenever an Authorization header is present, since renderers.security_tween
+        evaluates `request.authenticated_userid` before the view runs). That same tween re-reads the
+        flag AFTER the view returns and, if it is still set, overwrites the response's Set-Cookie
+        with a deletion and forces a 401 - destroying the session we just handed out.
+
+        On the Auth0 paths `get_token_info` already resets the flag as a side effect of verifying
+        the JWT, so this is belt-and-braces there; it is load-bearing on the RAS callback path,
+        which never calls `get_token_info`, and it keeps the invariant from depending on a side
+        effect of an unrelated function.
+    """
+    request.set_property(lambda r: False, 'auth0_expired')
+
+
 def set_session_cookie(request, value, *, samesite):
     """ Sets the credential cookie. `value` is a raw JWT in stateless mode and an opaque session
         token in Redis mode; see SESSION_TOKEN_MODE_NOTES.
@@ -406,6 +425,7 @@ def callback(context, request):
     # samesite is 'lax' rather than 'strict' because this cookie is set on the top-level navigation
     # back from the identity provider.
     set_session_cookie(request, redis_session_token.get_session_token(), samesite='lax')
+    _note_session_established(request)
     return resp_json
 
 
@@ -781,6 +801,7 @@ def _redis_login(request, id_token, *, samesite: str):
 
     session = create_session_token(request, jwt_token=id_token, email=email)
     set_session_cookie(request, session.get_session_token(), samesite=samesite)
+    _note_session_established(request)
 
     return {"saved_cookie": True}
 

--- a/snovault/authentication.py
+++ b/snovault/authentication.py
@@ -79,10 +79,20 @@ SESSION_COOKIE_NAME = 'jwtToken'
 # configured. Only reachable in local/test configurations; deployed environments always set one.
 DEFAULT_SESSION_NAMESPACE = 'snovault'
 
-# Redis failures we treat as *operational* (=> 5xx). Deliberately narrow: a cache miss is not an
-# error (RedisSessionToken.from_redis returns None), and a broad `except Exception` here would
-# collapse the exact distinction between "Redis is down" (5xx) and "this token is not valid"
-# (401) that the two-mode contract depends on.
+# Redis failures we treat as *operational* (=> 5xx). A token miss is NOT in here: dcicutils
+# signals that by returning None from `from_redis`, so the 503-vs-401 distinction never depends on
+# exception types.
+#
+# UPSTREAM GAP: this tuple should ideally be just `RedisException`, dcicutils' own error type, so
+# snovault needs no knowledge of the driver. Today `dcicutils.redis_tools` normalizes driver errors
+# in exactly one of the operations snovault uses -- `store_session_token`, which wraps its body in
+# `except Exception -> raise RedisException`. `from_redis`, `delete_session_token` and
+# `update_session_token` (and every `RedisBase` primitive beneath them) let raw `redis.exceptions.*`
+# through untouched. `from_redis` is on the per-request authentication path, so dropping `RedisError`
+# would turn every request during a Redis outage into an untyped 500 instead of the contracted 503.
+# `redis` is already a direct snovault dependency (pyproject.toml), so this is not a new coupling --
+# but it should be removed once dcicutils normalizes those three functions. Deliberately narrow
+# rather than `except Exception` so genuine programming errors still surface as 500s, not 503s.
 REDIS_OPERATIONAL_ERRORS = (RedisException, RedisError)
 
 SESSION_TOKEN_MODE_NOTES = """
@@ -173,8 +183,25 @@ def get_redis_handler(request):
     return handler
 
 
+def _redis_session_call(operation, description, detail):
+    """ Runs one canonical `dcicutils.redis_tools` operation, translating an infrastructure failure
+        into `RedisSessionUnavailable` (503). Pyramid-facing error translation is snovault's job;
+        the Redis behavior itself belongs to dcicutils and is never reimplemented here.
+
+        Catching here does NOT blur the outage-vs-invalid-token distinction: dcicutils signals a
+        token miss by *returning* None from `from_redis`, never by raising. Only genuine
+        infrastructure failures reach this handler.
+    """
+    try:
+        return operation()
+    except REDIS_OPERATIONAL_ERRORS as e:
+        # Note: never log the token value - session tokens are credentials.
+        log.error(f'Redis session store failure while {description}: {type(e).__name__}: {e}')
+        raise RedisSessionUnavailable(detail=detail)
+
+
 def resolve_session_token(request, token):
-    """ Resolves an opaque session token to its stored RedisSessionToken record.
+    """ Resolves an opaque session token via `RedisSessionToken.from_redis`.
 
         Tri-state, and the distinction matters (each is separately asserted in the test suite):
           * returns a RedisSessionToken  -> the session is live
@@ -187,54 +214,69 @@ def resolve_session_token(request, token):
     if not token:
         return None
     handler = get_redis_handler(request)
-    try:
-        return RedisSessionToken.from_redis(
-            redis_handler=handler,
-            namespace=session_namespace(request.registry),
-            token=token
-        )
-    except REDIS_OPERATIONAL_ERRORS as e:
-        # Note: no token value in the log message - session tokens are credentials.
-        log.error(f'Redis error resolving session token: {type(e).__name__}: {e}')
-        raise RedisSessionUnavailable(
-            detail='Session store is not available. Authentication cannot be performed.'
-        )
+    namespace = session_namespace(request.registry)
+    return _redis_session_call(
+        lambda: RedisSessionToken.from_redis(redis_handler=handler, namespace=namespace, token=token),
+        'resolving a session token',
+        'Session store is not available. Authentication cannot be performed.'
+    )
 
 
 def create_session_token(request, *, jwt_token, email):
-    """ Mints and persists a new opaque session token wrapping the given (already validated) JWT. """
+    """ Mints and persists a new session via `RedisSessionToken` + `store_session_token`.
+
+        Token generation, key derivation and TTL are all dcicutils' concern; snovault only supplies
+        the namespace and the already-validated JWT/email.
+    """
     handler = get_redis_handler(request)
     session = RedisSessionToken(
         namespace=session_namespace(request.registry),
         jwt=jwt_token,
         email=email
     )
-    try:
-        session.store_session_token(redis_handler=handler)
-    except REDIS_OPERATIONAL_ERRORS as e:
-        log.error(f'Redis error storing session token: {type(e).__name__}: {e}')
-        raise RedisSessionUnavailable(detail='Session store is not available. Cannot establish session.')
+    _redis_session_call(
+        lambda: session.store_session_token(redis_handler=handler),
+        'storing a session token',
+        'Session store is not available. Cannot establish session.'
+    )
     return session
 
 
 def revoke_session_token(request, token):
-    """ Deletes the given session token from Redis, immediately invalidating it server-side.
+    """ Revokes a session via `RedisSessionToken.delete_session_token`, immediately invalidating it
+        server-side. Returns False when there was no live session to revoke.
 
-        Constructs the key directly rather than reading the record first - revocation should not
-        depend on the record being readable, and it saves a round trip.
+        Resolves the record first rather than deriving the Redis key here: key layout is dcicutils'
+        contract (`<namespace>:session:<token>`), and snovault must not encode a second copy of it.
     """
-    if not token:
+    session = resolve_session_token(request, token)
+    if session is None:
         return False
     handler = get_redis_handler(request)
-    session = RedisSessionToken(
-        namespace=session_namespace(request.registry),
-        jwt='', email='', token=token
+    return _redis_session_call(
+        lambda: session.delete_session_token(redis_handler=handler),
+        'revoking a session token',
+        'Session store is not available. Cannot revoke session.'
     )
-    try:
-        return session.delete_session_token(redis_handler=handler)
-    except REDIS_OPERATIONAL_ERRORS as e:
-        log.error(f'Redis error revoking session token: {type(e).__name__}: {e}')
-        raise RedisSessionUnavailable(detail='Session store is not available. Cannot revoke session.')
+
+
+def rotate_session_token(request, *, previous_token, jwt_token, email):
+    """ Establishes a session for a caller who may already hold one (login / callback / impersonate).
+
+        When a live session exists this is `RedisSessionToken.update_session_token`, dcicutils' own
+        rotation primitive: it deletes the old key, mints a fresh token and stores the new JWT under
+        it, so no orphaned session is left live until its TTL lapses. Otherwise it is a plain mint.
+    """
+    existing = resolve_session_token(request, previous_token)
+    if existing is None:
+        return create_session_token(request, jwt_token=jwt_token, email=email)
+    handler = get_redis_handler(request)
+    _redis_session_call(
+        lambda: existing.update_session_token(redis_handler=handler, jwt=jwt_token, email=email),
+        'rotating a session token',
+        'Session store is not available. Cannot establish session.'
+    )
+    return existing
 
 
 def decode_session_jwt(request, session):
@@ -388,14 +430,17 @@ def callback(context, request):
     if not email:
         raise LoginDenied('No email extracted from JWT, not possible to continue')
 
-    # Re-login: if the caller already holds a session token, revoke it before minting a new one so
-    # a single browser never leaves live orphaned sessions behind in Redis.
-    revoke_session_token(request, request.cookies.get(SESSION_COOKIE_NAME))
-
-    # Generate a session from Redis. Note this is stored *before* the DB lookup below: the token is
-    # issued unconditionally (see comment further down), and storing first keeps the "what is in
-    # Redis" and "what is in the cookie" answers identical on every exit path from here.
-    redis_session_token = create_session_token(request, jwt_token=auth0_jwt, email=email)
+    # Generate a session from Redis, rotating whatever session the caller was already holding so no
+    # orphaned session is left live until its TTL lapses. Note this happens *before* the DB lookup
+    # below: the token is issued unconditionally (see comment further down), and establishing it
+    # first keeps the "what is in Redis" and "what is in the cookie" answers identical on every exit
+    # path from here.
+    redis_session_token = rotate_session_token(
+        request,
+        previous_token=request.cookies.get(SESSION_COOKIE_NAME),
+        jwt_token=auth0_jwt,
+        email=email
+    )
 
     try:
         Auth0AuthenticationPolicy.get_user_info(request, email, redis_session_token.get_session_token())
@@ -794,12 +839,15 @@ def _redis_login(request, id_token, *, samesite: str):
     if not email:
         raise LoginDenied(domain=request.domain, title='No email present on supplied id_token')
 
-    # Re-login: revoke whatever session the caller was previously holding rather than leaving it
+    # Re-login rotates whatever session the caller was previously holding rather than leaving it
     # live in Redis until its TTL lapses. Read the cookie directly - `get_auth_token` prefers the
     # Authorization header, which on this route carries the *new* id_token, not the old session.
-    revoke_session_token(request, request.cookies.get(SESSION_COOKIE_NAME))
-
-    session = create_session_token(request, jwt_token=id_token, email=email)
+    session = rotate_session_token(
+        request,
+        previous_token=request.cookies.get(SESSION_COOKIE_NAME),
+        jwt_token=id_token,
+        email=email
+    )
     set_session_cookie(request, session.get_session_token(), samesite=samesite)
     _note_session_established(request)
 
@@ -1019,8 +1067,12 @@ def impersonate_user(context, request):
     if redis_is_active(request):
         # In Redis mode a raw JWT cookie would simply fail to resolve on the next request (it is
         # never decoded as a JWT), so the impersonation token has to be wrapped in a session too.
-        revoke_session_token(request, request.cookies.get(SESSION_COOKIE_NAME))
-        session = create_session_token(request, jwt_token=token_value, email=userid)
+        session = rotate_session_token(
+            request,
+            previous_token=request.cookies.get(SESSION_COOKIE_NAME),
+            jwt_token=token_value,
+            email=userid
+        )
         token_value = session.get_session_token()
 
     set_session_cookie(request, token_value, samesite="strict")

--- a/snovault/authentication.py
+++ b/snovault/authentication.py
@@ -30,7 +30,6 @@ from urllib.parse import urlencode
 from snovault.redis.interfaces import REDIS
 from dcicutils.redis_tools import RedisSessionToken
 from dcicutils.redis_utils import RedisException
-from redis.exceptions import RedisError
 
 
 log = structlog.getLogger(__name__)
@@ -79,21 +78,35 @@ SESSION_COOKIE_NAME = 'jwtToken'
 # configured. Only reachable in local/test configurations; deployed environments always set one.
 DEFAULT_SESSION_NAMESPACE = 'snovault'
 
-# Redis failures we treat as *operational* (=> 5xx). A token miss is NOT in here: dcicutils
-# signals that by returning None from `from_redis`, so the 503-vs-401 distinction never depends on
-# exception types.
+# `RedisException` is dcicutils' own error type and the ONLY exception snovault treats as an
+# operational Redis failure. Snovault deliberately holds no knowledge of the redis driver's
+# exception hierarchy: normalizing driver errors is dcicutils' responsibility, and duplicating that
+# contract here would mean two places to keep in step.
 #
-# UPSTREAM GAP: this tuple should ideally be just `RedisException`, dcicutils' own error type, so
-# snovault needs no knowledge of the driver. Today `dcicutils.redis_tools` normalizes driver errors
-# in exactly one of the operations snovault uses -- `store_session_token`, which wraps its body in
-# `except Exception -> raise RedisException`. `from_redis`, `delete_session_token` and
-# `update_session_token` (and every `RedisBase` primitive beneath them) let raw `redis.exceptions.*`
-# through untouched. `from_redis` is on the per-request authentication path, so dropping `RedisError`
-# would turn every request during a Redis outage into an untyped 500 instead of the contracted 503.
-# `redis` is already a direct snovault dependency (pyproject.toml), so this is not a new coupling --
-# but it should be removed once dcicutils normalizes those three functions. Deliberately narrow
-# rather than `except Exception` so genuine programming errors still surface as 500s, not 503s.
-REDIS_OPERATIONAL_ERRORS = (RedisException, RedisError)
+# A token miss is not an error at all -- dcicutils signals it by *returning* None from `from_redis`
+# -- so the 503-vs-401 distinction never depends on exception types.
+#
+# DEPENDENCY: see `REDIS_ERROR_CONTRACT_DEPENDENCY` below for the dcicutils version this requires.
+REDIS_OPERATIONAL_ERRORS = (RedisException,)
+
+# Snovault requires dcicutils to raise `RedisException` for infrastructure failures across the whole
+# session API. As of dcicutils 8.19.0 (checked against 8.18.3, byte-identical) that holds for
+# `store_session_token` only, which wraps its body in `except Exception -> raise RedisException`;
+# `from_redis`, `delete_session_token` and `update_session_token` still let raw driver exceptions
+# through. A dcicutils change completing that contract is in progress.
+#
+# Until it is released and the floor in pyproject.toml is raised, the interim behavior on the
+# unnormalized paths is an untyped 500 rather than the intended 503. That is a degraded error
+# *label*, not a correctness hole: the failure is still 5xx, still logged, and is never silently
+# downgraded into an authentication failure or a stateless-JWT fallback - the properties the
+# two-mode contract actually depends on. Snovault deliberately does NOT bridge the gap locally.
+# `snovault/tests/test_redis_session_auth.py` carries a strict xfail that flips to a hard failure
+# the moment the upstream fix lands, so this note cannot be forgotten.
+REDIS_ERROR_CONTRACT_DEPENDENCY = (
+    'dcicutils must raise RedisException for infrastructure failures in from_redis, '
+    'delete_session_token and update_session_token, as store_session_token already does. '
+    'Pending upstream release; raise the dcicutils floor in pyproject.toml when it ships.'
+)
 
 SESSION_TOKEN_MODE_NOTES = """
 Snovault supports two mutually exclusive authentication modes, selected by configuration:
@@ -184,9 +197,11 @@ def get_redis_handler(request):
 
 
 def _redis_session_call(operation, description, detail):
-    """ Runs one canonical `dcicutils.redis_tools` operation, translating an infrastructure failure
-        into `RedisSessionUnavailable` (503). Pyramid-facing error translation is snovault's job;
-        the Redis behavior itself belongs to dcicutils and is never reimplemented here.
+    """ Runs one canonical `dcicutils.redis_tools` operation, translating dcicutils' own
+        `RedisException` into `RedisSessionUnavailable` (503). Pyramid-facing error translation is
+        snovault's job; the Redis behavior itself belongs to dcicutils and is never reimplemented
+        here - including the job of normalizing driver errors, which is why only `RedisException`
+        is caught (see `REDIS_ERROR_CONTRACT_DEPENDENCY`).
 
         Catching here does NOT blur the outage-vs-invalid-token distinction: dcicutils signals a
         token miss by *returning* None from `from_redis`, never by raising. Only genuine

--- a/snovault/redis/README.rst
+++ b/snovault/redis/README.rst
@@ -69,20 +69,32 @@ In particular, snovault never derives a Redis key itself: revocation and rotatio
 record through ``from_redis`` first, so ``<namespace>:session:<token>`` exists in exactly one place
 (dcicutils) and cannot drift.
 
-Known upstream gap: error normalization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Dependency: the dcicutils error contract
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``dcicutils.redis_tools`` normalizes driver errors to its own ``RedisException`` in exactly one of
-the operations snovault uses -- ``store_session_token``, which wraps its body in
-``except Exception -> raise RedisException``. ``from_redis``, ``delete_session_token`` and
-``update_session_token`` (and every ``RedisBase`` primitive beneath them) let raw
-``redis.exceptions.*`` through untouched.
+Snovault catches **only** ``dcicutils.redis_utils.RedisException`` and holds no knowledge of the
+redis driver's exception hierarchy. Normalizing driver errors is dcicutils' responsibility;
+duplicating that contract here would mean two places to keep in step.
 
-Because ``from_redis`` is on the per-request authentication path, snovault's
-``REDIS_OPERATIONAL_ERRORS`` must currently include ``redis.exceptions.RedisError`` alongside
-``RedisException`` -- otherwise every request during a Redis outage would surface as an untyped 500
-instead of the contracted 503. If dcicutils normalizes those three functions, that entry should be
-dropped and snovault will need no knowledge of the driver at all.
+As of dcicutils 8.19.0 (checked against 8.18.3 -- byte-identical) that contract is only partly
+implemented. ``store_session_token`` wraps its body in ``except Exception -> raise RedisException``;
+``from_redis``, ``delete_session_token`` and ``update_session_token`` (and every ``RedisBase``
+primitive beneath them) still let raw driver exceptions through. **A dcicutils change completing
+the contract is in progress.**
+
+Interim behavior on the unnormalized paths is an untyped 500 rather than the intended 503. That is
+a degraded error *label*, not a correctness hole -- the failure is still 5xx, still logged, and is
+never silently downgraded into an authentication failure or a stateless-JWT fallback, which are the
+properties the two-mode contract actually depends on.
+
+When the dcicutils release lands:
+
+1. Raise the ``dcicutils`` floor in ``pyproject.toml`` (there is a note at that line).
+2. Remove the ``@pytest.mark.xfail`` from
+   ``test_unnormalized_redis_error_becomes_503_once_dcicutils_normalizes``.
+
+That xfail is ``strict``, so it turns into a hard test failure the moment the upstream fix is
+present -- the reminder cannot be lost. No snovault code change should be needed.
 
 Key namespace
 -------------

--- a/snovault/redis/README.rst
+++ b/snovault/redis/README.rst
@@ -45,6 +45,45 @@ Rules that hold in Redis session mode
 * ``POST /logout`` revokes the session server-side; re-login revokes the caller's previous session
   before minting the new one.
 
+All Redis behavior lives in dcicutils
+-------------------------------------
+
+Snovault does **not** implement Redis connection, session or token behavior. Connection setup,
+token generation, key layout, TTL, storage, lookup, rotation and revocation are all
+``dcicutils.redis_utils`` / ``dcicutils.redis_tools``. Snovault contributes only what is
+genuinely its own: reading pyramid settings, and translating outcomes into HTTP.
+
+===================================  ==================================================
+Snovault integration point           Canonical dcicutils call it delegates to
+===================================  ==================================================
+``redis_connection.py::includeme``   ``RedisBase(create_redis_client(url=...))``
+``authentication.create_session_token``  ``RedisSessionToken(...)`` + ``store_session_token``
+``authentication.resolve_session_token`` ``RedisSessionToken.from_redis``
+``authentication.rotate_session_token``  ``RedisSessionToken.update_session_token``
+``authentication.revoke_session_token``  ``RedisSessionToken.delete_session_token``
+``authentication.decode_session_jwt``    ``RedisSessionToken.decode_jwt``
+``authentication.session_identity``      ``RedisSessionToken.get_email`` / ``get_jwt``
+===================================  ==================================================
+
+In particular, snovault never derives a Redis key itself: revocation and rotation resolve the real
+record through ``from_redis`` first, so ``<namespace>:session:<token>`` exists in exactly one place
+(dcicutils) and cannot drift.
+
+Known upstream gap: error normalization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``dcicutils.redis_tools`` normalizes driver errors to its own ``RedisException`` in exactly one of
+the operations snovault uses -- ``store_session_token``, which wraps its body in
+``except Exception -> raise RedisException``. ``from_redis``, ``delete_session_token`` and
+``update_session_token`` (and every ``RedisBase`` primitive beneath them) let raw
+``redis.exceptions.*`` through untouched.
+
+Because ``from_redis`` is on the per-request authentication path, snovault's
+``REDIS_OPERATIONAL_ERRORS`` must currently include ``redis.exceptions.RedisError`` alongside
+``RedisException`` -- otherwise every request during a Redis outage would surface as an untyped 500
+instead of the contracted 503. If dcicutils normalizes those three functions, that entry should be
+dropped and snovault will need no knowledge of the driver at all.
+
 Key namespace
 -------------
 

--- a/snovault/redis/README.rst
+++ b/snovault/redis/README.rst
@@ -4,3 +4,68 @@ REDIS README
 
 This file contains notes on the Redis implementation.
 
+Redis is optional. It is enabled purely by the presence of a ``redis.server`` setting in the
+application's PasteDeploy configuration; that same setting is what makes
+``snovault/__init__.py::main`` do ``config.include('snovault.redis')``.
+
+Two authentication modes
+========================
+
+``snovault/authentication.py`` supports exactly two mutually exclusive authentication modes. Which
+one is active is decided by configuration alone -- never by inspecting a token value -- via
+``redis_is_active(request)``. The canonical statement of the contract lives next to the code, in
+``snovault.authentication.SESSION_TOKEN_MODE_NOTES``.
+
+1. **Stateless JWT mode** (no ``redis.server``). The ``jwtToken`` cookie / ``Authorization: Bearer``
+   value *is* the Auth0 JWT, and it is verified on every request. This is the historical behavior
+   and is unchanged.
+
+2. **Redis session mode** (``redis.server`` configured). ``POST /login`` (SPA flow) and
+   ``GET /callback`` (Auth0/RAS redirect flow) verify the provider's JWT once, store it in Redis
+   under ``<namespace>:session:<token>`` with a TTL, and hand the client only an opaque session
+   token (``secrets.token_urlsafe``). The JWT never leaves the server afterwards. Every subsequent
+   request must present the session token; the server resolves it back to the recorded identity
+   before authorization.
+
+Rules that hold in Redis session mode
+-------------------------------------
+
+* The caller-supplied credential is **never** decoded as a JWT. A raw JWT presented as a cookie or
+  bearer token is simply an unknown Redis key and fails authentication -- there is no fallback to
+  mode 1 once Redis mode is selected.
+* An absent, unknown, expired (TTL lapsed), revoked or malformed session token is an
+  **authentication failure** (401), and marks ``request.auth0_expired`` so ``renderers.py`` unsets
+  the stale cookie.
+* A Redis outage -- whether the connection failed at startup (``redis_connection.py::includeme``
+  logs and stores ``None``) or fails mid-request -- is an **operational failure**:
+  ``authentication.RedisSessionUnavailable`` (HTTP 503). It is never downgraded to either of the
+  above.
+* Anonymous requests (no credential at all) do not touch Redis, so an outage cannot take down
+  unauthenticated traffic.
+* ``POST /logout`` revokes the session server-side; re-login revokes the caller's previous session
+  before minting the new one.
+
+Key namespace
+-------------
+
+``authentication.session_namespace(registry)`` resolves ``env.name``, else ``indexer.namespace``,
+else the ``DEFAULT_SESSION_NAMESPACE`` constant. Every touchpoint must use it -- a namespace
+mismatch between the writer and the reader silently 401s every session.
+
+Note that test settings deliberately set neither ``env.name`` nor ``indexer.namespace``; a truthy
+``env.name`` makes ``snovault.elasticsearch``'s ``includeme`` attempt a blue/green mirror lookup
+that raises without an ``IDENTITY``. See the top-level ``AGENTS.md``.
+
+Testing
+-------
+
+``snovault/tests/test_redis_session_auth.py`` covers both modes against a dict-backed fake
+implementing the small slice of ``RedisBase`` that ``dcicutils.redis_tools.RedisSessionToken``
+uses, plus locally-signed synthetic JWTs. No live Redis, no cloud credentials and no outbound
+Auth0 calls are required.
+
+Other Redis usage
+=================
+
+``RedisModel`` and ``RedisConnection`` in ``redis_connection.py`` sketch a future Redis-backed
+item cache. They are **not used at this time**.

--- a/snovault/tests/test_redis_session_auth.py
+++ b/snovault/tests/test_redis_session_auth.py
@@ -14,6 +14,8 @@ import requests
 from pyramid.httpexceptions import HTTPForbidden, HTTPUnauthorized
 from pyramid.registry import Registry
 from pyramid.request import Request
+from dcicutils.redis_tools import RedisSessionToken
+from dcicutils.redis_utils import RedisException
 from redis.exceptions import ConnectionError as RedisConnectionError
 from unittest import mock
 
@@ -32,6 +34,7 @@ from ..authentication import (
     logout,
     redis_is_active,
     resolve_session_token,
+    revoke_session_token,
     session_identity,
     session_namespace,
 )
@@ -306,6 +309,69 @@ def test_redis_relogin_revokes_the_previous_session():
 
 
 # ---------------------------------------------------------------------------------------------
+# Snovault delegates to the canonical dcicutils API rather than reimplementing it
+# ---------------------------------------------------------------------------------------------
+
+def test_relogin_delegates_to_dcicutils_update_session_token():
+    """ Rotation is dcicutils' own primitive; snovault must not hand-roll delete-then-create. """
+    redis = FakeRedis()
+    registry = make_registry(redis_handler=redis)
+    first = make_request(registry, json_body={'id_token': make_jwt()})
+    login(None, first)
+
+    second = make_request(registry, cookie=response_cookie(first.response),
+                          json_body={'id_token': make_jwt()})
+    with mock.patch.object(RedisSessionToken, 'update_session_token',
+                           autospec=True, side_effect=RedisSessionToken.update_session_token) as spy:
+        login(None, second)
+    assert spy.call_count == 1
+
+
+def test_logout_delegates_to_dcicutils_delete_session_token():
+    redis = FakeRedis()
+    registry = make_registry(redis_handler=redis)
+    session = create_session_token(make_request(registry), jwt_token=make_jwt(), email=USER_EMAIL)
+
+    with mock.patch.object(RedisSessionToken, 'delete_session_token',
+                           autospec=True, side_effect=RedisSessionToken.delete_session_token) as spy:
+        logout(None, make_request(registry, cookie=session.get_session_token()))
+    assert spy.call_count == 1
+    assert redis.store == {}
+
+
+def test_snovault_does_not_derive_redis_keys_itself():
+    """ Key layout (`<namespace>:session:<token>`) is dcicutils' contract. Snovault must reach every
+        key through a record dcicutils produced, so there is no second copy of that layout to drift.
+
+        Asserting the *mechanism*, not just the outcome: a hand-built
+        `RedisSessionToken(jwt='', email='', token=...)` would derive an identical key and delete
+        the same entry, so an outcome-only assertion cannot tell the two apart. Spying on
+        `from_redis` can.
+    """
+    redis = FakeRedis()
+    registry = make_registry(redis_handler=redis)
+    session = create_session_token(make_request(registry), jwt_token=make_jwt(), email=USER_EMAIL)
+
+    assert list(redis.store) == [session.get_redis_key()]
+
+    with mock.patch.object(RedisSessionToken, 'from_redis',
+                           side_effect=RedisSessionToken.from_redis) as spy:
+        revoke_session_token(make_request(registry), session.get_session_token())
+    assert spy.call_count == 1, 'revocation must resolve the real record, not fabricate one'
+    assert redis.store == {}
+
+
+def test_revoking_an_unknown_token_is_a_no_op_not_an_error():
+    redis = FakeRedis()
+    registry = make_registry(redis_handler=redis)
+    live = create_session_token(make_request(registry), jwt_token=make_jwt(), email=USER_EMAIL)
+
+    assert revoke_session_token(make_request(registry), 'never-issued') is False
+    # an unrelated live session is untouched
+    assert live.get_redis_key() in redis.store
+
+
+# ---------------------------------------------------------------------------------------------
 # Redis mode: per-request authentication resolves the token
 # ---------------------------------------------------------------------------------------------
 
@@ -433,12 +499,19 @@ def test_redis_logout_revokes_token_supplied_by_header():
 # Redis mode: outages are operational failures, never a downgrade
 # ---------------------------------------------------------------------------------------------
 
-@pytest.mark.parametrize('handler', [
-    None,                                                # never connected (includeme stored None)
-    FakeRedis(fail_with=RedisConnectionError('down')),   # connection lost at call time
+@pytest.mark.parametrize('handler_factory', [
+    # never connected - redis_connection.py::includeme stores None when it cannot connect at boot
+    lambda: None,
+    # connection lost at call time, reported with dcicutils' own error type
+    lambda: FakeRedis(fail_with=RedisException('down')),
+    # ...and reported as a raw driver error, which is what actually escapes today: dcicutils
+    # normalizes to RedisException in store_session_token only, not in from_redis. See the
+    # REDIS_OPERATIONAL_ERRORS upstream-gap note in authentication.py.
+    lambda: FakeRedis(fail_with=RedisConnectionError('down')),
 ])
-def test_redis_outage_on_authentication_is_operational_error(handler):
-    request = make_request(make_registry(redis_handler=handler), cookie='some-session-token')
+def test_redis_outage_on_authentication_is_operational_error(handler_factory):
+    request = make_request(make_registry(redis_handler=handler_factory()),
+                           cookie='some-session-token')
 
     with pytest.raises(RedisSessionUnavailable) as exc:
         Auth0AuthenticationPolicy().unauthenticated_userid(request)

--- a/snovault/tests/test_redis_session_auth.py
+++ b/snovault/tests/test_redis_session_auth.py
@@ -1,0 +1,632 @@
+"""
+Coverage for the two-mode authentication contract described in
+`snovault.authentication.SESSION_TOKEN_MODE_NOTES`.
+
+Everything here runs against a dict-backed fake implementing the small slice of the `RedisBase`
+surface that `dcicutils.redis_tools.RedisSessionToken` actually uses, and against synthetic,
+locally-signed JWTs. No live Redis, no cloud credentials, no outbound Auth0 calls.
+"""
+import json
+import jwt
+import pytest
+import requests
+
+from pyramid.httpexceptions import HTTPForbidden, HTTPUnauthorized
+from pyramid.registry import Registry
+from pyramid.request import Request
+from redis.exceptions import ConnectionError as RedisConnectionError
+from unittest import mock
+
+from .. import authentication as auth_module
+from ..authentication import (
+    Auth0AuthenticationPolicy,
+    DEFAULT_SESSION_NAMESPACE,
+    LoginDenied,
+    RedisSessionUnavailable,
+    SESSION_COOKIE_NAME,
+    callback,
+    create_session_token,
+    create_unauthorized_user,
+    get_auth_token,
+    login,
+    logout,
+    redis_is_active,
+    resolve_session_token,
+    session_identity,
+    session_namespace,
+)
+from ..interfaces import COLLECTIONS
+from ..redis.interfaces import REDIS
+
+
+pytestmark = [pytest.mark.unit]
+
+
+AUTH0_CLIENT = 'dummy-client'
+AUTH0_SECRET = 'dummy-secret'
+AUTH0_DOMAIN = 'dummy.auth0.com'
+AUTH0_OPTIONS = {'auth': {'params': {'scope': 'openid email'}}}
+USER_EMAIL = 'somebody@example.com'
+
+
+def make_jwt(email=USER_EMAIL, *, audience=AUTH0_CLIENT, secret=AUTH0_SECRET, email_verified=True):
+    """ A locally-signed synthetic id_token; never leaves this process. """
+    return jwt.encode({'email': email, 'email_verified': email_verified, 'aud': audience},
+                      secret, algorithm='HS256')
+
+
+class FakeRedis:
+    """ Dict-backed stand-in for dcicutils.redis_utils.RedisBase.
+
+        Only implements what RedisSessionToken calls: get/set/delete/ttl. `fail_with` makes every
+        operation raise, which is how the "Redis is down" cases are driven.
+    """
+
+    def __init__(self, fail_with=None):
+        self.store = {}
+        self.fail_with = fail_with
+
+    def _check(self):
+        if self.fail_with is not None:
+            raise self.fail_with
+
+    def set(self, key, value, exp=None):
+        self._check()
+        self.store[key] = value
+        return 'OK'
+
+    def get(self, key):
+        self._check()
+        return self.store.get(key)
+
+    def delete(self, key):
+        self._check()
+        return 1 if self.store.pop(key, None) is not None else 0
+
+    def ttl(self, key):
+        self._check()
+        return 3600 if key in self.store else -2
+
+    # test helper - simulates the key's TTL lapsing
+    def expire_now(self, key):
+        self.store.pop(key, None)
+
+
+def make_registry(*, redis=True, redis_handler=None, **extra_settings):
+    registry = Registry('testing')
+    registry.settings = {
+        'auth0.client': AUTH0_CLIENT,
+        'auth0.secret': AUTH0_SECRET,
+        'auth0.domain': AUTH0_DOMAIN,
+        'g.recaptcha.secret': 'dummy-recaptcha-secret',
+    }
+    registry.settings.update(extra_settings)
+    if redis:
+        registry.settings['redis.server'] = 'redis://localhost:6379'
+        # NOTE: redis_handler may deliberately be None - that is exactly the state
+        # snovault/redis/redis_connection.py::includeme leaves behind when it cannot connect.
+        registry[REDIS] = redis_handler
+    return registry
+
+
+def make_request(registry, *, cookie=None, auth_header=None, json_body=None, path='/'):
+    request = Request.blank(path)
+    request.registry = registry
+    if cookie is not None:
+        request.cookies[SESSION_COOKIE_NAME] = cookie
+    if auth_header is not None:
+        request.headers['Authorization'] = f'Bearer {auth_header}'
+    if json_body is not None:
+        request.method = 'POST'
+        request.content_type = 'application/json'
+        request.body = json.dumps(json_body).encode('utf-8')
+    return request
+
+
+def response_cookie(response, name=SESSION_COOKIE_NAME):
+    """ Returns the value the response sets for `name`, or None if it sets no such cookie. """
+    for header_name, header_value in response.headerlist:
+        if header_name.lower() == 'set-cookie' and header_value.startswith(f'{name}='):
+            return header_value.split('=', 1)[1].split(';', 1)[0]
+    return None
+
+
+# ---------------------------------------------------------------------------------------------
+# Mode selection
+# ---------------------------------------------------------------------------------------------
+
+def test_redis_is_active_follows_redis_server_setting():
+    assert redis_is_active(make_request(make_registry(redis=True, redis_handler=FakeRedis())))
+    assert not redis_is_active(make_request(make_registry(redis=False)))
+
+
+def test_session_namespace_prefers_env_name_then_indexer_namespace():
+    assert session_namespace(make_registry(**{'env.name': 'some-env',
+                                              'indexer.namespace': 'ns'})) == 'some-env'
+    assert session_namespace(make_registry(**{'indexer.namespace': 'ns'})) == 'ns'
+    # Test settings deliberately set neither (a truthy env.name breaks app construction - see
+    # CLAUDE.md), so the constant fallback has to keep login and per-request auth in agreement.
+    assert session_namespace(make_registry()) == DEFAULT_SESSION_NAMESPACE
+
+
+# ---------------------------------------------------------------------------------------------
+# No-Redis mode: existing stateless JWT behavior must be untouched
+# ---------------------------------------------------------------------------------------------
+
+def test_no_redis_login_stores_raw_jwt_cookie():
+    id_token = make_jwt()
+    request = make_request(make_registry(redis=False), json_body={'id_token': id_token})
+
+    assert login(None, request) == {'saved_cookie': True}
+    assert response_cookie(request.response) == id_token
+
+
+def test_no_redis_request_authentication_decodes_jwt():
+    id_token = make_jwt()
+    request = make_request(make_registry(redis=False), cookie=id_token)
+
+    assert Auth0AuthenticationPolicy().unauthenticated_userid(request) == USER_EMAIL
+    assert request.auth0_expired is False
+
+
+def test_no_redis_expired_jwt_is_rejected():
+    """ Baseline stateless-mode failure mode: a JWT we cannot verify authenticates nobody. """
+    request = make_request(make_registry(redis=False), cookie=make_jwt(secret='wrong-secret'))
+
+    assert Auth0AuthenticationPolicy().unauthenticated_userid(request) is None
+    assert request.auth0_expired is True
+
+
+def test_no_redis_logout_clears_cookie_without_touching_redis():
+    request = make_request(make_registry(redis=False), cookie=make_jwt())
+
+    assert logout(None, request) == {'deleted_cookie': True}
+    assert request.response.status_code == 401
+    assert response_cookie(request.response) == ''
+
+
+def test_no_redis_callback_is_refused():
+    """ /callback is Redis-only; without Redis the stateless flow stays the only one. """
+    with pytest.raises(HTTPForbidden):
+        callback(None, make_request(make_registry(redis=False)))
+
+
+def test_no_redis_registration_uses_auth0_authenticated_attribute():
+    """ Unchanged legacy behavior: the email comes off request._auth0_authenticated. """
+    request = _registration_request(make_registry(redis=False))
+    request._auth0_authenticated = USER_EMAIL
+
+    with _registration_harness() as recorded:
+        create_unauthorized_user(None, request)
+    assert recorded['user_props']['email'] == USER_EMAIL
+
+
+# ---------------------------------------------------------------------------------------------
+# Redis mode: login mints an opaque session token
+# ---------------------------------------------------------------------------------------------
+
+def test_redis_login_yields_opaque_session_token():
+    redis = FakeRedis()
+    id_token = make_jwt()
+    request = make_request(make_registry(redis_handler=redis), json_body={'id_token': id_token})
+
+    assert login(None, request) == {'saved_cookie': True}
+
+    cookie_value = response_cookie(request.response)
+    assert cookie_value
+    # The cookie is NOT the JWT, and is not any substring/transform of it.
+    assert cookie_value != id_token
+    assert '.' not in cookie_value  # a JWT always has two dots; a urlsafe token has none
+    # The JWT itself is held server-side, keyed by the opaque token.
+    assert redis.store[f'{DEFAULT_SESSION_NAMESPACE}:session:{cookie_value}'].startswith(id_token)
+
+
+def test_redis_login_rejects_unverifiable_jwt_and_writes_nothing():
+    redis = FakeRedis()
+    request = make_request(make_registry(redis_handler=redis),
+                           json_body={'id_token': make_jwt(secret='wrong-secret')})
+
+    with pytest.raises(LoginDenied):
+        login(None, request)
+    assert redis.store == {}
+
+
+def test_redis_login_requires_a_token():
+    redis = FakeRedis()
+    request = make_request(make_registry(redis_handler=redis), json_body={})
+
+    with pytest.raises(LoginDenied):
+        login(None, request)
+    assert redis.store == {}
+
+
+def test_redis_relogin_revokes_the_previous_session():
+    redis = FakeRedis()
+    registry = make_registry(redis_handler=redis)
+
+    first = make_request(registry, json_body={'id_token': make_jwt()})
+    login(None, first)
+    first_token = response_cookie(first.response)
+
+    second = make_request(registry, cookie=first_token, json_body={'id_token': make_jwt()})
+    login(None, second)
+    second_token = response_cookie(second.response)
+
+    assert second_token != first_token
+    assert len(redis.store) == 1
+    # The old token no longer authenticates anybody.
+    stale = make_request(registry, cookie=first_token)
+    assert Auth0AuthenticationPolicy().unauthenticated_userid(stale) is None
+
+
+# ---------------------------------------------------------------------------------------------
+# Redis mode: per-request authentication resolves the token
+# ---------------------------------------------------------------------------------------------
+
+def test_redis_authenticated_request_resolves_identity():
+    redis = FakeRedis()
+    registry = make_registry(redis_handler=redis)
+    session = create_session_token(make_request(registry), jwt_token=make_jwt(), email=USER_EMAIL)
+
+    request = make_request(registry, cookie=session.get_session_token())
+    assert Auth0AuthenticationPolicy().unauthenticated_userid(request) == USER_EMAIL
+    assert request.auth0_expired is False
+    assert request._auth0_session_jwt == session.get_jwt()
+
+
+def test_redis_authenticated_request_accepts_bearer_session_token():
+    redis = FakeRedis()
+    registry = make_registry(redis_handler=redis)
+    session = create_session_token(make_request(registry), jwt_token=make_jwt(), email=USER_EMAIL)
+
+    request = make_request(registry, auth_header=session.get_session_token())
+    assert Auth0AuthenticationPolicy().unauthenticated_userid(request) == USER_EMAIL
+
+
+def test_redis_identity_falls_back_to_jwt_when_no_email_recorded():
+    """ from_redis yields '' (not None) for a record stored without an email - the fallback has to
+        be truthiness-based, and must decode the *server-held* JWT, never a caller-supplied one.
+    """
+    redis = FakeRedis()
+    registry = make_registry(redis_handler=redis)
+    session = create_session_token(make_request(registry), jwt_token=make_jwt(), email=None)
+
+    request = make_request(registry, cookie=session.get_session_token())
+    resolved = resolve_session_token(request, session.get_session_token())
+    assert resolved.get_email() == ''
+    assert session_identity(request, resolved) == USER_EMAIL
+
+
+def test_redis_mode_never_authenticates_a_raw_jwt_cookie():
+    """ The no-bypass rule: a perfectly valid JWT presented directly is just an unknown Redis key.
+
+        Also asserts the JWT decode path is not even reached, which is what makes this a token
+        lookup rather than a JWT check that happens to fail.
+    """
+    redis = FakeRedis()
+    registry = make_registry(redis_handler=redis)
+    id_token = make_jwt()
+
+    for request in (make_request(registry, cookie=id_token),
+                    make_request(registry, auth_header=id_token)):
+        with mock.patch.object(Auth0AuthenticationPolicy, 'get_token_info') as mocked:
+            assert Auth0AuthenticationPolicy().unauthenticated_userid(request) is None
+            assert mocked.call_count == 0
+        assert request.auth0_expired is True
+    assert redis.store == {}
+
+
+def test_redis_anonymous_request_does_not_touch_redis():
+    """ No credential at all is anonymous, not an error - even while Redis is down. """
+    redis = FakeRedis(fail_with=RedisConnectionError('redis is down'))
+    request = make_request(make_registry(redis_handler=redis))
+
+    assert Auth0AuthenticationPolicy().unauthenticated_userid(request) is None
+    assert not hasattr(request, 'auth0_expired')
+
+
+@pytest.mark.parametrize('bad_token', [
+    'not-a-real-token',
+    'AAAA.BBBB.CCCC',
+    '',
+])
+def test_redis_unknown_or_malformed_token_is_authentication_failure(bad_token):
+    redis = FakeRedis()
+    request = make_request(make_registry(redis_handler=redis), cookie=bad_token)
+
+    assert Auth0AuthenticationPolicy().unauthenticated_userid(request) is None
+
+
+def test_redis_expired_session_is_rejected():
+    redis = FakeRedis()
+    registry = make_registry(redis_handler=redis)
+    session = create_session_token(make_request(registry), jwt_token=make_jwt(), email=USER_EMAIL)
+    token = session.get_session_token()
+
+    assert Auth0AuthenticationPolicy().unauthenticated_userid(
+        make_request(registry, cookie=token)) == USER_EMAIL
+
+    redis.expire_now(session.get_redis_key())  # TTL lapses
+
+    request = make_request(registry, cookie=token)
+    assert Auth0AuthenticationPolicy().unauthenticated_userid(request) is None
+    # marks the request so renderers.py unsets the stale cookie
+    assert request.auth0_expired is True
+
+
+# ---------------------------------------------------------------------------------------------
+# Redis mode: logout revokes server-side
+# ---------------------------------------------------------------------------------------------
+
+def test_redis_logout_revokes_the_session_server_side():
+    redis = FakeRedis()
+    registry = make_registry(redis_handler=redis)
+    session = create_session_token(make_request(registry), jwt_token=make_jwt(), email=USER_EMAIL)
+    token = session.get_session_token()
+
+    request = make_request(registry, cookie=token)
+    assert logout(None, request) == {'deleted_cookie': True}
+    assert response_cookie(request.response) == ''
+    assert redis.store == {}
+
+    # The revoked token is dead even though the client may still be presenting it.
+    assert Auth0AuthenticationPolicy().unauthenticated_userid(
+        make_request(registry, cookie=token)) is None
+
+
+def test_redis_logout_revokes_token_supplied_by_header():
+    redis = FakeRedis()
+    registry = make_registry(redis_handler=redis)
+    session = create_session_token(make_request(registry), jwt_token=make_jwt(), email=USER_EMAIL)
+
+    logout(None, make_request(registry, auth_header=session.get_session_token()))
+    assert redis.store == {}
+
+
+# ---------------------------------------------------------------------------------------------
+# Redis mode: outages are operational failures, never a downgrade
+# ---------------------------------------------------------------------------------------------
+
+@pytest.mark.parametrize('handler', [
+    None,                                                # never connected (includeme stored None)
+    FakeRedis(fail_with=RedisConnectionError('down')),   # connection lost at call time
+])
+def test_redis_outage_on_authentication_is_operational_error(handler):
+    request = make_request(make_registry(redis_handler=handler), cookie='some-session-token')
+
+    with pytest.raises(RedisSessionUnavailable) as exc:
+        Auth0AuthenticationPolicy().unauthenticated_userid(request)
+    assert 500 <= exc.value.code < 600
+    assert exc.value.code == 503
+
+
+def test_redis_outage_on_authentication_does_not_fall_back_to_jwt():
+    """ The token here is a *valid* JWT: if any fallback existed, this would authenticate. """
+    request = make_request(make_registry(redis_handler=None), cookie=make_jwt())
+
+    with mock.patch.object(Auth0AuthenticationPolicy, 'get_token_info') as mocked:
+        with pytest.raises(RedisSessionUnavailable):
+            Auth0AuthenticationPolicy().unauthenticated_userid(request)
+        assert mocked.call_count == 0
+
+
+def test_redis_outage_on_login_is_operational_error():
+    request = make_request(make_registry(redis_handler=None), json_body={'id_token': make_jwt()})
+
+    with pytest.raises(RedisSessionUnavailable) as exc:
+        login(None, request)
+    assert exc.value.code == 503
+    # and no credential cookie was handed out
+    assert response_cookie(request.response) is None
+
+
+def test_redis_outage_on_logout_is_operational_error():
+    request = make_request(make_registry(redis_handler=None), cookie='some-session-token')
+
+    with pytest.raises(RedisSessionUnavailable) as exc:
+        logout(None, request)
+    assert exc.value.code == 503
+
+
+def test_redis_outage_is_distinct_from_authentication_failure():
+    """ The two rejection kinds must not collapse into each other. """
+    healthy = make_request(make_registry(redis_handler=FakeRedis()), cookie='unknown-token')
+    assert Auth0AuthenticationPolicy().unauthenticated_userid(healthy) is None  # 401-shaped
+
+    broken = make_request(make_registry(redis_handler=None), cookie='unknown-token')
+    with pytest.raises(RedisSessionUnavailable):
+        Auth0AuthenticationPolicy().unauthenticated_userid(broken)  # 503-shaped
+
+
+def test_session_errors_do_not_leak_the_token(caplog):
+    token = 'super-secret-session-token'
+    redis = FakeRedis(fail_with=RedisConnectionError('down'))
+    request = make_request(make_registry(redis_handler=redis), cookie=token)
+
+    with pytest.raises(RedisSessionUnavailable) as exc:
+        Auth0AuthenticationPolicy().unauthenticated_userid(request)
+
+    assert token not in str(exc.value)
+    assert token not in (exc.value.detail or '')
+    assert token not in caplog.text
+
+
+# ---------------------------------------------------------------------------------------------
+# Redis mode: registration
+# ---------------------------------------------------------------------------------------------
+
+class _FakeUserCollection:
+    class type_info:
+        schema = {'type': 'object', 'properties': {}}
+
+
+def _registration_harness():
+    """ Stubs out everything create_unauthorized_user needs downstream of authentication:
+        the User collection, JSON-schema validation, the reCAPTCHA round trip and the POST.
+        Records the props that made it through so tests can assert on them.
+    """
+    recorded = {}
+
+    def fake_validate_request(schema, request, props):
+        # This is the point at which the (already whitelisted) props are handed to validation,
+        # so it is the faithful place to observe what would actually be written.
+        recorded['user_props'] = dict(props)
+        request.validated = props
+
+    def fake_collection_add(collection, request, render):
+        return {'status': 'success'}
+
+    class _Harness:
+        def __enter__(self):
+            self.patches = [
+                mock.patch.object(auth_module, 'validate_request', fake_validate_request),
+                mock.patch.object(auth_module, 'sno_collection_add', fake_collection_add),
+                mock.patch.object(requests, 'get',
+                                  lambda *a, **kw: mock.Mock(json=lambda: {'success': True})),
+            ]
+            for p in self.patches:
+                p.start()
+            return recorded
+
+        def __exit__(self, *exc):
+            for p in self.patches:
+                p.stop()
+            return False
+
+    return _Harness()
+
+
+def _registration_request(registry, *, cookie=None, email=USER_EMAIL):
+    request = make_request(registry, cookie=cookie,
+                           json_body={'g-recaptcha-response': 'dummy', 'email': email,
+                                      'first_name': 'Some', 'last_name': 'Body'})
+    registry[COLLECTIONS] = {'User': _FakeUserCollection()}
+    request.errors = []
+    return request
+
+
+def test_redis_registration_resolves_email_from_session():
+    redis = FakeRedis()
+    registry = make_registry(redis_handler=redis)
+    session = create_session_token(make_request(registry), jwt_token=make_jwt(), email=USER_EMAIL)
+
+    request = _registration_request(registry, cookie=session.get_session_token())
+    with _registration_harness() as recorded:
+        result = create_unauthorized_user(None, request)
+
+    assert result == {'status': 'success'}
+    assert recorded['user_props']['email'] == USER_EMAIL
+    assert recorded['user_props']['was_unauthorized'] is True
+
+
+def test_redis_registration_without_session_is_login_denied():
+    request = _registration_request(make_registry(redis_handler=FakeRedis()),
+                                    cookie='unknown-token')
+    with _registration_harness():
+        with pytest.raises(LoginDenied) as exc:
+            create_unauthorized_user(None, request)
+    assert exc.value.code == 401
+
+
+def test_redis_registration_with_raw_jwt_cookie_is_login_denied():
+    """ No bypass on the registration path either. """
+    request = _registration_request(make_registry(redis_handler=FakeRedis()), cookie=make_jwt())
+    with _registration_harness():
+        with pytest.raises(LoginDenied):
+            create_unauthorized_user(None, request)
+
+
+def test_redis_registration_during_outage_is_operational_error():
+    request = _registration_request(make_registry(redis_handler=None), cookie='some-token')
+    with _registration_harness():
+        with pytest.raises(RedisSessionUnavailable) as exc:
+            create_unauthorized_user(None, request)
+    assert exc.value.code == 503
+
+
+def test_redis_registration_rejects_email_mismatch():
+    redis = FakeRedis()
+    registry = make_registry(redis_handler=redis)
+    session = create_session_token(make_request(registry), jwt_token=make_jwt(), email=USER_EMAIL)
+
+    request = _registration_request(registry, cookie=session.get_session_token(),
+                                    email='someone.else@example.com')
+    with _registration_harness():
+        with pytest.raises(HTTPUnauthorized):
+            create_unauthorized_user(None, request)
+
+
+# ---------------------------------------------------------------------------------------------
+# Redis mode: /callback
+# ---------------------------------------------------------------------------------------------
+
+def _auth0_callback_response(id_token):
+    return mock.Mock(json=lambda: {'id_token': id_token, 'access_token': 'dummy-access-token'})
+
+
+def test_redis_callback_mints_session_token_for_known_user():
+    redis = FakeRedis()
+    registry = make_registry(redis_handler=redis, **{'auth0.options': AUTH0_OPTIONS})
+    id_token = make_jwt()
+    request = make_request(registry, path='/callback?code=some-auth0-code')
+
+    with mock.patch.object(requests, 'post', lambda *a, **kw: _auth0_callback_response(id_token)):
+        with mock.patch.object(Auth0AuthenticationPolicy, 'get_user_info',
+                               lambda *a, **kw: {'details': {'email': USER_EMAIL}}):
+            result = callback(None, request)
+
+    assert result['@type'] == ['callback']
+    token = response_cookie(request.response)
+    assert token and token != id_token
+    assert redis.store[f'{DEFAULT_SESSION_NAMESPACE}:session:{token}'].startswith(id_token)
+
+
+def test_redis_callback_mints_session_token_for_unregistered_user():
+    """ Unknown users still get a session so they can complete registration through Redis. """
+    redis = FakeRedis()
+    registry = make_registry(redis_handler=redis, **{'auth0.options': AUTH0_OPTIONS})
+    id_token = make_jwt()
+    request = make_request(registry, path='/callback?code=some-auth0-code')
+
+    def unknown_user(*args, **kwargs):
+        raise HTTPUnauthorized()
+
+    with mock.patch.object(requests, 'post', lambda *a, **kw: _auth0_callback_response(id_token)):
+        with mock.patch.object(Auth0AuthenticationPolicy, 'get_user_info', unknown_user):
+            result = callback(None, request)
+
+    assert result['@type'] == ['registration']
+    assert result['@graph'] == [USER_EMAIL]
+    token = response_cookie(request.response)
+    assert token
+    # ...and that session is immediately usable for the registration POST.
+    assert session_identity(make_request(registry),
+                            resolve_session_token(make_request(registry), token)) == USER_EMAIL
+
+
+def test_redis_callback_requires_a_code():
+    registry = make_registry(redis_handler=FakeRedis(), **{'auth0.options': AUTH0_OPTIONS})
+    with pytest.raises(HTTPForbidden):
+        callback(None, make_request(registry, path='/callback'))
+
+
+def test_redis_callback_outage_is_operational_error():
+    registry = make_registry(redis_handler=None, **{'auth0.options': AUTH0_OPTIONS})
+    id_token = make_jwt()
+    request = make_request(registry, path='/callback?code=some-auth0-code')
+
+    with mock.patch.object(requests, 'post', lambda *a, **kw: _auth0_callback_response(id_token)):
+        with pytest.raises(RedisSessionUnavailable) as exc:
+            callback(None, request)
+    assert exc.value.code == 503
+
+
+# ---------------------------------------------------------------------------------------------
+# Token extraction
+# ---------------------------------------------------------------------------------------------
+
+def test_get_auth_token_prefers_header_then_cookie():
+    registry = make_registry(redis_handler=FakeRedis())
+    assert get_auth_token(make_request(registry, cookie='c', auth_header='h')) == 'h'
+    assert get_auth_token(make_request(registry, cookie='c')) == 'c'
+    assert get_auth_token(make_request(registry)) is None

--- a/snovault/tests/test_redis_session_auth.py
+++ b/snovault/tests/test_redis_session_auth.py
@@ -219,6 +219,52 @@ def test_redis_login_yields_opaque_session_token():
     assert '.' not in cookie_value  # a JWT always has two dots; a urlsafe token has none
     # The JWT itself is held server-side, keyed by the opaque token.
     assert redis.store[f'{DEFAULT_SESSION_NAMESPACE}:session:{cookie_value}'].startswith(id_token)
+    assert request.auth0_expired is False
+
+
+def test_redis_login_via_authorization_header_survives_the_security_tween():
+    """ renderers.security_tween evaluates request.authenticated_userid BEFORE the view whenever an
+        Authorization header is present, and re-reads request.auth0_expired AFTER the view returns:
+        if it is still set, it overwrites the response Set-Cookie with a deletion and forces a 401.
+
+        A header login legitimately presents the provider's JWT, which by design does not resolve
+        as a session - so login must clear that marker or it destroys the session it just minted.
+    """
+    redis = FakeRedis()
+    registry = make_registry(redis_handler=redis)
+    id_token = make_jwt()
+    request = make_request(registry, auth_header=id_token, json_body={'id_token': id_token})
+
+    # ...what the security tween does on the way in
+    assert Auth0AuthenticationPolicy().unauthenticated_userid(request) is None
+    assert request.auth0_expired is True
+
+    assert login(None, request) == {'saved_cookie': True}
+
+    # ...and what it re-reads on the way out
+    assert request.auth0_expired is False
+    token = response_cookie(request.response)
+    assert token and token != id_token
+    assert redis.store[f'{DEFAULT_SESSION_NAMESPACE}:session:{token}'].startswith(id_token)
+
+
+def test_redis_login_with_lapsed_cookie_survives_the_security_tween():
+    """ Same hazard on re-login after a session has expired: the stale cookie marks the request
+        expired before the view runs.
+    """
+    redis = FakeRedis()
+    registry = make_registry(redis_handler=redis)
+    id_token = make_jwt()
+    request = make_request(registry, cookie='lapsed-session-token',
+                           auth_header=id_token, json_body={'id_token': id_token})
+
+    assert Auth0AuthenticationPolicy().unauthenticated_userid(request) is None
+    assert request.auth0_expired is True
+
+    login(None, request)
+
+    assert request.auth0_expired is False
+    assert response_cookie(request.response)
 
 
 def test_redis_login_rejects_unverifiable_jwt_and_writes_nothing():
@@ -579,6 +625,8 @@ def test_redis_callback_mints_session_token_for_known_user():
     token = response_cookie(request.response)
     assert token and token != id_token
     assert redis.store[f'{DEFAULT_SESSION_NAMESPACE}:session:{token}'].startswith(id_token)
+    # not marked expired, or the security tween would delete the cookie we just set
+    assert request.auth0_expired is False
 
 
 def test_redis_callback_mints_session_token_for_unregistered_user():
@@ -599,6 +647,7 @@ def test_redis_callback_mints_session_token_for_unregistered_user():
     assert result['@graph'] == [USER_EMAIL]
     token = response_cookie(request.response)
     assert token
+    assert request.auth0_expired is False
     # ...and that session is immediately usable for the registration POST.
     assert session_identity(make_request(registry),
                             resolve_session_token(make_request(registry), token)) == USER_EMAIL

--- a/snovault/tests/test_redis_session_auth.py
+++ b/snovault/tests/test_redis_session_auth.py
@@ -16,7 +16,6 @@ from pyramid.registry import Registry
 from pyramid.request import Request
 from dcicutils.redis_tools import RedisSessionToken
 from dcicutils.redis_utils import RedisException
-from redis.exceptions import ConnectionError as RedisConnectionError
 from unittest import mock
 
 from .. import authentication as auth_module
@@ -430,7 +429,7 @@ def test_redis_mode_never_authenticates_a_raw_jwt_cookie():
 
 def test_redis_anonymous_request_does_not_touch_redis():
     """ No credential at all is anonymous, not an error - even while Redis is down. """
-    redis = FakeRedis(fail_with=RedisConnectionError('redis is down'))
+    redis = FakeRedis(fail_with=RedisException('redis is down'))
     request = make_request(make_registry(redis_handler=redis))
 
     assert Auth0AuthenticationPolicy().unauthenticated_userid(request) is None
@@ -504,10 +503,6 @@ def test_redis_logout_revokes_token_supplied_by_header():
     lambda: None,
     # connection lost at call time, reported with dcicutils' own error type
     lambda: FakeRedis(fail_with=RedisException('down')),
-    # ...and reported as a raw driver error, which is what actually escapes today: dcicutils
-    # normalizes to RedisException in store_session_token only, not in from_redis. See the
-    # REDIS_OPERATIONAL_ERRORS upstream-gap note in authentication.py.
-    lambda: FakeRedis(fail_with=RedisConnectionError('down')),
 ])
 def test_redis_outage_on_authentication_is_operational_error(handler_factory):
     request = make_request(make_registry(redis_handler=handler_factory()),
@@ -517,6 +512,56 @@ def test_redis_outage_on_authentication_is_operational_error(handler_factory):
         Auth0AuthenticationPolicy().unauthenticated_userid(request)
     assert 500 <= exc.value.code < 600
     assert exc.value.code == 503
+
+
+class UnnormalizedRedisFailure(Exception):
+    """ Stands in for any infrastructure error dcicutils has not yet wrapped in RedisException.
+
+        Deliberately NOT `redis.exceptions.ConnectionError`: snovault holds no knowledge of the
+        driver's exception hierarchy, in production code or here.
+    """
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="PENDING dcicutils release: from_redis does not yet normalize infrastructure errors to "
+           "RedisException (store_session_token already does). Snovault deliberately does not "
+           "bridge this locally - see REDIS_ERROR_CONTRACT_DEPENDENCY in authentication.py. When "
+           "this test XPASSes, the upstream fix has landed: raise the dcicutils floor in "
+           "pyproject.toml and remove this marker."
+)
+def test_unnormalized_redis_error_becomes_503_once_dcicutils_normalizes():
+    """ Locks in the behavior snovault expects once the canonical error contract is complete, and
+        acts as the alarm that tells us the upstream release has shipped.
+    """
+    request = make_request(
+        make_registry(redis_handler=FakeRedis(fail_with=UnnormalizedRedisFailure('down'))),
+        cookie='some-session-token')
+
+    with pytest.raises(RedisSessionUnavailable) as exc:
+        Auth0AuthenticationPolicy().unauthenticated_userid(request)
+    assert exc.value.code == 503
+
+
+def test_unnormalized_redis_error_is_never_a_downgrade():
+    """ The property that must hold regardless of how the upstream error contract evolves: an
+        infrastructure failure never becomes an authentication success or a stateless-JWT fallback.
+
+        Deliberately accepts either outcome, so this test does not itself break when the fix lands:
+        today an unnormalized error escapes as an untyped 500 (a degraded error *label*, not a
+        correctness hole); afterwards it will be a 503. The strict xfail above is the single alarm
+        that tells us which regime we are in.
+    """
+    request = make_request(
+        make_registry(redis_handler=FakeRedis(fail_with=UnnormalizedRedisFailure('down'))),
+        cookie=make_jwt())  # a *valid* JWT: any fallback would authenticate it
+
+    with mock.patch.object(Auth0AuthenticationPolicy, 'get_token_info') as mocked:
+        with pytest.raises((UnnormalizedRedisFailure, RedisSessionUnavailable)):
+            Auth0AuthenticationPolicy().unauthenticated_userid(request)
+        assert mocked.call_count == 0, 'must not fall back to decoding the JWT'
+    # ...and it did not quietly resolve to an authenticated identity
+    assert not hasattr(request, '_auth0_authenticated')
 
 
 def test_redis_outage_on_authentication_does_not_fall_back_to_jwt():
@@ -559,7 +604,7 @@ def test_redis_outage_is_distinct_from_authentication_failure():
 
 def test_session_errors_do_not_leak_the_token(caplog):
     token = 'super-secret-session-token'
-    redis = FakeRedis(fail_with=RedisConnectionError('down'))
+    redis = FakeRedis(fail_with=RedisException('down'))
     request = make_request(make_registry(redis_handler=redis), cookie=token)
 
     with pytest.raises(RedisSessionUnavailable) as exc:


### PR DESCRIPTION
## Summary

Snovault now supports two mutually exclusive authentication modes, selected by configuration alone — the presence of the `redis.server` setting, which is the same condition `snovault/__init__.py::main` already uses to decide whether to include `snovault.redis`. Mode is never inferred by inspecting a token value.

| | No Redis configured | Redis configured |
|---|---|---|
| `jwtToken` cookie / `Authorization: Bearer` | the raw Auth0 JWT | an opaque session token (`secrets.token_urlsafe`) |
| Where the JWT lives | with the client | server-side only, in `<namespace>:session:<token>` with a TTL |
| Session lifetime | JWT `exp` | Redis TTL |
| `/callback` | refused (unchanged) | active |

The contract is stated next to the code in `authentication.SESSION_TOKEN_MODE_NOTES`, expanded in `snovault/redis/README.rst`, and summarized for future agents in `AGENTS.md`.

**No-Redis behavior is unchanged** for login, request authentication, registration, logout and cookie handling.

## What was broken

Redis mode existed only in `/callback`, and could not work:

- `Auth0AuthenticationPolicy.unauthenticated_userid` always tried to decode the cookie as a JWT, so **no authenticated request could ever succeed** in Redis mode — the only implementation was in a route the current SPA login flow never reaches.
- `callback` called `auth0_response.json()` while `auth0_response` was still `None` — an unconditional crash on the Auth0 branch.
- `callback` read `registry.settings['env.name']` and `registry[REDIS]` unguarded, and did `get_token_info(...).get(...)` which raises when that returns `None`.
- `create_unauthorized_user` called `RedisSessionToken.from_redis(...).decode_jwt(...)` without checking the `None` returned on a session miss — a 500 where a 401 belongs.
- `logout` never revoked the server-side session.
- A Redis connection failure was invisible: `redis/redis_connection.py::includeme` swallows the error and stores `None`, so every downstream use crashed or silently misbehaved.

## What this changes

**Login.** `POST /login` — the SPA flow the front-end actually uses — now implements Redis mode: it verifies the provider JWT once, stores it in Redis, and returns only the opaque session token. `/callback` does the same for the Auth0/RAS redirect flow. Neither is an unreachable second implementation.

**Per-request authentication** resolves the session token to the identity recorded server-side before authorization. Identity is the email recorded at login; the server-held JWT is decoded only as a fallback. That choice is deliberate: `get_token_info` is Auth0-only (HS256/`auth0.secret`) while RAS uses RS256/`auth0.public.key`, so re-verifying the JWT per request would break RAS and put session lifetime on two competing clocks.

**Strict, non-bypassable failure semantics in Redis mode:**

- The caller-supplied credential is **never** decoded as a JWT. A valid raw JWT presented as a cookie or bearer token is just an unknown Redis key and is rejected. There is no fallback to the stateless path once Redis mode is selected.
- Absent / unknown / expired (TTL lapsed) / revoked / malformed token → **401**, and marks `request.auth0_expired` so `renderers.py` unsets the stale cookie.
- Redis unreachable — including the `registry[REDIS] is None` startup state — → **`RedisSessionUnavailable` (503)**. `except` clauses are scoped to `REDIS_OPERATIONAL_ERRORS`, never bare `Exception`, precisely so "Redis is down" and "this token is invalid" cannot collapse into each other.
- Anonymous requests return before touching Redis, so an outage cannot take down public traffic.

**Session lifecycle.** `/logout` revokes server-side; `/login` and `/callback` revoke the caller's previous session before minting a new one; `/impersonate-user` wraps its minted token in a session rather than setting a raw JWT cookie that could never resolve.

**Consolidation.** All cookie/token handling goes through `SESSION_COOKIE_NAME`, `set_session_cookie`, `get_auth_token` and `session_namespace`, so login, callback, per-request auth, registration and logout cannot drift apart. `get_jwt` is retained as a delegating alias for downstream callers.

## All Redis behavior is delegated to dcicutils

Snovault implements **no** Redis connection, session or token behavior. Connection setup, token generation, key layout, TTL, storage, lookup, rotation and revocation are all `dcicutils.redis_utils` / `dcicutils.redis_tools`. Snovault contributes only what is genuinely its own: reading pyramid settings, and translating outcomes into HTTP.

| Snovault integration point | Canonical dcicutils call |
|---|---|
| `redis_connection.py::includeme` | `RedisBase(create_redis_client(url=...))` |
| `create_session_token` | `RedisSessionToken(...)` + `store_session_token` |
| `resolve_session_token` | `RedisSessionToken.from_redis` |
| `rotate_session_token` | `RedisSessionToken.update_session_token` |
| `revoke_session_token` | `RedisSessionToken.delete_session_token` |
| `decode_session_jwt` | `RedisSessionToken.decode_jwt` |
| `session_identity` | `RedisSessionToken.get_email` / `get_jwt` |

Snovault-side code is limited to `redis_is_active`, `session_namespace`, `get_redis_handler` (pyramid settings/registry), `RedisSessionUnavailable` (HTTP status), and one `_redis_session_call` error-translation boundary.

**Two pieces of duplication were removed:**

- `revoke_session_token` hand-built a `RedisSessionToken(jwt='', email='', token=...)` purely to re-derive the Redis key — a second copy of dcicutils' `<namespace>:session:<token>` layout. It now resolves the real record via `from_redis` and calls `delete_session_token`, so that layout exists in exactly one place.
- Re-login hand-rolled rotation as revoke-then-create. `RedisSessionToken.update_session_token` is dcicutils' own rotation primitive and is now used, via a single `rotate_session_token` shared by `/login`, `/callback` and `/impersonate-user`.

### Blocked on the dcicutils error contract

Snovault catches **only** `dcicutils.redis_utils.RedisException` and references no
`redis.exceptions.*` type anywhere — normalizing driver errors is dcicutils' responsibility and
this PR does not duplicate it.

That contract is currently only partly implemented upstream:

| dcicutils call | Raises `RedisException` on infrastructure failure? |
|---|---|
| `store_session_token` | yes — `except Exception -> raise RedisException` |
| `from_redis` | **not yet** |
| `delete_session_token` | **not yet** |
| `update_session_token` | **not yet** |
| `RedisBase` primitives | **not yet** |

**A dcicutils change completing this is in progress, and this PR waits for it rather than
compensating locally.**

Interim behavior on the unnormalized paths — most importantly `from_redis`, which is on the
per-request authentication path — is an untyped **500** instead of the intended **503**. That is a
degraded error *label*, not a correctness hole. The properties the two-mode contract actually
depends on all still hold: the failure is 5xx, it is logged, and it is never silently downgraded
into an authentication failure or a stateless-JWT fallback. There is a test asserting exactly that,
written to pass in both regimes.

**When the dcicutils release lands, the follow-up is two lines and no snovault code change:**

1. Raise the `dcicutils` floor in `pyproject.toml` (there is a note at that line).
2. Drop the `@pytest.mark.xfail` from `test_unnormalized_redis_error_becomes_503_once_dcicutils_normalizes`.

That xfail is `strict`, so it becomes a hard test failure the moment the upstream fix is present —
the reminder cannot be lost. I verified this by simulating the fix (wrapping `from_redis` the way
`store_session_token` already is): the test flips to XPASS and is reported as a failure.

The dependency is also recorded in `REDIS_ERROR_CONTRACT_DEPENDENCY` (`authentication.py`),
`snovault/redis/README.rst` and `AGENTS.md`.

### Related, pre-existing, not touched

`snovault/redis/redis_connection.py:110` — `RedisConnection.__init__` does `RedisBase(registry[REDIS])`, double-wrapping an already-wrapped `RedisBase`. It is dead code (the class is marked "NOT USED AT THIS TIME" and every method body is `pass`), unrelated to authentication, and predates this PR, so it is flagged rather than deleted here.

## Downstream integration requirements

Nothing changes for consumers that do not set `redis.server`. For those that do:

1. **`Authorization: Bearer` must carry the session token** on every request after login. Only `POST /login` accepts a raw JWT there. An API client that keeps sending a raw JWT bearer token will now be rejected — that is the intended no-bypass behavior, but it is a client-visible change.
2. **`env.name` or `indexer.namespace` should be set** in deployed environments. `session_namespace()` falls back to a constant otherwise; that is fine locally but means two differently-configured app instances would not share sessions.
3. **Clients must handle 503 distinctly from 401.** A 503 means the session store is down — retry; it is not a signal to log the user out.
4. **`/logout` can return 503** if Redis is unreachable, since revocation cannot be honored. That is deliberate: a logout that silently fails to revoke is worse than a visible error.
5. **Sessions have a 3-hour TTL** (`dcicutils.redis_tools.RedisSessionToken` default) independent of the Auth0 JWT lifetime.

## Deliberately deferred

- **No Redis infrastructure or configuration is deployed here.** No `redis.server` is added to any INI; every existing deployment stays in stateless mode until someone opts in. SMaHT Portal is untouched.
- **`X-Request-JWT` still echoes the cookie value** (`renderers.py:204`) on the HTML-transform path. In Redis mode that exposes the opaque session token to JS, defeating the point of `httpOnly`. Changing it to a sentinel requires a coordinated front-end change (an unmodified front-end would treat the sentinel as a credential and send it as a bearer token), so it is left alone rather than shipped half-done. `renderers.py` also still hardcodes `'jwtToken'` in three places instead of importing `SESSION_COOKIE_NAME` — same value, no defect.
- **`redis_connection.py::includeme` still swallows startup connection errors** and stores `None`. That is now handled correctly at every use site (503), but there is no reconnect: a Redis that was down at boot stays unusable until the app restarts.
- **`dcicutils`'s `SESSION_TOKEN_COOKIE = 'c4_st'` is deliberately not adopted.** It is a canonical constant with no consumer anywhere; switching to it would rename the cookie every existing front-end reads and writes, which contradicts the requirement to preserve cookie behavior. Both modes keep `jwtToken`. Flagging it as a decision rather than an oversight — say the word and it can change.

## Tests

New: `snovault/tests/test_redis_session_auth.py` — 48 tests (47 + 1 strict xfail) against a dict-backed fake implementing the slice of `RedisBase` that `RedisSessionToken` actually uses, plus locally-signed synthetic JWTs. **No live Redis, no cloud credentials, no outbound Auth0 calls, no DB.**

Covers: unchanged no-Redis login / request auth / logout / registration / callback-refused; Redis-mode login yielding an opaque token; authenticated request and registration through Redis; logout, expiry, revocation and re-login rejecting the old session; Redis outage returning 503 with no JWT fallback (asserted by patching `get_token_info` and checking it is never called); raw JWT cookies and bearer tokens failing to bypass; outage-vs-auth-failure kept distinct; and error messages/logs not containing token values.

Also covers delegation to the canonical primitives. Outage tests are driven with `RedisException` (dcicutils’ own type); the pending upstream contract is covered by the strict xfail described above plus a regime-agnostic test of the no-downgrade invariant.

Each critical assertion was mutation-checked: reverting the redis branch in `unauthenticated_userid` fails 9 tests; swallowing Redis errors fails 7; hand-rolling rotation as revoke-then-create fails the `update_session_token` delegation test; and hand-deriving the Redis key fails the key-derivation test. (That last one initially did *not* discriminate — a hand-built token derives an identical key, so an outcome-only assertion cannot tell them apart — and was rewritten to spy on `from_redis`.)

Ran locally (`snovault311`, `NO_SERVER_FIXTURES=TRUE USE_SAMPLE_ENVUTILS=TRUE`):

- `pytest snovault/tests -m "not es and not indexing"` → **722 passed, 1 xfailed** vs. **675** on a clean baseline of the same tree (+47 passing and the expected-fail, exactly the new tests). The 146 failures / 72 errors are identical before and after: all DB-dependent, from a broken local homebrew postgres.
- `pytest -m static` → 3 passed. `flake8 deploy/ snovault/` → clean.

Not run locally: the ES/indexing partition (no local Elasticsearch) and anything requiring live postgres — CI covers both.

---

**Status: paused pending the dcicutils release** that completes the Redis error contract. Everything else in this PR is finished and reviewable now. Not merged.
